### PR TITLE
feat: add opening mechanism options

### DIFF
--- a/src/core/pricing.ts
+++ b/src/core/pricing.ts
@@ -5,7 +5,7 @@ export type Price = { total:number; parts: Parts; counts:any }
 function hingeCountPerDoor(doorHeightMM:number){ if (doorHeightMM<=900) return 2; if (doorHeightMM<=1500) return 3; return 4 }
 export function computeModuleCost(params: {
   family: FAMILY; kind:string; variant:string; width:number;
-  adv: { height:number; depth:number; boardType:string; frontType:string; gaps?: any };
+  adv: { height:number; depth:number; boardType:string; frontType:string; openingMechanism?:'standard'|'TIP-ON'|'BLUMOTION'; gaps?: any };
 }): Price {
   const P = usePlannerStore.getState().prices
   const base = usePlannerStore.getState().globals[params.family]
@@ -31,7 +31,10 @@ export function computeModuleCost(params: {
   }
   const doorHeightMM = hMM - 100
   const hingesPerDoor = hingeCountPerDoor(doorHeightMM)
-  const hingesCost = (P.hinges['Blum ClipTop']||0) * hingesPerDoor * doors
+  let hingeKey = 'Blum ClipTop'
+  if (g.openingMechanism === 'TIP-ON') hingeKey = 'Blum TIP-ON'
+  else if (g.openingMechanism === 'BLUMOTION') hingeKey = 'Blum ClipTop BLUMOTION'
+  const hingesCost = (P.hinges[hingeKey]||0) * hingesPerDoor * doors
   const slidesCost = (P.drawerSlide['BLUM LEGRABOX']||0) * drawers
   const legsCount = params.family===FAMILY.BASE ? Math.max(4, Math.ceil(wMM/300)*2) : 0
   const legsCost = legsCount * (P.legs['Standard 10cm']||0)

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -6,14 +6,15 @@ export const defaultGaps: Gaps = { left:2, right:2, top:2, bottom:2, between:3 }
 
 export type Globals = Record<FAMILY, {
   height:number; depth:number; boardType:string; frontType:string;
+  openingMechanism:'standard'|'TIP-ON'|'BLUMOTION';
   gaps: Gaps; legsType?:string; hangerType?:string; offsetWall?:number; shelves?:number;
 }>
 
 export const defaultGlobal: Globals = {
-  [FAMILY.BASE]: { height:800, depth:600, boardType:'Płyta 18mm', frontType:'Laminat', gaps:{...defaultGaps}, legsType:'Standard 10cm', offsetWall:30, shelves:1 },
-  [FAMILY.WALL]: { height:720, depth:320, boardType:'Płyta 18mm', frontType:'Laminat', gaps:{...defaultGaps}, hangerType:'Standard', offsetWall:20, shelves:1 },
-  [FAMILY.PAWLACZ]: { height:400, depth:600, boardType:'Płyta 18mm', frontType:'Laminat', gaps:{...defaultGaps}, hangerType:'Wzmocnione', offsetWall:30, shelves:1 },
-  [FAMILY.TALL]: { height:2100, depth:600, boardType:'Płyta 18mm', frontType:'Laminat', gaps:{...defaultGaps}, shelves:4 }
+  [FAMILY.BASE]: { height:800, depth:600, boardType:'Płyta 18mm', frontType:'Laminat', openingMechanism:'standard', gaps:{...defaultGaps}, legsType:'Standard 10cm', offsetWall:30, shelves:1 },
+  [FAMILY.WALL]: { height:720, depth:320, boardType:'Płyta 18mm', frontType:'Laminat', openingMechanism:'standard', gaps:{...defaultGaps}, hangerType:'Standard', offsetWall:20, shelves:1 },
+  [FAMILY.PAWLACZ]: { height:400, depth:600, boardType:'Płyta 18mm', frontType:'Laminat', openingMechanism:'standard', gaps:{...defaultGaps}, hangerType:'Wzmocnione', offsetWall:30, shelves:1 },
+  [FAMILY.TALL]: { height:2100, depth:600, boardType:'Płyta 18mm', frontType:'Laminat', openingMechanism:'standard', gaps:{...defaultGaps}, shelves:4 }
 }
 
 export const defaultPrices = {
@@ -23,7 +24,7 @@ export const defaultPrices = {
   cut: 4.0,
   legs: { 'Standard 10cm': 6, 'Regulowane 12cm': 9, 'Metal 10cm': 12 },
   hangers: { 'Standard': 10, 'Wzmocnione': 18 },
-  hinges: { 'Blum ClipTop': 16, 'GTV': 9 },
+  hinges: { 'Blum ClipTop': 16, 'Blum TIP-ON': 20, 'Blum ClipTop BLUMOTION': 18, 'GTV': 9 },
   drawerSlide: { 'BLUM LEGRABOX': 68, 'BLUM TANDEMBOX': 48, 'GTV': 22 },
   aventos: { 'HK': 180, 'HS': 240 },
   cargo: { '150': 180, '200': 210, '300': 260 },
@@ -45,7 +46,7 @@ type Module3D = {
   size:{ w:number; h:number; d:number }; position:[number,number,number]; rotationY?:number;
   price?: any; fittings?: any
   segIndex?: number | null
-  adv?: { height?:number; depth?:number; boardType?:string; frontType?:string; gaps?: Gaps; drawerFronts?: number[]; shelves?:number }
+  adv?: { height?:number; depth?:number; boardType?:string; frontType?:string; openingMechanism?:'standard'|'TIP-ON'|'BLUMOTION'; gaps?: Gaps; drawerFronts?: number[]; shelves?:number }
     /**
      * Array of booleans indicating whether each front on this module is open.
      * A single-element array corresponds to a single door; multiple elements
@@ -99,6 +100,7 @@ export const usePlannerStore = create<Store>((set,get)=>({
       if (patch.depth !== undefined) newAdv.depth = patch.depth
       if (patch.boardType !== undefined) newAdv.boardType = patch.boardType
       if (patch.frontType !== undefined) newAdv.frontType = patch.frontType
+      if (patch.openingMechanism !== undefined) newAdv.openingMechanism = patch.openingMechanism
       if (patch.gaps !== undefined) newAdv.gaps = { ...(m.adv?.gaps||{}), ...patch.gaps }
       if (patch.shelves !== undefined) newAdv.shelves = patch.shelves
       const newSize = { ...m.size }

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -510,7 +510,7 @@ export default function App(){
     const g = { ...store.globals[family], ...advLocal, gaps: { ...store.globals[family].gaps, ...(advLocal?.gaps||{}) } }
     const h = (g.height)/1000, d=(g.depth)/1000, w=(widthMM)/1000
     const id = `mod_${Date.now()}_${Math.floor(Math.random()*1e6)}`
-    const price = computeModuleCost({ family, kind:kind.key, variant:variant.key, width: widthMM, adv:{ height:g.height, depth:g.depth, boardType:g.boardType, frontType:g.frontType, gaps:g.gaps } })
+    const price = computeModuleCost({ family, kind:kind.key, variant:variant.key, width: widthMM, adv:{ height:g.height, depth:g.depth, boardType:g.boardType, frontType:g.frontType, openingMechanism:g.openingMechanism, gaps:g.gaps } })
     const snap = snapToWalls({ w, h, d }, family)
     // Augment advanced settings with defaults for hinge, drawer slide type and animation speed if missing.
     // Additionally, compute drawer front heights based on the selected variant if none were provided.
@@ -600,7 +600,7 @@ export default function App(){
     placed.forEach((pl,i)=>{
       const wmm = widths[i]; const w=wmm/1000
       const id = `auto_${Date.now()}_${i}_${Math.floor(Math.random()*1e6)}`
-      const price = computeModuleCost({ family, kind:(KIND_SETS[family][0]?.key)||'doors', variant:'d1', width: wmm, adv:{ height:g.height, depth:g.depth, boardType:g.boardType, frontType:g.frontType, gaps:g.gaps } })
+      const price = computeModuleCost({ family, kind:(KIND_SETS[family][0]?.key)||'doors', variant:'d1', width: wmm, adv:{ height:g.height, depth:g.depth, boardType:g.boardType, frontType:g.frontType, openingMechanism:g.openingMechanism, gaps:g.gaps } })
       let mod:any = { id, label:'Auto', family, kind:(KIND_SETS[family][0]?.key)||'doors', size:{ w,h,d }, position:[pl.center[0]/1000, h/2, pl.center[1]/1000], rotationY:pl.rot, segIndex: selWall, price, adv:g }
       mod = resolveCollisions(mod)
       store.addModule(mod)
@@ -728,10 +728,10 @@ export default function App(){
                       />
                     </div>
                     <div className="row" style={{marginTop:8}}>
-                      <Cabinet3D family={family} widthMM={widthMM} heightMM={gLocal.height} depthMM={gLocal.depth} drawers={variant?.key?.startsWith('s') ? Number(variant.key.slice(1)) : (variant?.key?.includes('+drawer') ? 1 : 0)} gaps={{top:gLocal.gaps.top, bottom:gLocal.gaps.bottom}} drawerFronts={gLocal.drawerFronts} shelves={gLocal.shelves} />
+                      <Cabinet3D family={family} widthMM={widthMM} heightMM={gLocal.height} depthMM={gLocal.depth} drawers={variant?.key?.startsWith('s') ? Number(variant.key.slice(1)) : (variant?.key?.includes('+drawer') ? 1 : 0)} gaps={{top:gLocal.gaps.top, bottom:gLocal.gaps.bottom}} drawerFronts={gLocal.drawerFronts} shelves={gLocal.shelves} openingMechanism={gLocal.openingMechanism} />
                     </div>
                     <div className="row" style={{marginTop:8}}>
-                      <Cabinet3D family={family} widthMM={widthMM} heightMM={gLocal.height} depthMM={gLocal.depth} drawers={variant?.key?.startsWith('s') ? Number(variant.key.slice(1)) : (variant?.key?.includes('+drawer') ? 1 : 0)} gaps={{top:gLocal.gaps.top, bottom:gLocal.gaps.bottom}} drawerFronts={gLocal.drawerFronts} shelves={gLocal.shelves} />
+                      <Cabinet3D family={family} widthMM={widthMM} heightMM={gLocal.height} depthMM={gLocal.depth} drawers={variant?.key?.startsWith('s') ? Number(variant.key.slice(1)) : (variant?.key?.includes('+drawer') ? 1 : 0)} gaps={{top:gLocal.gaps.top, bottom:gLocal.gaps.bottom}} drawerFronts={gLocal.drawerFronts} shelves={gLocal.shelves} openingMechanism={gLocal.openingMechanism} />
                     </div>
                   </div>
                 )}
@@ -742,6 +742,7 @@ export default function App(){
                       <div><div className="small">Głębokość (mm)</div><input className="input" type="number" value={gLocal.depth} onChange={e=>setAdv({...gLocal, depth:Number((e.target as HTMLInputElement).value)||0})} /></div>
                       <div><div className="small">Płyta</div><select className="input" value={gLocal.boardType} onChange={e=>setAdv({...gLocal, boardType:(e.target as HTMLSelectElement).value})}>{Object.keys(store.prices.board).map(k=><option key={k} value={k}>{k}</option>)}</select></div>
                       <div><div className="small">Front</div><select className="input" value={gLocal.frontType} onChange={e=>setAdv({...gLocal, frontType:(e.target as HTMLSelectElement).value})}>{Object.keys(store.prices.front).map(k=><option key={k} value={k}>{k}</option>)}</select></div>
+                      <div><div className="small">Mechanizm</div><select className="input" value={gLocal.openingMechanism||'standard'} onChange={e=>setAdv({...gLocal, openingMechanism:(e.target as HTMLSelectElement).value})}>{['standard','TIP-ON','BLUMOTION'].map(k=><option key={k} value={k}>{k}</option>)}</select></div>
                     </div>
                     {!(variant?.key?.startsWith('s')) && (
                       <div style={{marginTop:8}}>
@@ -767,10 +768,10 @@ export default function App(){
                       />
                     </div>
                     <div className="row" style={{marginTop:8}}>
-                      <Cabinet3D family={family} widthMM={widthMM} heightMM={gLocal.height} depthMM={gLocal.depth} drawers={variant?.key?.startsWith('s') ? Number(variant.key.slice(1)) : (variant?.key?.includes('+drawer') ? 1 : 0)} gaps={{top:gLocal.gaps.top, bottom:gLocal.gaps.bottom}} drawerFronts={gLocal.drawerFronts} shelves={gLocal.shelves} />
+                      <Cabinet3D family={family} widthMM={widthMM} heightMM={gLocal.height} depthMM={gLocal.depth} drawers={variant?.key?.startsWith('s') ? Number(variant.key.slice(1)) : (variant?.key?.includes('+drawer') ? 1 : 0)} gaps={{top:gLocal.gaps.top, bottom:gLocal.gaps.bottom}} drawerFronts={gLocal.drawerFronts} shelves={gLocal.shelves} openingMechanism={gLocal.openingMechanism} />
                     </div>
                     <div className="row" style={{marginTop:8}}>
-                      <Cabinet3D family={family} widthMM={widthMM} heightMM={gLocal.height} depthMM={gLocal.depth} drawers={variant?.key?.startsWith('s') ? Number(variant.key.slice(1)) : (variant?.key?.includes('+drawer') ? 1 : 0)} gaps={{top:gLocal.gaps.top, bottom:gLocal.gaps.bottom}} drawerFronts={gLocal.drawerFronts} shelves={gLocal.shelves} />
+                      <Cabinet3D family={family} widthMM={widthMM} heightMM={gLocal.height} depthMM={gLocal.depth} drawers={variant?.key?.startsWith('s') ? Number(variant.key.slice(1)) : (variant?.key?.includes('+drawer') ? 1 : 0)} gaps={{top:gLocal.gaps.top, bottom:gLocal.gaps.bottom}} drawerFronts={gLocal.drawerFronts} shelves={gLocal.shelves} openingMechanism={gLocal.openingMechanism} />
                     </div>
                     <div className="row" style={{marginTop:8}}>
                       <button className="btn" onClick={()=>onAdd(widthMM, gLocal)}>Wstaw szafkę</button>

--- a/src/ui/components/Cabinet3D.tsx
+++ b/src/ui/components/Cabinet3D.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef } from 'react'
 import * as THREE from 'three'
 import { FAMILY, FAMILY_COLORS } from '../../core/catalog'
 
-export default function Cabinet3D({ widthMM, heightMM, depthMM, drawers, gaps, drawerFronts, family, shelves=1 }:{ widthMM:number;heightMM:number;depthMM:number;drawers:number;gaps:{top:number;bottom:number};drawerFronts?:number[];family:FAMILY; shelves?:number }){
+export default function Cabinet3D({ widthMM, heightMM, depthMM, drawers, gaps, drawerFronts, family, shelves=1, openingMechanism='standard' }:{ widthMM:number;heightMM:number;depthMM:number;drawers:number;gaps:{top:number;bottom:number};drawerFronts?:number[];family:FAMILY; shelves?:number; openingMechanism?:'standard'|'TIP-ON'|'BLUMOTION' }){
   const ref = useRef<HTMLDivElement>(null)
   useEffect(()=>{
     // Wait until our container is available
@@ -92,16 +92,18 @@ export default function Cabinet3D({ widthMM, heightMM, depthMM, drawers, gaps, d
         // Position each drawer front; note: y is bottom of front + h/2
         frontMesh.position.set(W / 2, currentY + h / 2, -T / 2)
         cabGroup.add(frontMesh)
-        // Add handle for each drawer: small dark box centered horizontally
-        const handleWidth = Math.min(0.4, W * 0.5)
-        const handleHeight = 0.02
-        const handleDepth = 0.03
-        const handleGeo = new THREE.BoxGeometry(handleWidth, handleHeight, handleDepth)
-        const handleMat = new THREE.MeshStandardMaterial({ color: 0x333333, metalness:0.8, roughness:0.4 })
-        const handleMesh = new THREE.Mesh(handleGeo, handleMat)
-        // Position handle near top of drawer front
-        handleMesh.position.set(W / 2, currentY + h - handleHeight * 1.5, 0.01)
-        cabGroup.add(handleMesh)
+        if (openingMechanism !== 'TIP-ON') {
+          // Add handle for each drawer: small dark box centered horizontally
+          const handleWidth = Math.min(0.4, W * 0.5)
+          const handleHeight = 0.02
+          const handleDepth = 0.03
+          const handleGeo = new THREE.BoxGeometry(handleWidth, handleHeight, handleDepth)
+          const handleMat = new THREE.MeshStandardMaterial({ color: 0x333333, metalness:0.8, roughness:0.4 })
+          const handleMesh = new THREE.Mesh(handleGeo, handleMat)
+          // Position handle near top of drawer front
+          handleMesh.position.set(W / 2, currentY + h - handleHeight * 1.5, 0.01)
+          cabGroup.add(handleMesh)
+        }
         // Move up by this front's height for the next drawer
         currentY += h
       }
@@ -111,15 +113,27 @@ export default function Cabinet3D({ widthMM, heightMM, depthMM, drawers, gaps, d
       const door = new THREE.Mesh(doorGeo, frontMat)
       door.position.set(W / 2, H / 2, -T / 2)
       cabGroup.add(door)
-      // Handle: horizontal bar
-      const handleWidth = Math.min(0.4, W * 0.5)
-      const handleHeight = 0.02
-      const handleDepth = 0.03
-      const handleGeo = new THREE.BoxGeometry(handleWidth, handleHeight, handleDepth)
-      const handleMat = new THREE.MeshStandardMaterial({ color: 0x333333, metalness:0.8, roughness:0.4 })
-      const handle = new THREE.Mesh(handleGeo, handleMat)
-      handle.position.set(W / 2, H * 0.7, 0.01)
-      cabGroup.add(handle)
+      if (openingMechanism !== 'TIP-ON') {
+        // Handle: horizontal bar
+        const handleWidth = Math.min(0.4, W * 0.5)
+        const handleHeight = 0.02
+        const handleDepth = 0.03
+        const handleGeo = new THREE.BoxGeometry(handleWidth, handleHeight, handleDepth)
+        const handleMat = new THREE.MeshStandardMaterial({ color: 0x333333, metalness:0.8, roughness:0.4 })
+        const handle = new THREE.Mesh(handleGeo, handleMat)
+        handle.position.set(W / 2, H * 0.7, 0.01)
+        cabGroup.add(handle)
+      }
+      if (openingMechanism !== 'standard') {
+        const hingeGeo = new THREE.SphereGeometry(0.01, 8, 8)
+        const hingeMat = new THREE.MeshStandardMaterial({ color: openingMechanism === 'BLUMOTION' ? 0x0000ff : 0x00aa00 })
+        const h1 = new THREE.Mesh(hingeGeo, hingeMat)
+        h1.position.set(T / 2, H * 0.2, -T / 2 - 0.01)
+        cabGroup.add(h1)
+        const h2 = h1.clone()
+        h2.position.set(T / 2, H * 0.8, -T / 2 - 0.01)
+        cabGroup.add(h2)
+      }
     }
     // Legs: only for base and tall cabinets
     if (family === FAMILY.BASE || family === FAMILY.TALL) {
@@ -146,6 +160,6 @@ export default function Cabinet3D({ widthMM, heightMM, depthMM, drawers, gaps, d
     return () => {
       renderer.dispose()
     }
-  }, [widthMM, heightMM, depthMM, drawers, gaps, drawerFronts, family, shelves])
+    }, [widthMM, heightMM, depthMM, drawers, gaps, drawerFronts, family, shelves, openingMechanism])
   return <div ref={ref} style={{ width: 260, height: 190, border: '1px solid #E5E7EB', borderRadius: 8, background: '#fff' }} />
 }

--- a/src/ui/panels/GlobalSettings.tsx
+++ b/src/ui/panels/GlobalSettings.tsx
@@ -35,6 +35,7 @@ export default function GlobalSettings(){
             <Field label="Głębokość (mm)" value={g.depth} onChange={(v)=>set({depth:v})} />
             <Field label="Rodzaj płyty" type="select" value={g.boardType} onChange={(v)=>set({boardType:v})} options={Object.keys(store.prices.board)} />
             <Field label="Rodzaj frontu" type="select" value={g.frontType} onChange={(v)=>set({frontType:v})} options={Object.keys(store.prices.front)} />
+            <Field label="Mechanizm" type="select" value={g.openingMechanism||'standard'} onChange={(v)=>set({openingMechanism:v})} options={['standard','TIP-ON','BLUMOTION']} />
             {fam===FAMILY.BASE && (<>
               <Field label="Nóżki" type="select" value={g.legsType} onChange={(v)=>set({legsType:v})} options={Object.keys(store.prices.legs)} />
               <Field label="Odsunięcie od ściany (mm)" value={g.offsetWall||0} onChange={(v)=>set({offsetWall:v})} />


### PR DESCRIPTION
## Summary
- add `openingMechanism` to global state and modules
- price hinges according to chosen opening mechanism
- hide handles and show hinge markers for push-to-open cabinets

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b157e43cdc83228c4860e00ecbfeee