### PR TITLE
feat: add specialized cabinet modules

### DIFF
--- a/src/core/builders.ts
+++ b/src/core/builders.ts
@@ -1,0 +1,63 @@
+import * as THREE from 'three'
+
+export interface BuilderOpts {
+  width: number // in millimetres
+  height: number // in millimetres
+  depth: number // in millimetres
+  adv?: any
+  hardware?: any
+}
+
+/**
+ * Build a very simple rectangular cabinet carcass.  This helper is used by
+ * specialised cabinet builders and keeps geometry creation in one place.
+ */
+export function buildBasicCabinet({ width, height, depth }: BuilderOpts): THREE.Group {
+  const group = new THREE.Group()
+  const geo = new THREE.BoxGeometry(width / 1000, height / 1000, depth / 1000)
+  const mat = new THREE.MeshStandardMaterial({ color: 0xcccccc })
+  const mesh = new THREE.Mesh(geo, mat)
+  mesh.position.set(width / 2000, height / 2000, -depth / 2000)
+  group.add(mesh)
+  return group
+}
+
+/**
+ * Corner cabinet – currently just a basic box but tagged for future
+ * enhancements like angled fronts.
+ */
+export function buildCornerCabinet(opts: BuilderOpts): THREE.Group {
+  const g = buildBasicCabinet(opts)
+  g.userData.type = 'corner'
+  return g
+}
+
+/**
+ * Sink cabinet – placeholder implementation without cutouts.  Keeping the
+ * builder separate allows UI and hardware options to reference this type.
+ */
+export function buildSinkCabinet(opts: BuilderOpts): THREE.Group {
+  const g = buildBasicCabinet(opts)
+  g.userData.type = 'sink'
+  return g
+}
+
+/**
+ * Cargo cabinet – typically tall and narrow with baskets.  For now it shares
+ * the basic box geometry.
+ */
+export function buildCargoCabinet(opts: BuilderOpts): THREE.Group {
+  const g = buildBasicCabinet(opts)
+  g.userData.type = 'cargo'
+  return g
+}
+
+/**
+ * Appliance cabinet – used for oven stacks or built‑in fridges.  Geometry is a
+ * simple box; specific appliance cut‑outs can be added later.
+ */
+export function buildApplianceCabinet(opts: BuilderOpts): THREE.Group {
+  const g = buildBasicCabinet(opts)
+  g.userData.type = 'appliance'
+  return g
+}

