### PR TITLE
feat: expand catalog with specialty cabinets

### DIFF
--- a/src/core/catalog.ts
+++ b/src/core/catalog.ts
@@ -13,9 +13,7 @@ export const KIND_SETS: Record<FAMILY, Kind[]> = {
       { key:'d1', label:'1 drzwiczki' },
       { key:'d2', label:'2 drzwiczki' },
       { key:'d1+drawer', label:'1 drzwiczki + szuflada' },
-      { key:'d2+drawer', label:'2 drzwiczki + szuflada' },
-      { key:'sink', label:'Zlewowa' },
-      { key:'hob', label:'Pod płytę' }
+      { key:'d2+drawer', label:'2 drzwiczki + szuflada' }
     ]},
     { key:'drawers', label:'Szuflady', variants:[
       { key:'s1', label:'1 szuflada' },
@@ -27,16 +25,25 @@ export const KIND_SETS: Record<FAMILY, Kind[]> = {
       { key:'blind-L', label:'Ślepa L' },
       { key:'blind-R', label:'Ślepa P' }
     ]},
+    { key:'sink', label:'Zlewowe', variants:[
+      { key:'sink', label:'Szafka zlewozmywakowa' }
+    ]},
     { key:'cargo', label:'Cargo dolne', variants:[
       { key:'cargo150', label:'Cargo 150' },
       { key:'cargo200', label:'Cargo 200' },
       { key:'cargo300', label:'Cargo 300' }
+    ]},
+    { key:'appliance', label:'Pod AGD', variants:[
+      { key:'dw', label:'Zmywarka' },
+      { key:'hob', label:'Pod płytę' }
     ]}
   ],
   [FAMILY.TALL]: [
     { key:'tall', label:'Słupki', variants:[
       { key:'t1', label:'1 drzwi' },
-      { key:'t2', label:'2 drzwi' },
+      { key:'t2', label:'2 drzwi' }
+    ]},
+    { key:'appliance', label:'AGD w słupku', variants:[
       { key:'oven', label:'Piekarnik' },
       { key:'oven+mw', label:'Piekarnik + MW' },
       { key:'fridge', label:'Lodówka' }
@@ -45,7 +52,9 @@ export const KIND_SETS: Record<FAMILY, Kind[]> = {
   [FAMILY.WALL]: [
     { key:'doors', label:'Drzwiczki', variants:[
       { key:'wd1', label:'1 drzwiczki' },
-      { key:'wd2', label:'2 drzwiczki' },
+      { key:'wd2', label:'2 drzwiczki' }
+    ]},
+    { key:'appliance', label:'Pod AGD', variants:[
       { key:'hood', label:'Okapowa' },
       { key:'avHK', label:'Aventos HK' },
       { key:'avHS', label:'Aventos HS' }

--- a/src/core/pricing.ts
+++ b/src/core/pricing.ts
@@ -19,13 +19,18 @@ export function computeModuleCost(params: {
   const edgingPrice = P.edging['ABS 1mm'] || 0
   let doors = 0, drawers = 0, cargoW: '150'|'200'|'300'|null = null, aventosType: 'HK'|'HS'|null = null, kits = 0
   if(params.family===FAMILY.BASE){
-    if(params.kind==='doors'){ if(params.variant==='d1') doors=1; if(params.variant==='d2') doors=2; if(params.variant==='d1+drawer'){ doors=1; drawers=1 } if(params.variant==='d2+drawer'){ doors=2; drawers=1 } if(params.variant==='sink'){ doors=2; kits += (P.sinkKit||0) } if(params.variant==='hob'){ doors=2 } }
+    if(params.kind==='doors'){ if(params.variant==='d1') doors=1; if(params.variant==='d2') doors=2; if(params.variant==='d1+drawer'){ doors=1; drawers=1 } if(params.variant==='d2+drawer'){ doors=2; drawers=1 } }
     if(params.kind==='drawers'){ if(params.variant.startsWith('s')) drawers = Number(params.variant.slice(1))||0 }
+    if(params.kind==='corner'){ doors=2 }
+    if(params.kind==='sink'){ doors=2; kits += (P.sinkKit||0) }
     if(params.kind==='cargo'){ if(params.variant==='cargo150') cargoW='150'; if(params.variant==='cargo200') cargoW='200'; if(params.variant==='cargo300') cargoW='300' }
+    if(params.kind==='appliance'){ if(params.variant==='dw'){ kits += (P.dwKit||0); doors=1 } if(params.variant==='hob'){ doors=2 } }
   } else if(params.family===FAMILY.TALL){
-    if(params.variant==='t1') doors=1; if(params.variant==='t2') doors=2; if(params.variant==='oven'){ kits += (P.dwKit||0) } if(params.variant==='oven+mw'){ kits += (P.dwKit||0) + 100 } if(params.variant==='fridge'){ kits += (P.fridgeKit||0); doors=2 }
+    if(params.kind==='tall'){ if(params.variant==='t1') doors=1; if(params.variant==='t2') doors=2 }
+    if(params.kind==='appliance'){ if(params.variant==='oven'){ kits += (P.dwKit||0) } if(params.variant==='oven+mw'){ kits += (P.dwKit||0) + 100 } if(params.variant==='fridge'){ kits += (P.fridgeKit||0); doors=2 } }
   } else if(params.family===FAMILY.WALL){
-    if(params.variant==='wd1') doors=1; if(params.variant==='wd2') doors=2; if(params.variant==='hood'){ kits += (P.hoodKit||0); doors=2 } if(params.variant==='avHK'){ aventosType='HK' } if(params.variant==='avHS'){ aventosType='HS' }
+    if(params.kind==='doors'){ if(params.variant==='wd1') doors=1; if(params.variant==='wd2') doors=2 }
+    if(params.kind==='appliance'){ if(params.variant==='hood'){ kits += (P.hoodKit||0); doors=2 } if(params.variant==='avHK'){ aventosType='HK' } if(params.variant==='avHS'){ aventosType='HS' } }
   } else if(params.family===FAMILY.PAWLACZ){
     if(params.variant==='p1') doors=1; if(params.variant==='p2') doors=2; if(params.variant==='p3') doors=3
   }

--- a/src/scene/cabinetBuilders.ts
+++ b/src/scene/cabinetBuilders.ts
@@ -1,0 +1,80 @@
+import * as THREE from 'three'
+import { FAMILY, FAMILY_COLORS } from '../core/catalog'
+
+export type BuildParams = {
+  W:number; H:number; D:number;
+  drawers?:number; gaps?:{top:number;bottom:number}; drawerFronts?:number[];
+  family:FAMILY; shelves?:number; omitTop?:boolean; variantKey?:string;
+}
+
+export function buildStandardCabinet({W,H,D,drawers=0,gaps={top:0,bottom:0},drawerFronts=[],family,shelves=1,omitTop=false}:BuildParams):THREE.Group{
+  const T=0.018, backT=0.003
+  const carcMat = new THREE.MeshStandardMaterial({ color:0xf5f5f5, metalness:0.1, roughness:0.8 })
+  const frontMat = new THREE.MeshStandardMaterial({ color:new THREE.Color(FAMILY_COLORS[family]), metalness:0.2, roughness:0.6 })
+  const backMat = new THREE.MeshStandardMaterial({ color:0xf0f0f0, metalness:0.05, roughness:0.9 })
+  const group = new THREE.Group()
+  // sides
+  const sideGeo = new THREE.BoxGeometry(T,H,D)
+  const left = new THREE.Mesh(sideGeo,carcMat); left.position.set(T/2,H/2,-D/2); group.add(left)
+  const right = new THREE.Mesh(sideGeo,carcMat); right.position.set(W-T/2,H/2,-D/2); group.add(right)
+  // top/bottom
+  const horizGeo = new THREE.BoxGeometry(W,T,D)
+  const bottom = new THREE.Mesh(horizGeo,carcMat); bottom.position.set(W/2,T/2,-D/2); group.add(bottom)
+  if(!omitTop){ const top = new THREE.Mesh(horizGeo,carcMat); top.position.set(W/2,H-T/2,-D/2); group.add(top) }
+  // back
+  const back = new THREE.Mesh(new THREE.BoxGeometry(W,H,backT), backMat); back.position.set(W/2,H/2,-D+backT/2); group.add(back)
+  // shelves
+  if(drawers===0){
+    const shelfGeo = new THREE.BoxGeometry(W-2*T,T,D)
+    const cnt = Math.max(0,shelves||0)
+    for(let i=0;i<cnt;i++){ const shelf = new THREE.Mesh(shelfGeo,carcMat); const y=H*(i+1)/(cnt+1); shelf.position.set(W/2,y,-D/2); group.add(shelf) }
+  }
+  // front
+  if(drawers>0){
+    const total = Math.max(0,H - (gaps.top+gaps.bottom)/1000)
+    const arr = (drawerFronts && drawerFronts.length===drawers) ? drawerFronts.map(v=>v/1000) : Array.from({length:drawers},()=> total/drawers)
+    let y = (gaps.bottom||0)/1000
+    arr.forEach(h=>{ const fg=new THREE.BoxGeometry(W,h,T); const fm=new THREE.Mesh(fg,frontMat); fm.position.set(W/2,y+h/2,-T/2); group.add(fm); y+=h })
+  }else{
+    const door = new THREE.Mesh(new THREE.BoxGeometry(W,H,T), frontMat)
+    door.position.set(W/2,H/2,-T/2)
+    group.add(door)
+  }
+  // legs
+  if(family===FAMILY.BASE || family===FAMILY.TALL){
+    const r=0.02, h=0.04
+    const geo = new THREE.CylinderGeometry(r,r,h,16)
+    const mat = new THREE.MeshStandardMaterial({ color:0x444444, metalness:0.3, roughness:0.7 })
+    const fl=new THREE.Mesh(geo,mat); fl.position.set(T+r,-h/2,-T); group.add(fl)
+    const fr=new THREE.Mesh(geo,mat); fr.position.set(W-T-r,-h/2,-T); group.add(fr)
+    const bl=new THREE.Mesh(geo,mat); bl.position.set(T+r,-h/2,-D+T); group.add(bl)
+    const br=new THREE.Mesh(geo,mat); br.position.set(W-T-r,-h/2,-D+T); group.add(br)
+  }
+  return group
+}
+
+export function buildSinkCabinet(p:BuildParams){ return buildStandardCabinet({ ...p, omitTop:true }) }
+export function buildCargoCabinet(p:BuildParams){ return buildStandardCabinet(p) }
+export function buildApplianceCabinet(p:BuildParams){
+  const g = buildStandardCabinet(p)
+  const box = new THREE.Mesh(new THREE.BoxGeometry(p.W*0.8, p.H*0.5, p.D*0.9), new THREE.MeshStandardMaterial({ color:0x888888, metalness:0.2, roughness:0.6 }))
+  box.position.set(p.W/2, p.H*0.3, -p.D*0.45)
+  g.add(box)
+  return g
+}
+export function buildCornerCabinet({W,H,D,family}: {W:number;H:number;D:number;family:FAMILY}):THREE.Group{
+  const T=0.018
+  const carcMat = new THREE.MeshStandardMaterial({ color:0xf5f5f5, metalness:0.1, roughness:0.8 })
+  const group = new THREE.Group()
+  const a = new THREE.Mesh(new THREE.BoxGeometry(W,H,D/2),carcMat); a.position.set(W/2,H/2,-D/4); group.add(a)
+  const b = new THREE.Mesh(new THREE.BoxGeometry(W/2,H,D),carcMat); b.position.set(W/4,H/2,-D/2); group.add(b)
+  if(family===FAMILY.BASE || family===FAMILY.TALL){
+    const r=0.02, h=0.04, mat=new THREE.MeshStandardMaterial({color:0x444444,metalness:0.3,roughness:0.7})
+    const geo=new THREE.CylinderGeometry(r,r,h,16)
+    const fl=new THREE.Mesh(geo,mat); fl.position.set(T+r,-h/2,-T); group.add(fl)
+    const fr=new THREE.Mesh(geo,mat); fr.position.set(W-T-r,-h/2,-T); group.add(fr)
+    const bl=new THREE.Mesh(geo,mat); bl.position.set(T+r,-h/2,-D+T); group.add(bl)
+    const br=new THREE.Mesh(geo,mat); br.position.set(W-T-r,-h/2,-D+T); group.add(br)
+  }
+  return group
+}

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -41,7 +41,7 @@ const persisted = (()=>{
 })()
 
 type Module3D = {
-  id:string; label:string; family:FAMILY; kind:string;
+  id:string; label:string; family:FAMILY; kind:string; variant?:string;
   size:{ w:number; h:number; d:number }; position:[number,number,number]; rotationY?:number;
   price?: any; fittings?: any
   segIndex?: number | null

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -16,6 +16,8 @@ import CabinetsPhase8Tab from './panels/CabinetsPhase8Tab'
 import BoxPreview from './components/BoxPreview'
 import TechDrawing from './components/TechDrawing'
 import Cabinet3D from './components/Cabinet3D'
+import { CornerForm, SinkForm, CargoForm, ApplianceForm } from './components/VariantForms'
+import { buildCornerCabinet, buildSinkCabinet, buildCargoCabinet, buildApplianceCabinet } from '../scene/cabinetBuilders'
 import SingleMMInput from './components/SingleMMInput'
 
 export default function App(){
@@ -79,7 +81,7 @@ export default function App(){
    * door is rendered.  Gaps are taken from adv.gaps when computing
    * drawer heights.
    */
-  const createCabinetMesh = (mod: any) => {
+  const createStdCabinetMesh = (mod: any) => {
     const W = mod.size.w
     const H = mod.size.h
     const D = mod.size.d
@@ -315,6 +317,14 @@ export default function App(){
       group.add(br)
     }
     return group
+  }
+
+  const createCabinetMesh = (mod:any) => {
+    if(mod.kind==='corner') return buildCornerCabinet({W:mod.size.w,H:mod.size.h,D:mod.size.d,family:mod.family})
+    if(mod.kind==='sink') return buildSinkCabinet({W:mod.size.w,H:mod.size.h,D:mod.size.d, drawers:0, gaps:mod.adv?.gaps||{top:0,bottom:0}, family:mod.family, shelves:mod.adv?.shelves})
+    if(mod.kind==='cargo') return buildCargoCabinet({W:mod.size.w,H:mod.size.h,D:mod.size.d, drawers:0, gaps:mod.adv?.gaps||{top:0,bottom:0}, family:mod.family, shelves:mod.adv?.shelves})
+    if(mod.kind==='appliance') return buildApplianceCabinet({W:mod.size.w,H:mod.size.h,D:mod.size.d, drawers:0, gaps:mod.adv?.gaps||{top:0,bottom:0}, family:mod.family, shelves:mod.adv?.shelves, variantKey:mod.variant})
+    return createStdCabinetMesh(mod)
   }
 
   const drawScene = () => {
@@ -575,6 +585,7 @@ export default function App(){
       label: variant.label,
       family,
       kind: kind.key,
+      variant: variant.key,
       size: { w, h, d },
       position: snap.pos,
       rotationY: snap.rot,
@@ -713,6 +724,10 @@ export default function App(){
                         <button className="btn" onClick={()=>onAdd(widthMM, gLocal)}>Wstaw szafkę</button>
                       </div>
                     </div>
+                    {kind?.key==='corner' && <CornerForm />}
+                    {kind?.key==='sink' && <SinkForm />}
+                    {kind?.key==='cargo' && <CargoForm />}
+                    {kind?.key==='appliance' && <ApplianceForm variant={variant?.label||''} />}
                     <div style={{marginTop:8}}>
                       <TechDrawing
                         mode="view"
@@ -728,10 +743,10 @@ export default function App(){
                       />
                     </div>
                     <div className="row" style={{marginTop:8}}>
-                      <Cabinet3D family={family} widthMM={widthMM} heightMM={gLocal.height} depthMM={gLocal.depth} drawers={variant?.key?.startsWith('s') ? Number(variant.key.slice(1)) : (variant?.key?.includes('+drawer') ? 1 : 0)} gaps={{top:gLocal.gaps.top, bottom:gLocal.gaps.bottom}} drawerFronts={gLocal.drawerFronts} shelves={gLocal.shelves} />
+                      <Cabinet3D family={family} kindKey={kind?.key||''} variantKey={variant?.key||''} widthMM={widthMM} heightMM={gLocal.height} depthMM={gLocal.depth} drawers={variant?.key?.startsWith('s') ? Number(variant.key.slice(1)) : (variant?.key?.includes('+drawer') ? 1 : 0)} gaps={{top:gLocal.gaps.top, bottom:gLocal.gaps.bottom}} drawerFronts={gLocal.drawerFronts} shelves={gLocal.shelves} />
                     </div>
                     <div className="row" style={{marginTop:8}}>
-                      <Cabinet3D family={family} widthMM={widthMM} heightMM={gLocal.height} depthMM={gLocal.depth} drawers={variant?.key?.startsWith('s') ? Number(variant.key.slice(1)) : (variant?.key?.includes('+drawer') ? 1 : 0)} gaps={{top:gLocal.gaps.top, bottom:gLocal.gaps.bottom}} drawerFronts={gLocal.drawerFronts} shelves={gLocal.shelves} />
+                      <Cabinet3D family={family} kindKey={kind?.key||''} variantKey={variant?.key||''} widthMM={widthMM} heightMM={gLocal.height} depthMM={gLocal.depth} drawers={variant?.key?.startsWith('s') ? Number(variant.key.slice(1)) : (variant?.key?.includes('+drawer') ? 1 : 0)} gaps={{top:gLocal.gaps.top, bottom:gLocal.gaps.bottom}} drawerFronts={gLocal.drawerFronts} shelves={gLocal.shelves} />
                     </div>
                   </div>
                 )}
@@ -767,10 +782,10 @@ export default function App(){
                       />
                     </div>
                     <div className="row" style={{marginTop:8}}>
-                      <Cabinet3D family={family} widthMM={widthMM} heightMM={gLocal.height} depthMM={gLocal.depth} drawers={variant?.key?.startsWith('s') ? Number(variant.key.slice(1)) : (variant?.key?.includes('+drawer') ? 1 : 0)} gaps={{top:gLocal.gaps.top, bottom:gLocal.gaps.bottom}} drawerFronts={gLocal.drawerFronts} shelves={gLocal.shelves} />
+                      <Cabinet3D family={family} kindKey={kind?.key||''} variantKey={variant?.key||''} widthMM={widthMM} heightMM={gLocal.height} depthMM={gLocal.depth} drawers={variant?.key?.startsWith('s') ? Number(variant.key.slice(1)) : (variant?.key?.includes('+drawer') ? 1 : 0)} gaps={{top:gLocal.gaps.top, bottom:gLocal.gaps.bottom}} drawerFronts={gLocal.drawerFronts} shelves={gLocal.shelves} />
                     </div>
                     <div className="row" style={{marginTop:8}}>
-                      <Cabinet3D family={family} widthMM={widthMM} heightMM={gLocal.height} depthMM={gLocal.depth} drawers={variant?.key?.startsWith('s') ? Number(variant.key.slice(1)) : (variant?.key?.includes('+drawer') ? 1 : 0)} gaps={{top:gLocal.gaps.top, bottom:gLocal.gaps.bottom}} drawerFronts={gLocal.drawerFronts} shelves={gLocal.shelves} />
+                      <Cabinet3D family={family} kindKey={kind?.key||''} variantKey={variant?.key||''} widthMM={widthMM} heightMM={gLocal.height} depthMM={gLocal.depth} drawers={variant?.key?.startsWith('s') ? Number(variant.key.slice(1)) : (variant?.key?.includes('+drawer') ? 1 : 0)} gaps={{top:gLocal.gaps.top, bottom:gLocal.gaps.bottom}} drawerFronts={gLocal.drawerFronts} shelves={gLocal.shelves} />
                     </div>
                     <div className="row" style={{marginTop:8}}>
                       <button className="btn" onClick={()=>onAdd(widthMM, gLocal)}>Wstaw szafkę</button>

--- a/src/ui/components/Cabinet3D.tsx
+++ b/src/ui/components/Cabinet3D.tsx
@@ -1,151 +1,30 @@
 import React, { useEffect, useRef } from 'react'
 import * as THREE from 'three'
-import { FAMILY, FAMILY_COLORS } from '../../core/catalog'
+import { FAMILY } from '../../core/catalog'
+import { buildStandardCabinet, buildCornerCabinet, buildSinkCabinet, buildCargoCabinet, buildApplianceCabinet } from '../../scene/cabinetBuilders'
 
-export default function Cabinet3D({ widthMM, heightMM, depthMM, drawers, gaps, drawerFronts, family, shelves=1 }:{ widthMM:number;heightMM:number;depthMM:number;drawers:number;gaps:{top:number;bottom:number};drawerFronts?:number[];family:FAMILY; shelves?:number }){
+export default function Cabinet3D({ widthMM, heightMM, depthMM, drawers, gaps, drawerFronts, family, shelves=1, kindKey='doors', variantKey='' }:{ widthMM:number;heightMM:number;depthMM:number;drawers:number;gaps:{top:number;bottom:number};drawerFronts?:number[];family:FAMILY; shelves?:number; kindKey?:string; variantKey?:string }){
   const ref = useRef<HTMLDivElement>(null)
   useEffect(()=>{
-    // Wait until our container is available
-    if (!ref.current) return
-    const w = 260, h = 190
-    // Create renderer
-    const renderer = new THREE.WebGLRenderer({ antialias:true })
+    if(!ref.current) return
+    const w=260,h=190
+    const renderer = new THREE.WebGLRenderer({antialias:true})
     renderer.setSize(w,h)
-    // Replace any previous canvas
     ref.current.innerHTML=''
     ref.current.appendChild(renderer.domElement)
-    // Scene setup
-    const scene = new THREE.Scene()
-    scene.background = new THREE.Color(0xffffff)
-    // Camera setup: position slightly above and to the side to reveal depth
-    const camera = new THREE.PerspectiveCamera(35, w/h, 0.01, 100)
-    camera.position.set(0.9, 0.7, 1.3)
-    camera.lookAt(0, 0.4, -0.2)
-    // Lighting: directional and ambient for soft shadows
-    const dirLight = new THREE.DirectionalLight(0xffffff, 0.9)
-    dirLight.position.set(2, 3, 2)
-    scene.add(dirLight)
-    scene.add(new THREE.AmbientLight(0xffffff, 0.5))
-    // Convert millimetres to metres
-    const W = widthMM / 1000
-    const H = heightMM / 1000
-    const D = depthMM / 1000
-    // Board thickness (18 mm) and back thickness (3 mm)
-    const T = 0.018
-    const backT = 0.003
-    // Colour palette: carcase (light grey), front (warm wood), back (very light)
-    const carcColour = new THREE.Color(0xf5f5f5)
-    const frontColour = new THREE.Color(FAMILY_COLORS[family])
-    const backColour = new THREE.Color(0xf0f0f0)
-    // Materials
-    const carcMat = new THREE.MeshStandardMaterial({ color: carcColour, metalness:0.1, roughness:0.8 })
-    const frontMat = new THREE.MeshStandardMaterial({ color: frontColour, metalness:0.2, roughness:0.6 })
-    const backMat = new THREE.MeshStandardMaterial({ color: backColour, metalness:0.05, roughness:0.9 })
-    // Group to hold cabinet parts
-    const cabGroup = new THREE.Group()
-    scene.add(cabGroup)
-    // Build carcase: sides
-    // Left side
-    const leftSideGeo = new THREE.BoxGeometry(T, H, D)
-    const leftSide = new THREE.Mesh(leftSideGeo, carcMat)
-    leftSide.position.set(T / 2, H / 2, -D / 2)
-    cabGroup.add(leftSide)
-    // Right side
-    const rightSide = new THREE.Mesh(leftSideGeo.clone(), carcMat)
-    rightSide.position.set(W - T / 2, H / 2, -D / 2)
-    cabGroup.add(rightSide)
-    // Top and bottom
-    const horizGeo = new THREE.BoxGeometry(W, T, D)
-    const bottomBoard = new THREE.Mesh(horizGeo, carcMat)
-    bottomBoard.position.set(W / 2, T / 2, -D / 2)
-    cabGroup.add(bottomBoard)
-    const topBoard = new THREE.Mesh(horizGeo.clone(), carcMat)
-    topBoard.position.set(W / 2, H - T / 2, -D / 2)
-    cabGroup.add(topBoard)
-    // Back board
-    const backGeo = new THREE.BoxGeometry(W, H, backT)
-    const backBoard = new THREE.Mesh(backGeo, backMat)
-    backBoard.position.set(W / 2, H / 2, -D + backT / 2)
-    cabGroup.add(backBoard)
-    // Shelves: simple horizontal boards (if drawers = 0) else skip
-    if (drawers === 0) {
-      const shelfGeo = new THREE.BoxGeometry(W - 2 * T, T, D)
-      const count = Math.max(0, shelves)
-      for (let i = 0; i < count; i++) {
-        const shelf = new THREE.Mesh(shelfGeo, carcMat)
-        const y = H * (i + 1) / (count + 1)
-        shelf.position.set(W / 2, y, -D / 2)
-        cabGroup.add(shelf)
-      }
-    }
-    // Front: if drawers > 0, split into drawer fronts; otherwise full door
-    if (drawers > 0) {
-      // Determine heights of drawer fronts
-      const totalFrontHeight = Math.max(50, Math.round(heightMM - (gaps.top + gaps.bottom)))
-      const arr = drawerFronts && drawerFronts.length === drawers ? drawerFronts : Array.from({ length: drawers }, () => Math.floor(totalFrontHeight / drawers))
-      // Start stacking fronts from the bottom gap (convert mm to m)
-      let currentY = gaps.bottom / 1000
-      for (let i = 0; i < drawers; i++) {
-        const h = arr[i] / 1000
-        const frontGeo = new THREE.BoxGeometry(W, h, T)
-        const frontMesh = new THREE.Mesh(frontGeo, frontMat)
-        // Position each drawer front; note: y is bottom of front + h/2
-        frontMesh.position.set(W / 2, currentY + h / 2, -T / 2)
-        cabGroup.add(frontMesh)
-        // Add handle for each drawer: small dark box centered horizontally
-        const handleWidth = Math.min(0.4, W * 0.5)
-        const handleHeight = 0.02
-        const handleDepth = 0.03
-        const handleGeo = new THREE.BoxGeometry(handleWidth, handleHeight, handleDepth)
-        const handleMat = new THREE.MeshStandardMaterial({ color: 0x333333, metalness:0.8, roughness:0.4 })
-        const handleMesh = new THREE.Mesh(handleGeo, handleMat)
-        // Position handle near top of drawer front
-        handleMesh.position.set(W / 2, currentY + h - handleHeight * 1.5, 0.01)
-        cabGroup.add(handleMesh)
-        // Move up by this front's height for the next drawer
-        currentY += h
-      }
-    } else {
-      // Single door
-      const doorGeo = new THREE.BoxGeometry(W, H, T)
-      const door = new THREE.Mesh(doorGeo, frontMat)
-      door.position.set(W / 2, H / 2, -T / 2)
-      cabGroup.add(door)
-      // Handle: horizontal bar
-      const handleWidth = Math.min(0.4, W * 0.5)
-      const handleHeight = 0.02
-      const handleDepth = 0.03
-      const handleGeo = new THREE.BoxGeometry(handleWidth, handleHeight, handleDepth)
-      const handleMat = new THREE.MeshStandardMaterial({ color: 0x333333, metalness:0.8, roughness:0.4 })
-      const handle = new THREE.Mesh(handleGeo, handleMat)
-      handle.position.set(W / 2, H * 0.7, 0.01)
-      cabGroup.add(handle)
-    }
-    // Legs: only for base and tall cabinets
-    if (family === FAMILY.BASE || family === FAMILY.TALL) {
-      const footRadius = 0.02
-      const footHeight = 0.04
-      const footGeo = new THREE.CylinderGeometry(footRadius, footRadius, footHeight, 16)
-      const footMat = new THREE.MeshStandardMaterial({ color: 0x444444, metalness:0.3, roughness:0.7 })
-      const fl = new THREE.Mesh(footGeo, footMat)
-      fl.position.set(T + footRadius, -footHeight / 2, -T)
-      cabGroup.add(fl)
-      const fr = new THREE.Mesh(footGeo.clone(), footMat)
-      fr.position.set(W - T - footRadius, -footHeight / 2, -T)
-      cabGroup.add(fr)
-      const bl = new THREE.Mesh(footGeo.clone(), footMat)
-      bl.position.set(T + footRadius, -footHeight / 2, -D + T)
-      cabGroup.add(bl)
-      const br = new THREE.Mesh(footGeo.clone(), footMat)
-      br.position.set(W - T - footRadius, -footHeight / 2, -D + T)
-      cabGroup.add(br)
-    }
-    // Render once
-    renderer.render(scene, camera)
-    // Clean up on unmount
-    return () => {
-      renderer.dispose()
-    }
-  }, [widthMM, heightMM, depthMM, drawers, gaps, drawerFronts, family, shelves])
-  return <div ref={ref} style={{ width: 260, height: 190, border: '1px solid #E5E7EB', borderRadius: 8, background: '#fff' }} />
+    const scene = new THREE.Scene(); scene.background=new THREE.Color(0xffffff)
+    const camera = new THREE.PerspectiveCamera(35,w/h,0.01,100); camera.position.set(0.9,0.7,1.3); camera.lookAt(0,0.4,-0.2)
+    const dirLight=new THREE.DirectionalLight(0xffffff,0.9); dirLight.position.set(2,3,2); scene.add(dirLight); scene.add(new THREE.AmbientLight(0xffffff,0.5))
+    const params = { W:widthMM/1000, H:heightMM/1000, D:depthMM/1000, drawers, gaps, drawerFronts, family, shelves, variantKey }
+    let group:THREE.Group
+    if(kindKey==='corner') group=buildCornerCabinet({W:params.W,H:params.H,D:params.D,family})
+    else if(kindKey==='sink') group=buildSinkCabinet(params)
+    else if(kindKey==='cargo') group=buildCargoCabinet(params)
+    else if(kindKey==='appliance') group=buildApplianceCabinet({...params, variantKey})
+    else group=buildStandardCabinet(params)
+    scene.add(group)
+    renderer.render(scene,camera)
+    return ()=>{ renderer.dispose() }
+  }, [widthMM,heightMM,depthMM,drawers,gaps,drawerFronts,family,shelves,kindKey,variantKey])
+  return <div ref={ref} style={{ width:260, height:190, border:'1px solid #E5E7EB', borderRadius:8, background:'#fff' }} />
 }

--- a/src/ui/components/VariantForms.tsx
+++ b/src/ui/components/VariantForms.tsx
@@ -1,0 +1,17 @@
+import React from 'react'
+
+export const CornerForm = () => (
+  <div className="small">Szafka narożna posiada kształt litery L.</div>
+)
+
+export const SinkForm = () => (
+  <div className="small">Szafka zlewozmywakowa bez górnego wieńca.</div>
+)
+
+export const CargoForm = () => (
+  <div className="small">Szafka cargo z wysuwanym koszem.</div>
+)
+
+export const ApplianceForm = ({variant}:{variant:string}) => (
+  <div className="small">Szafka pod urządzenie: {variant}</div>
+)


### PR DESCRIPTION
## Summary
- add catalog entries for corner, sink, cargo, and appliance cabinets
- support new cabinet types with geometry builders and UI forms
- update pricing and state to handle new variants

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b157ec5b8c8322a49d3ff60a3efc1c