### PR TITLE
feat: add configurable back panel

### DIFF
--- a/src/core/pricing.ts
+++ b/src/core/pricing.ts
@@ -5,7 +5,7 @@ export type Price = { total:number; parts: Parts; counts:any }
 function hingeCountPerDoor(doorHeightMM:number){ if (doorHeightMM<=900) return 2; if (doorHeightMM<=1500) return 3; return 4 }
 export function computeModuleCost(params: {
   family: FAMILY; kind:string; variant:string; width:number;
-  adv: { height:number; depth:number; boardType:string; frontType:string; gaps?: any };
+  adv: { height:number; depth:number; boardType:string; frontType:string; gaps?: any; backPanel?:'full'|'split'|'none' };
 }): Price {
   const P = usePlannerStore.getState().prices
   const base = usePlannerStore.getState().globals[params.family]
@@ -39,7 +39,8 @@ export function computeModuleCost(params: {
   const hangersCost = hangersCount * (P.hangers['Standard']||0)
   const aventosCost = aventosType ? (P.aventos[aventosType]||0) : 0
   const cargoCost = cargoW ? (P.cargo[cargoW]||0) : 0
-  const boardArea = 2*(h*d)+2*(w*d)+1*(w*d)+0.4*(w*h)
+  const backFactor = g.backPanel === 'none' ? 0 : g.backPanel === 'split' ? 2 : 1
+  const boardArea = 2*(h*d)+2*(w*d)+1*(w*d)+0.4*backFactor*(w*h)
   const boardCost = boardArea*boardPrice
   const frontArea = w*h
   const frontCost = frontArea*frontPrice

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -7,13 +7,14 @@ export const defaultGaps: Gaps = { left:2, right:2, top:2, bottom:2, between:3 }
 export type Globals = Record<FAMILY, {
   height:number; depth:number; boardType:string; frontType:string;
   gaps: Gaps; legsType?:string; hangerType?:string; offsetWall?:number; shelves?:number;
+  backPanel?:'full'|'split'|'none';
 }>
 
 export const defaultGlobal: Globals = {
-  [FAMILY.BASE]: { height:800, depth:600, boardType:'Płyta 18mm', frontType:'Laminat', gaps:{...defaultGaps}, legsType:'Standard 10cm', offsetWall:30, shelves:1 },
-  [FAMILY.WALL]: { height:720, depth:320, boardType:'Płyta 18mm', frontType:'Laminat', gaps:{...defaultGaps}, hangerType:'Standard', offsetWall:20, shelves:1 },
-  [FAMILY.PAWLACZ]: { height:400, depth:600, boardType:'Płyta 18mm', frontType:'Laminat', gaps:{...defaultGaps}, hangerType:'Wzmocnione', offsetWall:30, shelves:1 },
-  [FAMILY.TALL]: { height:2100, depth:600, boardType:'Płyta 18mm', frontType:'Laminat', gaps:{...defaultGaps}, shelves:4 }
+  [FAMILY.BASE]: { height:800, depth:600, boardType:'Płyta 18mm', frontType:'Laminat', gaps:{...defaultGaps}, legsType:'Standard 10cm', offsetWall:30, shelves:1, backPanel:'full' },
+  [FAMILY.WALL]: { height:720, depth:320, boardType:'Płyta 18mm', frontType:'Laminat', gaps:{...defaultGaps}, hangerType:'Standard', offsetWall:20, shelves:1, backPanel:'full' },
+  [FAMILY.PAWLACZ]: { height:400, depth:600, boardType:'Płyta 18mm', frontType:'Laminat', gaps:{...defaultGaps}, hangerType:'Wzmocnione', offsetWall:30, shelves:1, backPanel:'full' },
+  [FAMILY.TALL]: { height:2100, depth:600, boardType:'Płyta 18mm', frontType:'Laminat', gaps:{...defaultGaps}, shelves:4, backPanel:'full' }
 }
 
 export const defaultPrices = {
@@ -45,7 +46,7 @@ type Module3D = {
   size:{ w:number; h:number; d:number }; position:[number,number,number]; rotationY?:number;
   price?: any; fittings?: any
   segIndex?: number | null
-  adv?: { height?:number; depth?:number; boardType?:string; frontType?:string; gaps?: Gaps; drawerFronts?: number[]; shelves?:number }
+  adv?: { height?:number; depth?:number; boardType?:string; frontType?:string; gaps?: Gaps; drawerFronts?: number[]; shelves?:number; backPanel?:'full'|'split'|'none' }
     /**
      * Array of booleans indicating whether each front on this module is open.
      * A single-element array corresponds to a single door; multiple elements
@@ -101,6 +102,7 @@ export const usePlannerStore = create<Store>((set,get)=>({
       if (patch.frontType !== undefined) newAdv.frontType = patch.frontType
       if (patch.gaps !== undefined) newAdv.gaps = { ...(m.adv?.gaps||{}), ...patch.gaps }
       if (patch.shelves !== undefined) newAdv.shelves = patch.shelves
+      if (patch.backPanel !== undefined) newAdv.backPanel = patch.backPanel
       const newSize = { ...m.size }
       if (patch.height !== undefined) newSize.h = patch.height/1000
       if (patch.depth !== undefined) newSize.d = patch.depth/1000

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -49,7 +49,7 @@ export default function App(){
   useEffect(()=>{
     const g = store.globals[family]
     const defaultShelves = family===FAMILY.TALL ? 4 : 1
-    setAdv({ height:g.height, depth:g.depth, boardType:g.boardType, frontType:g.frontType, gaps:{...g.gaps}, shelves:g.shelves ?? defaultShelves })
+    setAdv({ height:g.height, depth:g.depth, boardType:g.boardType, frontType:g.frontType, gaps:{...g.gaps}, shelves:g.shelves ?? defaultShelves, backPanel:g.backPanel })
   }, [family, store.globals])
 
   const undo = store.undo
@@ -111,6 +111,8 @@ export default function App(){
     const footMat = new THREE.MeshStandardMaterial({ color: footColour, metalness:0.3, roughness:0.7 })
     const group = new THREE.Group()
     group.userData.kind = 'cab'
+    // Extract advanced settings once at the beginning
+    const adv = mod.adv || {}
     // Carcase sides (add legHeight offset on Y axis)
     const sideGeo = new THREE.BoxGeometry(T, H, D)
     const leftSide = new THREE.Mesh(sideGeo, carcMat)
@@ -128,12 +130,23 @@ export default function App(){
     top.position.set(W / 2, legHeight + H - T / 2, -D / 2)
     group.add(top)
     // Back panel
-    const backGeo = new THREE.BoxGeometry(W, H, backT)
-    const back = new THREE.Mesh(backGeo, backMat)
-    back.position.set(W / 2, legHeight + H / 2, -D + backT / 2)
-    group.add(back)
-    // Extract advanced settings once at the beginning
-    const adv = mod.adv || {}
+    const backStyle = adv.backPanel || 'full'
+    if (backStyle === 'full') {
+      const backGeo = new THREE.BoxGeometry(W, H, backT)
+      const back = new THREE.Mesh(backGeo, backMat)
+      back.position.set(W / 2, legHeight + H / 2, -D + backT / 2)
+      group.add(back)
+    } else if (backStyle === 'split') {
+      const gap = 0.002
+      const halfH = (H - gap) / 2
+      const backGeo = new THREE.BoxGeometry(W, halfH, backT)
+      const bottomBack = new THREE.Mesh(backGeo, backMat)
+      bottomBack.position.set(W / 2, legHeight + halfH / 2, -D + backT / 2)
+      group.add(bottomBack)
+      const topBack = new THREE.Mesh(backGeo.clone(), backMat)
+      topBack.position.set(W / 2, legHeight + H - halfH / 2, -D + backT / 2)
+      group.add(topBack)
+    }
     const gaps = adv.gaps || { top: 0, bottom: 0 }
     // Determine if the cabinet has drawers (presence of drawerFronts array)
     const hasDrawers = Array.isArray(adv.drawerFronts) && adv.drawerFronts.length > 0
@@ -510,7 +523,7 @@ export default function App(){
     const g = { ...store.globals[family], ...advLocal, gaps: { ...store.globals[family].gaps, ...(advLocal?.gaps||{}) } }
     const h = (g.height)/1000, d=(g.depth)/1000, w=(widthMM)/1000
     const id = `mod_${Date.now()}_${Math.floor(Math.random()*1e6)}`
-    const price = computeModuleCost({ family, kind:kind.key, variant:variant.key, width: widthMM, adv:{ height:g.height, depth:g.depth, boardType:g.boardType, frontType:g.frontType, gaps:g.gaps } })
+    const price = computeModuleCost({ family, kind:kind.key, variant:variant.key, width: widthMM, adv:{ height:g.height, depth:g.depth, boardType:g.boardType, frontType:g.frontType, gaps:g.gaps, backPanel:g.backPanel } })
     const snap = snapToWalls({ w, h, d }, family)
     // Augment advanced settings with defaults for hinge, drawer slide type and animation speed if missing.
     // Additionally, compute drawer front heights based on the selected variant if none were provided.
@@ -600,7 +613,7 @@ export default function App(){
     placed.forEach((pl,i)=>{
       const wmm = widths[i]; const w=wmm/1000
       const id = `auto_${Date.now()}_${i}_${Math.floor(Math.random()*1e6)}`
-      const price = computeModuleCost({ family, kind:(KIND_SETS[family][0]?.key)||'doors', variant:'d1', width: wmm, adv:{ height:g.height, depth:g.depth, boardType:g.boardType, frontType:g.frontType, gaps:g.gaps } })
+      const price = computeModuleCost({ family, kind:(KIND_SETS[family][0]?.key)||'doors', variant:'d1', width: wmm, adv:{ height:g.height, depth:g.depth, boardType:g.boardType, frontType:g.frontType, gaps:g.gaps, backPanel:g.backPanel } })
       let mod:any = { id, label:'Auto', family, kind:(KIND_SETS[family][0]?.key)||'doors', size:{ w,h,d }, position:[pl.center[0]/1000, h/2, pl.center[1]/1000], rotationY:pl.rot, segIndex: selWall, price, adv:g }
       mod = resolveCollisions(mod)
       store.addModule(mod)
@@ -728,10 +741,10 @@ export default function App(){
                       />
                     </div>
                     <div className="row" style={{marginTop:8}}>
-                      <Cabinet3D family={family} widthMM={widthMM} heightMM={gLocal.height} depthMM={gLocal.depth} drawers={variant?.key?.startsWith('s') ? Number(variant.key.slice(1)) : (variant?.key?.includes('+drawer') ? 1 : 0)} gaps={{top:gLocal.gaps.top, bottom:gLocal.gaps.bottom}} drawerFronts={gLocal.drawerFronts} shelves={gLocal.shelves} />
+                      <Cabinet3D family={family} widthMM={widthMM} heightMM={gLocal.height} depthMM={gLocal.depth} drawers={variant?.key?.startsWith('s') ? Number(variant.key.slice(1)) : (variant?.key?.includes('+drawer') ? 1 : 0)} gaps={{top:gLocal.gaps.top, bottom:gLocal.gaps.bottom}} drawerFronts={gLocal.drawerFronts} shelves={gLocal.shelves} backPanel={gLocal.backPanel} />
                     </div>
                     <div className="row" style={{marginTop:8}}>
-                      <Cabinet3D family={family} widthMM={widthMM} heightMM={gLocal.height} depthMM={gLocal.depth} drawers={variant?.key?.startsWith('s') ? Number(variant.key.slice(1)) : (variant?.key?.includes('+drawer') ? 1 : 0)} gaps={{top:gLocal.gaps.top, bottom:gLocal.gaps.bottom}} drawerFronts={gLocal.drawerFronts} shelves={gLocal.shelves} />
+                      <Cabinet3D family={family} widthMM={widthMM} heightMM={gLocal.height} depthMM={gLocal.depth} drawers={variant?.key?.startsWith('s') ? Number(variant.key.slice(1)) : (variant?.key?.includes('+drawer') ? 1 : 0)} gaps={{top:gLocal.gaps.top, bottom:gLocal.gaps.bottom}} drawerFronts={gLocal.drawerFronts} shelves={gLocal.shelves} backPanel={gLocal.backPanel} />
                     </div>
                   </div>
                 )}
@@ -742,6 +755,11 @@ export default function App(){
                       <div><div className="small">Głębokość (mm)</div><input className="input" type="number" value={gLocal.depth} onChange={e=>setAdv({...gLocal, depth:Number((e.target as HTMLInputElement).value)||0})} /></div>
                       <div><div className="small">Płyta</div><select className="input" value={gLocal.boardType} onChange={e=>setAdv({...gLocal, boardType:(e.target as HTMLSelectElement).value})}>{Object.keys(store.prices.board).map(k=><option key={k} value={k}>{k}</option>)}</select></div>
                       <div><div className="small">Front</div><select className="input" value={gLocal.frontType} onChange={e=>setAdv({...gLocal, frontType:(e.target as HTMLSelectElement).value})}>{Object.keys(store.prices.front).map(k=><option key={k} value={k}>{k}</option>)}</select></div>
+                      <div><div className="small">Plecy</div><select className="input" value={gLocal.backPanel||'full'} onChange={e=>setAdv({...gLocal, backPanel:(e.target as HTMLSelectElement).value})}>
+                        <option value="full">full</option>
+                        <option value="split">split</option>
+                        <option value="none">none</option>
+                      </select></div>
                     </div>
                     {!(variant?.key?.startsWith('s')) && (
                       <div style={{marginTop:8}}>
@@ -767,10 +785,10 @@ export default function App(){
                       />
                     </div>
                     <div className="row" style={{marginTop:8}}>
-                      <Cabinet3D family={family} widthMM={widthMM} heightMM={gLocal.height} depthMM={gLocal.depth} drawers={variant?.key?.startsWith('s') ? Number(variant.key.slice(1)) : (variant?.key?.includes('+drawer') ? 1 : 0)} gaps={{top:gLocal.gaps.top, bottom:gLocal.gaps.bottom}} drawerFronts={gLocal.drawerFronts} shelves={gLocal.shelves} />
+                      <Cabinet3D family={family} widthMM={widthMM} heightMM={gLocal.height} depthMM={gLocal.depth} drawers={variant?.key?.startsWith('s') ? Number(variant.key.slice(1)) : (variant?.key?.includes('+drawer') ? 1 : 0)} gaps={{top:gLocal.gaps.top, bottom:gLocal.gaps.bottom}} drawerFronts={gLocal.drawerFronts} shelves={gLocal.shelves} backPanel={gLocal.backPanel} />
                     </div>
                     <div className="row" style={{marginTop:8}}>
-                      <Cabinet3D family={family} widthMM={widthMM} heightMM={gLocal.height} depthMM={gLocal.depth} drawers={variant?.key?.startsWith('s') ? Number(variant.key.slice(1)) : (variant?.key?.includes('+drawer') ? 1 : 0)} gaps={{top:gLocal.gaps.top, bottom:gLocal.gaps.bottom}} drawerFronts={gLocal.drawerFronts} shelves={gLocal.shelves} />
+                      <Cabinet3D family={family} widthMM={widthMM} heightMM={gLocal.height} depthMM={gLocal.depth} drawers={variant?.key?.startsWith('s') ? Number(variant.key.slice(1)) : (variant?.key?.includes('+drawer') ? 1 : 0)} gaps={{top:gLocal.gaps.top, bottom:gLocal.gaps.bottom}} drawerFronts={gLocal.drawerFronts} shelves={gLocal.shelves} backPanel={gLocal.backPanel} />
                     </div>
                     <div className="row" style={{marginTop:8}}>
                       <button className="btn" onClick={()=>onAdd(widthMM, gLocal)}>Wstaw szafkę</button>

--- a/src/ui/components/Cabinet3D.tsx
+++ b/src/ui/components/Cabinet3D.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef } from 'react'
 import * as THREE from 'three'
 import { FAMILY, FAMILY_COLORS } from '../../core/catalog'
 
-export default function Cabinet3D({ widthMM, heightMM, depthMM, drawers, gaps, drawerFronts, family, shelves=1 }:{ widthMM:number;heightMM:number;depthMM:number;drawers:number;gaps:{top:number;bottom:number};drawerFronts?:number[];family:FAMILY; shelves?:number }){
+export default function Cabinet3D({ widthMM, heightMM, depthMM, drawers, gaps, drawerFronts, family, shelves=1, backPanel='full' }:{ widthMM:number;heightMM:number;depthMM:number;drawers:number;gaps:{top:number;bottom:number};drawerFronts?:number[];family:FAMILY; shelves?:number; backPanel?:'full'|'split'|'none' }){
   const ref = useRef<HTMLDivElement>(null)
   useEffect(()=>{
     // Wait until our container is available
@@ -63,10 +63,22 @@ export default function Cabinet3D({ widthMM, heightMM, depthMM, drawers, gaps, d
     topBoard.position.set(W / 2, H - T / 2, -D / 2)
     cabGroup.add(topBoard)
     // Back board
-    const backGeo = new THREE.BoxGeometry(W, H, backT)
-    const backBoard = new THREE.Mesh(backGeo, backMat)
-    backBoard.position.set(W / 2, H / 2, -D + backT / 2)
-    cabGroup.add(backBoard)
+    if (backPanel === 'full') {
+      const backGeo = new THREE.BoxGeometry(W, H, backT)
+      const backBoard = new THREE.Mesh(backGeo, backMat)
+      backBoard.position.set(W / 2, H / 2, -D + backT / 2)
+      cabGroup.add(backBoard)
+    } else if (backPanel === 'split') {
+      const gap = 0.002
+      const halfH = (H - gap) / 2
+      const backGeo = new THREE.BoxGeometry(W, halfH, backT)
+      const bottomBack = new THREE.Mesh(backGeo, backMat)
+      bottomBack.position.set(W / 2, halfH / 2, -D + backT / 2)
+      cabGroup.add(bottomBack)
+      const topBack = new THREE.Mesh(backGeo.clone(), backMat)
+      topBack.position.set(W / 2, H - halfH / 2, -D + backT / 2)
+      cabGroup.add(topBack)
+    }
     // Shelves: simple horizontal boards (if drawers = 0) else skip
     if (drawers === 0) {
       const shelfGeo = new THREE.BoxGeometry(W - 2 * T, T, D)
@@ -146,6 +158,6 @@ export default function Cabinet3D({ widthMM, heightMM, depthMM, drawers, gaps, d
     return () => {
       renderer.dispose()
     }
-  }, [widthMM, heightMM, depthMM, drawers, gaps, drawerFronts, family, shelves])
+  }, [widthMM, heightMM, depthMM, drawers, gaps, drawerFronts, family, shelves, backPanel])
   return <div ref={ref} style={{ width: 260, height: 190, border: '1px solid #E5E7EB', borderRadius: 8, background: '#fff' }} />
 }

--- a/src/ui/panels/GlobalSettings.tsx
+++ b/src/ui/panels/GlobalSettings.tsx
@@ -35,6 +35,7 @@ export default function GlobalSettings(){
             <Field label="Głębokość (mm)" value={g.depth} onChange={(v)=>set({depth:v})} />
             <Field label="Rodzaj płyty" type="select" value={g.boardType} onChange={(v)=>set({boardType:v})} options={Object.keys(store.prices.board)} />
             <Field label="Rodzaj frontu" type="select" value={g.frontType} onChange={(v)=>set({frontType:v})} options={Object.keys(store.prices.front)} />
+            <Field label="Plecy" type="select" value={g.backPanel||'full'} onChange={(v)=>set({backPanel:v})} options={['full','split','none']} />
             {fam===FAMILY.BASE && (<>
               <Field label="Nóżki" type="select" value={g.legsType} onChange={(v)=>set({legsType:v})} options={Object.keys(store.prices.legs)} />
               <Field label="Odsunięcie od ściany (mm)" value={g.offsetWall||0} onChange={(v)=>set({offsetWall:v})} />


### PR DESCRIPTION
## Summary
- add `backPanel` option to global and module settings
- support full, split, or no back panel rendering
- include back panel style in pricing calculations

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b157da898c832281cc0556f9a2f5a6