--- a/src/core/catalog.ts
+++ b/src/core/catalog.ts
@@ -9,38 +9,78 @@ export type Variant = { key:string; label:string }
 export type Kind = { key:string; label:string; variants: Variant[] }
 export const KIND_SETS: Record<FAMILY, Kind[]> = {
   [FAMILY.BASE]: [
-    { key:'doors', label:'Drzwiczki', variants:[
-      { key:'d1', label:'1 drzwiczki' },
-      { key:'d2', label:'2 drzwiczki' },
-      { key:'d1+drawer', label:'1 drzwiczki + szuflada' },
-      { key:'d2+drawer', label:'2 drzwiczki + szuflada' },
-      { key:'sink', label:'Zlewowa' },
-      { key:'hob', label:'Pod płytę' }
-    ]},
-    { key:'drawers', label:'Szuflady', variants:[
-      { key:'s1', label:'1 szuflada' },
-      { key:'s2', label:'2 szuflady' },
-      { key:'s3', label:'3 szuflady' },
-      { key:'s4', label:'4 szuflady' }
-    ]},
-    { key:'corner', label:'Narożne', variants:[
-      { key:'blind-L', label:'Ślepa L' },
-      { key:'blind-R', label:'Ślepa P' }
-    ]},
-    { key:'cargo', label:'Cargo dolne', variants:[
-      { key:'cargo150', label:'Cargo 150' },
-      { key:'cargo200', label:'Cargo 200' },
-      { key:'cargo300', label:'Cargo 300' }
-    ]}
+    {
+      key:'doors',
+      label:'Drzwiczki',
+      variants:[
+        { key:'d1', label:'1 drzwiczki' },
+        { key:'d2', label:'2 drzwiczki' },
+        { key:'d1+drawer', label:'1 drzwiczki + szuflada' },
+        { key:'d2+drawer', label:'2 drzwiczki + szuflada' }
+      ]
+    },
+    {
+      key:'drawers',
+      label:'Szuflady',
+      variants:[
+        { key:'s1', label:'1 szuflada' },
+        { key:'s2', label:'2 szuflady' },
+        { key:'s3', label:'3 szuflady' },
+        { key:'s4', label:'4 szuflady' }
+      ]
+    },
+    {
+      key:'corner',
+      label:'Narożne',
+      variants:[
+        { key:'blind-L', label:'Ślepa L' },
+        { key:'blind-R', label:'Ślepa P' }
+      ]
+    },
+    {
+      key:'sink',
+      label:'Zlewy',
+      variants:[
+        { key:'sink1', label:'1 komora' },
+        { key:'sink2', label:'2 komory' }
+      ]
+    },
+    {
+      key:'cargo',
+      label:'Cargo dolne',
+      variants:[
+        { key:'cargo150', label:'Cargo 150' },
+        { key:'cargo200', label:'Cargo 200' },
+        { key:'cargo300', label:'Cargo 300' }
+      ]
+    },
+    {
+      key:'appliance',
+      label:'AGD dolne',
+      variants:[
+        { key:'hob', label:'Pod płytę' },
+        { key:'dishwasher', label:'Zmywarka' }
+      ]
+    }
   ],
   [FAMILY.TALL]: [
-    { key:'tall', label:'Słupki', variants:[
-      { key:'t1', label:'1 drzwi' },
-      { key:'t2', label:'2 drzwi' },
-      { key:'oven', label:'Piekarnik' },
-      { key:'oven+mw', label:'Piekarnik + MW' },
-      { key:'fridge', label:'Lodówka' }
-    ]}
+    {
+      key:'tall',
+      label:'Słupki',
+      variants:[
+        { key:'t1', label:'1 drzwi' },
+        { key:'t2', label:'2 drzwi' }
+      ]
+    },
+    {
+      key:'appliance',
+      label:'AGD',
+      variants:[
+        { key:'oven', label:'Piekarnik' },
+        { key:'oven+mw', label:'Piekarnik + MW' },
+        { key:'fridge', label:'Lodówka' }
+      ]
+    }
   ],
   [FAMILY.WALL]: [
     { key:'doors', label:'Drzwiczki', variants:[

--- a/src/ui/forms/ApplianceCabinetForm.tsx
+++ b/src/ui/forms/ApplianceCabinetForm.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+import SingleMMInput from '../components/SingleMMInput'
+import { CabinetFormValues, CabinetFormProps } from './CornerCabinetForm'
+
+export default function ApplianceCabinetForm({ values, onChange }: CabinetFormProps){
+  const { width, height, depth, adv, hardware } = values
+  const update = (patch: Partial<CabinetFormValues>) => onChange({ ...values, ...patch })
+  return (
+    <div>
+      <SingleMMInput label="Szerokość" value={width} onChange={w=>update({ width:w })} />
+      <SingleMMInput label="Wysokość" value={height} onChange={h=>update({ height:h })} />
+      <SingleMMInput label="Głębokość" value={depth} onChange={d=>update({ depth:d })} />
+      {/* Appliance specific options such as appliance type could be configured elsewhere. */}
+      {adv && <pre style={{ display:'none' }}>{JSON.stringify(adv)}</pre>}
+      {hardware && <pre style={{ display:'none' }}>{JSON.stringify(hardware)}</pre>}
+    </div>
+  )
+}

--- a/src/ui/forms/CargoCabinetForm.tsx
+++ b/src/ui/forms/CargoCabinetForm.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+import SingleMMInput from '../components/SingleMMInput'
+import { CabinetFormValues, CabinetFormProps } from './CornerCabinetForm'
+
+export default function CargoCabinetForm({ values, onChange }: CabinetFormProps){
+  const { width, height, depth, adv, hardware } = values
+  const update = (patch: Partial<CabinetFormValues>) => onChange({ ...values, ...patch })
+  return (
+    <div>
+      <SingleMMInput label="Szerokość" value={width} onChange={w=>update({ width:w })} />
+      <SingleMMInput label="Wysokość" value={height} onChange={h=>update({ height:h })} />
+      <SingleMMInput label="Głębokość" value={depth} onChange={d=>update({ depth:d })} />
+      {/* Cargo specific options such as basket count could be added here. */}
+      {adv && <pre style={{ display:'none' }}>{JSON.stringify(adv)}</pre>}
+      {hardware && <pre style={{ display:'none' }}>{JSON.stringify(hardware)}</pre>}
+    </div>
+  )
+}

--- a/src/ui/forms/CornerCabinetForm.tsx
+++ b/src/ui/forms/CornerCabinetForm.tsx
@@ -1,0 +1,30 @@
+import React from 'react'
+import SingleMMInput from '../components/SingleMMInput'
+
+export interface CabinetFormValues {
+  width: number
+  height: number
+  depth: number
+  adv?: any
+  hardware?: any
+}
+
+export interface CabinetFormProps {
+  values: CabinetFormValues
+  onChange: (vals: CabinetFormValues) => void
+}
+
+export default function CornerCabinetForm({ values, onChange }: CabinetFormProps){
+  const { width, height, depth, adv, hardware } = values
+  const update = (patch: Partial<CabinetFormValues>) => onChange({ ...values, ...patch })
+  return (
+    <div>
+      <SingleMMInput label="Szerokość" value={width} onChange={w=>update({ width:w })} />
+      <SingleMMInput label="Wysokość" value={height} onChange={h=>update({ height:h })} />
+      <SingleMMInput label="Głębokość" value={depth} onChange={d=>update({ depth:d })} />
+      {/* Advanced settings and hardware options are passed through unchanged */}
+      {adv && <pre style={{ display:'none' }}>{JSON.stringify(adv)}</pre>}
+      {hardware && <pre style={{ display:'none' }}>{JSON.stringify(hardware)}</pre>}
+    </div>
+  )
+}

--- a/src/ui/forms/SinkCabinetForm.tsx
+++ b/src/ui/forms/SinkCabinetForm.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+import SingleMMInput from '../components/SingleMMInput'
+import { CabinetFormValues, CabinetFormProps } from './CornerCabinetForm'
+
+export default function SinkCabinetForm({ values, onChange }: CabinetFormProps){
+  const { width, height, depth, adv, hardware } = values
+  const update = (patch: Partial<CabinetFormValues>) => onChange({ ...values, ...patch })
+  return (
+    <div>
+      <SingleMMInput label="Szerokość" value={width} onChange={w=>update({ width:w })} />
+      <SingleMMInput label="Wysokość" value={height} onChange={h=>update({ height:h })} />
+      <SingleMMInput label="Głębokość" value={depth} onChange={d=>update({ depth:d })} />
+      {/* Sink specific advanced settings may include bowl size or position. */}
+      {adv && <pre style={{ display:'none' }}>{JSON.stringify(adv)}</pre>}
+      {hardware && <pre style={{ display:'none' }}>{JSON.stringify(hardware)}</pre>}
+    </div>
+  )
+}

--- a/src/ui/forms/index.ts
+++ b/src/ui/forms/index.ts
@@ -1,0 +1,5 @@
+export { default as CornerCabinetForm } from './CornerCabinetForm'
+export { default as SinkCabinetForm } from './SinkCabinetForm'
+export { default as CargoCabinetForm } from './CargoCabinetForm'
+export { default as ApplianceCabinetForm } from './ApplianceCabinetForm'
+export type { CabinetFormValues, CabinetFormProps } from './CornerCabinetForm'


### PR DESCRIPTION
## Summary
- expand catalog with sink, cargo, corner, and appliance cabinet entries for base and tall families
- add basic geometry builders for corner, sink, cargo, and appliance modules
- implement React forms to configure new cabinet types while passing advanced settings and hardware

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1709b63008322bbca8ae8e3271263