### PR TITLE
Add configurable shelf count for cabinets

### DIFF
--- a/src/core/cutlist.ts
+++ b/src/core/cutlist.ts
@@ -46,14 +46,14 @@ export function cutlistForModule(m:any, globals:any): { items: CutItem[]; edges:
   const addShelves = () => {
     const shelfW = clampPos(W-2*t - tol.assembly)
     const shelfD = clampPos(D-backT - tol.shelfFrontSetback)
-    if (m.family===FAMILY.BASE){
-      if (m.kind==='doors') { add({ moduleId:m.id, moduleLabel:m.label, material:`Płyta ${t}mm`, part:'Półka', qty:1, w:shelfW, h:shelfD }); addEdge('ABS 1mm', shelfW, 'Półka — przód') }
-    }
-    if (m.family===FAMILY.WALL){
-      add({ moduleId:m.id, moduleLabel:m.label, material:`Płyta ${t}mm`, part:'Półka', qty:1, w:shelfW, h:shelfD }); addEdge('ABS 1mm', shelfW, 'Półka — przód')
-    }
-    if (m.family===FAMILY.TALL){
-      add({ moduleId:m.id, moduleLabel:m.label, material:`Płyta ${t}mm`, part:'Półka', qty:4, w:shelfW, h:shelfD }); addEdge('ABS 1mm', shelfW*4, 'Półki — przód sumarycznie')
+    let defaultShelves = 0
+    if (m.family===FAMILY.BASE && m.kind==='doors') defaultShelves = 1
+    else if (m.family===FAMILY.WALL) defaultShelves = 1
+    else if (m.family===FAMILY.TALL) defaultShelves = 4
+    const shelfQty = g.shelves !== undefined ? g.shelves : defaultShelves
+    if (shelfQty>0){
+      add({ moduleId:m.id, moduleLabel:m.label, material:`Płyta ${t}mm`, part:'Półka', qty:shelfQty, w:shelfW, h:shelfD })
+      addEdge('ABS 1mm', shelfW*shelfQty, shelfQty>1?'Półki — przód sumarycznie':'Półka — przód')
     }
   }
 

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -6,14 +6,14 @@ export const defaultGaps: Gaps = { left:2, right:2, top:2, bottom:2, between:3 }
 
 export type Globals = Record<FAMILY, {
   height:number; depth:number; boardType:string; frontType:string;
-  gaps: Gaps; legsType?:string; hangerType?:string; offsetWall?:number;
+  gaps: Gaps; legsType?:string; hangerType?:string; offsetWall?:number; shelves?:number;
 }>
 
 export const defaultGlobal: Globals = {
-  [FAMILY.BASE]: { height:800, depth:600, boardType:'Płyta 18mm', frontType:'Laminat', gaps:{...defaultGaps}, legsType:'Standard 10cm', offsetWall:30 },
-  [FAMILY.WALL]: { height:720, depth:320, boardType:'Płyta 18mm', frontType:'Laminat', gaps:{...defaultGaps}, hangerType:'Standard', offsetWall:20 },
-  [FAMILY.PAWLACZ]: { height:400, depth:600, boardType:'Płyta 18mm', frontType:'Laminat', gaps:{...defaultGaps}, hangerType:'Wzmocnione', offsetWall:30 },
-  [FAMILY.TALL]: { height:2100, depth:600, boardType:'Płyta 18mm', frontType:'Laminat', gaps:{...defaultGaps} }
+  [FAMILY.BASE]: { height:800, depth:600, boardType:'Płyta 18mm', frontType:'Laminat', gaps:{...defaultGaps}, legsType:'Standard 10cm', offsetWall:30, shelves:1 },
+  [FAMILY.WALL]: { height:720, depth:320, boardType:'Płyta 18mm', frontType:'Laminat', gaps:{...defaultGaps}, hangerType:'Standard', offsetWall:20, shelves:1 },
+  [FAMILY.PAWLACZ]: { height:400, depth:600, boardType:'Płyta 18mm', frontType:'Laminat', gaps:{...defaultGaps}, hangerType:'Wzmocnione', offsetWall:30, shelves:1 },
+  [FAMILY.TALL]: { height:2100, depth:600, boardType:'Płyta 18mm', frontType:'Laminat', gaps:{...defaultGaps}, shelves:4 }
 }
 
 export const defaultPrices = {
@@ -45,7 +45,7 @@ type Module3D = {
   size:{ w:number; h:number; d:number }; position:[number,number,number]; rotationY?:number;
   price?: any; fittings?: any
   segIndex?: number | null
-  adv?: { height?:number; depth?:number; boardType?:string; frontType?:string; gaps?: Gaps; drawerFronts?: number[] }
+  adv?: { height?:number; depth?:number; boardType?:string; frontType?:string; gaps?: Gaps; drawerFronts?: number[]; shelves?:number }
     /**
      * Array of booleans indicating whether each front on this module is open.
      * A single-element array corresponds to a single door; multiple elements
@@ -100,6 +100,7 @@ export const usePlannerStore = create<Store>((set,get)=>({
       if (patch.boardType !== undefined) newAdv.boardType = patch.boardType
       if (patch.frontType !== undefined) newAdv.frontType = patch.frontType
       if (patch.gaps !== undefined) newAdv.gaps = { ...(m.adv?.gaps||{}), ...patch.gaps }
+      if (patch.shelves !== undefined) newAdv.shelves = patch.shelves
       const newSize = { ...m.size }
       if (patch.height !== undefined) newSize.h = patch.height/1000
       if (patch.depth !== undefined) newSize.d = patch.depth/1000

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -48,7 +48,8 @@ export default function App(){
 
   useEffect(()=>{
     const g = store.globals[family]
-    setAdv({ height:g.height, depth:g.depth, boardType:g.boardType, frontType:g.frontType, gaps:{...g.gaps} })
+    const defaultShelves = family===FAMILY.TALL ? 4 : 1
+    setAdv({ height:g.height, depth:g.depth, boardType:g.boardType, frontType:g.frontType, gaps:{...g.gaps}, shelves:g.shelves ?? defaultShelves })
   }, [family, store.globals])
 
   const undo = store.undo
@@ -143,15 +144,17 @@ export default function App(){
     }
     // Determine number of doors from advanced settings when no drawers are present
     const doorCount = !hasDrawers && typeof adv.doorCount === 'number' && adv.doorCount > 0 ? adv.doorCount : 1
-    // If this module has no drawers (no drawerFronts array), add a simple shelf
-    // positioned at mid-height inside the carcase.  Shelf spans the full depth
-    // and sits between the side panels (subtract thickness on both sides).
+    // If this module has no drawers, add adjustable number of shelves.
     if (!hasDrawers) {
       const shelfWidth = Math.max(0, W - 2 * T)
       const shelfGeo = new THREE.BoxGeometry(shelfWidth, T, D)
-      const shelf = new THREE.Mesh(shelfGeo, carcMat)
-      shelf.position.set(W / 2, legHeight + H / 2, -D / 2)
-      group.add(shelf)
+      const count = Math.max(0, adv.shelves ?? 1)
+      for (let i = 0; i < count; i++) {
+        const shelf = new THREE.Mesh(shelfGeo, carcMat)
+        const y = legHeight + (H * (i + 1)) / (count + 1)
+        shelf.position.set(W / 2, y, -D / 2)
+        group.add(shelf)
+      }
     }
     // Determine number of front pieces: if drawers are defined, use their count; otherwise use doorCount
     const nFronts = hasDrawers ? fronts.length : doorCount
@@ -725,10 +728,10 @@ export default function App(){
                       />
                     </div>
                     <div className="row" style={{marginTop:8}}>
-                      <Cabinet3D family={family} widthMM={widthMM} heightMM={gLocal.height} depthMM={gLocal.depth} drawers={variant?.key?.startsWith('s') ? Number(variant.key.slice(1)) : (variant?.key?.includes('+drawer') ? 1 : 0)} gaps={{top:gLocal.gaps.top, bottom:gLocal.gaps.bottom}} drawerFronts={gLocal.drawerFronts} />
+                      <Cabinet3D family={family} widthMM={widthMM} heightMM={gLocal.height} depthMM={gLocal.depth} drawers={variant?.key?.startsWith('s') ? Number(variant.key.slice(1)) : (variant?.key?.includes('+drawer') ? 1 : 0)} gaps={{top:gLocal.gaps.top, bottom:gLocal.gaps.bottom}} drawerFronts={gLocal.drawerFronts} shelves={gLocal.shelves} />
                     </div>
                     <div className="row" style={{marginTop:8}}>
-                      <Cabinet3D family={family} widthMM={widthMM} heightMM={gLocal.height} depthMM={gLocal.depth} drawers={variant?.key?.startsWith('s') ? Number(variant.key.slice(1)) : (variant?.key?.includes('+drawer') ? 1 : 0)} gaps={{top:gLocal.gaps.top, bottom:gLocal.gaps.bottom}} drawerFronts={gLocal.drawerFronts} />
+                      <Cabinet3D family={family} widthMM={widthMM} heightMM={gLocal.height} depthMM={gLocal.depth} drawers={variant?.key?.startsWith('s') ? Number(variant.key.slice(1)) : (variant?.key?.includes('+drawer') ? 1 : 0)} gaps={{top:gLocal.gaps.top, bottom:gLocal.gaps.bottom}} drawerFronts={gLocal.drawerFronts} shelves={gLocal.shelves} />
                     </div>
                   </div>
                 )}
@@ -740,6 +743,12 @@ export default function App(){
                       <div><div className="small">Płyta</div><select className="input" value={gLocal.boardType} onChange={e=>setAdv({...gLocal, boardType:(e.target as HTMLSelectElement).value})}>{Object.keys(store.prices.board).map(k=><option key={k} value={k}>{k}</option>)}</select></div>
                       <div><div className="small">Front</div><select className="input" value={gLocal.frontType} onChange={e=>setAdv({...gLocal, frontType:(e.target as HTMLSelectElement).value})}>{Object.keys(store.prices.front).map(k=><option key={k} value={k}>{k}</option>)}</select></div>
                     </div>
+                    {!(variant?.key?.startsWith('s')) && (
+                      <div style={{marginTop:8}}>
+                        <div className="small">Liczba półek</div>
+                        <input className="input" type="number" min={0} value={gLocal.shelves||0} onChange={e=>setAdv({...gLocal, shelves:Number((e.target as HTMLInputElement).value)||0})} />
+                      </div>
+                    )}
                     <div style={{marginTop:8}}>
                       <div className="small">Szczeliny i wysokości frontów (ustawiaj graficznie)</div>
                       <TechDrawing
@@ -758,10 +767,10 @@ export default function App(){
                       />
                     </div>
                     <div className="row" style={{marginTop:8}}>
-                      <Cabinet3D family={family} widthMM={widthMM} heightMM={gLocal.height} depthMM={gLocal.depth} drawers={variant?.key?.startsWith('s') ? Number(variant.key.slice(1)) : (variant?.key?.includes('+drawer') ? 1 : 0)} gaps={{top:gLocal.gaps.top, bottom:gLocal.gaps.bottom}} drawerFronts={gLocal.drawerFronts} />
+                      <Cabinet3D family={family} widthMM={widthMM} heightMM={gLocal.height} depthMM={gLocal.depth} drawers={variant?.key?.startsWith('s') ? Number(variant.key.slice(1)) : (variant?.key?.includes('+drawer') ? 1 : 0)} gaps={{top:gLocal.gaps.top, bottom:gLocal.gaps.bottom}} drawerFronts={gLocal.drawerFronts} shelves={gLocal.shelves} />
                     </div>
                     <div className="row" style={{marginTop:8}}>
-                      <Cabinet3D family={family} widthMM={widthMM} heightMM={gLocal.height} depthMM={gLocal.depth} drawers={variant?.key?.startsWith('s') ? Number(variant.key.slice(1)) : (variant?.key?.includes('+drawer') ? 1 : 0)} gaps={{top:gLocal.gaps.top, bottom:gLocal.gaps.bottom}} drawerFronts={gLocal.drawerFronts} />
+                      <Cabinet3D family={family} widthMM={widthMM} heightMM={gLocal.height} depthMM={gLocal.depth} drawers={variant?.key?.startsWith('s') ? Number(variant.key.slice(1)) : (variant?.key?.includes('+drawer') ? 1 : 0)} gaps={{top:gLocal.gaps.top, bottom:gLocal.gaps.bottom}} drawerFronts={gLocal.drawerFronts} shelves={gLocal.shelves} />
                     </div>
                     <div className="row" style={{marginTop:8}}>
                       <button className="btn" onClick={()=>onAdd(widthMM, gLocal)}>Wstaw szafkę</button>

--- a/src/ui/components/Cabinet3D.tsx
+++ b/src/ui/components/Cabinet3D.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef } from 'react'
 import * as THREE from 'three'
 import { FAMILY, FAMILY_COLORS } from '../../core/catalog'
 
-export default function Cabinet3D({ widthMM, heightMM, depthMM, drawers, gaps, drawerFronts, family }:{ widthMM:number;heightMM:number;depthMM:number;drawers:number;gaps:{top:number;bottom:number};drawerFronts?:number[];family:FAMILY }){
+export default function Cabinet3D({ widthMM, heightMM, depthMM, drawers, gaps, drawerFronts, family, shelves=1 }:{ widthMM:number;heightMM:number;depthMM:number;drawers:number;gaps:{top:number;bottom:number};drawerFronts?:number[];family:FAMILY; shelves?:number }){
   const ref = useRef<HTMLDivElement>(null)
   useEffect(()=>{
     // Wait until our container is available
@@ -69,11 +69,14 @@ export default function Cabinet3D({ widthMM, heightMM, depthMM, drawers, gaps, d
     cabGroup.add(backBoard)
     // Shelves: simple horizontal boards (if drawers = 0) else skip
     if (drawers === 0) {
-      // Single mid shelf for visual interest
       const shelfGeo = new THREE.BoxGeometry(W - 2 * T, T, D)
-      const shelf = new THREE.Mesh(shelfGeo, carcMat)
-      shelf.position.set(W / 2, H / 2, -D / 2)
-      cabGroup.add(shelf)
+      const count = Math.max(0, shelves)
+      for (let i = 0; i < count; i++) {
+        const shelf = new THREE.Mesh(shelfGeo, carcMat)
+        const y = H * (i + 1) / (count + 1)
+        shelf.position.set(W / 2, y, -D / 2)
+        cabGroup.add(shelf)
+      }
     }
     // Front: if drawers > 0, split into drawer fronts; otherwise full door
     if (drawers > 0) {
@@ -143,6 +146,6 @@ export default function Cabinet3D({ widthMM, heightMM, depthMM, drawers, gaps, d
     return () => {
       renderer.dispose()
     }
-  }, [widthMM, heightMM, depthMM, drawers, gaps, drawerFronts, family])
+  }, [widthMM, heightMM, depthMM, drawers, gaps, drawerFronts, family, shelves])
   return <div ref={ref} style={{ width: 260, height: 190, border: '1px solid #E5E7EB', borderRadius: 8, background: '#fff' }} />
 }


### PR DESCRIPTION
## Summary
- allow specifying number of shelves per cabinet
- render correct shelf count in 3D preview and module mesh
- include shelf count in cut list and global settings

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0db3feb348322a47ef28d03d10c48