### PR TITLE
feat: add opening mechanism options

### DIFF
--- a/src/core/pricing.ts
+++ b/src/core/pricing.ts
@@ -1,11 +1,11 @@
 import { FAMILY } from './catalog'
 import { usePlannerStore } from '../state/store'
-export type Parts = { board:number; front:number; edging:number; cut:number; hinges:number; slides:number; legs:number; hangers:number; aventos:number; cargo:number; kits:number; labor:number }
+export type Parts = { board:number; front:number; edging:number; cut:number; hinges:number; slides:number; legs:number; hangers:number; aventos:number; cargo:number; kits:number; labor:number; mechanism:number }
 export type Price = { total:number; parts: Parts; counts:any }
 function hingeCountPerDoor(doorHeightMM:number){ if (doorHeightMM<=900) return 2; if (doorHeightMM<=1500) return 3; return 4 }
 export function computeModuleCost(params: {
   family: FAMILY; kind:string; variant:string; width:number;
-  adv: { height:number; depth:number; boardType:string; frontType:string; gaps?: any };
+  adv: { height:number; depth:number; boardType:string; frontType:string; gaps?: any; openingMechanism?: 'standard' | 'TIP-ON' | 'BLUMOTION' };
 }): Price {
   const P = usePlannerStore.getState().prices
   const base = usePlannerStore.getState().globals[params.family]
@@ -39,6 +39,7 @@ export function computeModuleCost(params: {
   const hangersCost = hangersCount * (P.hangers['Standard']||0)
   const aventosCost = aventosType ? (P.aventos[aventosType]||0) : 0
   const cargoCost = cargoW ? (P.cargo[cargoW]||0) : 0
+  const mechanismCost = (P.openingMechanism?.[g.openingMechanism] || 0) * (doors + drawers)
   const boardArea = 2*(h*d)+2*(w*d)+1*(w*d)+0.4*(w*h)
   const boardCost = boardArea*boardPrice
   const frontArea = w*h
@@ -47,7 +48,7 @@ export function computeModuleCost(params: {
   const edgingCost = edgeMeters * (edgingPrice||0)
   const cutCost = (edgeMeters) * (P.cut||4)
   const labor = P.labor||0
-  const parts = { board: Math.round(boardCost), front: Math.round(frontCost), edging: Math.round(edgingCost), cut: Math.round(cutCost), hinges: Math.round(hingesCost), slides: Math.round(slidesCost), legs: Math.round(legsCost), hangers: Math.round(hangersCost), aventos: Math.round(aventosCost), cargo: Math.round(cargoCost), kits: Math.round(kits), labor: Math.round(labor) }
+  const parts = { board: Math.round(boardCost), front: Math.round(frontCost), edging: Math.round(edgingCost), cut: Math.round(cutCost), hinges: Math.round(hingesCost), slides: Math.round(slidesCost), legs: Math.round(legsCost), hangers: Math.round(hangersCost), aventos: Math.round(aventosCost), cargo: Math.round(cargoCost), kits: Math.round(kits), labor: Math.round(labor), mechanism: Math.round(mechanismCost) }
   const subtotal = Object.values(parts).reduce((s,n)=>s+(n||0),0)
   const total = Math.round(subtotal*(1+(P.margin||0)))
   return { total, parts, counts:{ doors, drawers, legs:legsCount, hangers:hangersCount, hinges:hingesPerDoor*doors } }

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -7,13 +7,14 @@ export const defaultGaps: Gaps = { left:2, right:2, top:2, bottom:2, between:3 }
 export type Globals = Record<FAMILY, {
   height:number; depth:number; boardType:string; frontType:string;
   gaps: Gaps; legsType?:string; hangerType?:string; offsetWall?:number; shelves?:number;
+  openingMechanism?: 'standard' | 'TIP-ON' | 'BLUMOTION';
 }>
 
 export const defaultGlobal: Globals = {
-  [FAMILY.BASE]: { height:800, depth:600, boardType:'Płyta 18mm', frontType:'Laminat', gaps:{...defaultGaps}, legsType:'Standard 10cm', offsetWall:30, shelves:1 },
-  [FAMILY.WALL]: { height:720, depth:320, boardType:'Płyta 18mm', frontType:'Laminat', gaps:{...defaultGaps}, hangerType:'Standard', offsetWall:20, shelves:1 },
-  [FAMILY.PAWLACZ]: { height:400, depth:600, boardType:'Płyta 18mm', frontType:'Laminat', gaps:{...defaultGaps}, hangerType:'Wzmocnione', offsetWall:30, shelves:1 },
-  [FAMILY.TALL]: { height:2100, depth:600, boardType:'Płyta 18mm', frontType:'Laminat', gaps:{...defaultGaps}, shelves:4 }
+  [FAMILY.BASE]: { height:800, depth:600, boardType:'Płyta 18mm', frontType:'Laminat', gaps:{...defaultGaps}, legsType:'Standard 10cm', offsetWall:30, shelves:1, openingMechanism:'standard' },
+  [FAMILY.WALL]: { height:720, depth:320, boardType:'Płyta 18mm', frontType:'Laminat', gaps:{...defaultGaps}, hangerType:'Standard', offsetWall:20, shelves:1, openingMechanism:'standard' },
+  [FAMILY.PAWLACZ]: { height:400, depth:600, boardType:'Płyta 18mm', frontType:'Laminat', gaps:{...defaultGaps}, hangerType:'Wzmocnione', offsetWall:30, shelves:1, openingMechanism:'standard' },
+  [FAMILY.TALL]: { height:2100, depth:600, boardType:'Płyta 18mm', frontType:'Laminat', gaps:{...defaultGaps}, shelves:4, openingMechanism:'standard' }
 }
 
 export const defaultPrices = {
@@ -32,6 +33,7 @@ export const defaultPrices = {
   dwKit: 90,
   fridgeKit: 120,
   handle: { 'Brak': 0, 'Uchwyt T': 8 },
+  openingMechanism: { 'standard': 0, 'TIP-ON': 15, 'BLUMOTION': 25 },
   labor: 0,
   margin: 0.15
 }
@@ -45,7 +47,7 @@ type Module3D = {
   size:{ w:number; h:number; d:number }; position:[number,number,number]; rotationY?:number;
   price?: any; fittings?: any
   segIndex?: number | null
-  adv?: { height?:number; depth?:number; boardType?:string; frontType?:string; gaps?: Gaps; drawerFronts?: number[]; shelves?:number }
+  adv?: { height?:number; depth?:number; boardType?:string; frontType?:string; gaps?: Gaps; drawerFronts?: number[]; shelves?:number; openingMechanism?: 'standard' | 'TIP-ON' | 'BLUMOTION' }
     /**
      * Array of booleans indicating whether each front on this module is open.
      * A single-element array corresponds to a single door; multiple elements
@@ -101,6 +103,7 @@ export const usePlannerStore = create<Store>((set,get)=>({
       if (patch.frontType !== undefined) newAdv.frontType = patch.frontType
       if (patch.gaps !== undefined) newAdv.gaps = { ...(m.adv?.gaps||{}), ...patch.gaps }
       if (patch.shelves !== undefined) newAdv.shelves = patch.shelves
+      if (patch.openingMechanism !== undefined) newAdv.openingMechanism = patch.openingMechanism
       const newSize = { ...m.size }
       if (patch.height !== undefined) newSize.h = patch.height/1000
       if (patch.depth !== undefined) newSize.d = patch.depth/1000

--- a/src/ui/components/Cabinet3D.tsx
+++ b/src/ui/components/Cabinet3D.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef } from 'react'
 import * as THREE from 'three'
 import { FAMILY, FAMILY_COLORS } from '../../core/catalog'
 
-export default function Cabinet3D({ widthMM, heightMM, depthMM, drawers, gaps, drawerFronts, family, shelves=1 }:{ widthMM:number;heightMM:number;depthMM:number;drawers:number;gaps:{top:number;bottom:number};drawerFronts?:number[];family:FAMILY; shelves?:number }){
+export default function Cabinet3D({ widthMM, heightMM, depthMM, drawers, gaps, drawerFronts, family, shelves=1, openingMechanism='standard' }:{ widthMM:number;heightMM:number;depthMM:number;drawers:number;gaps:{top:number;bottom:number};drawerFronts?:number[];family:FAMILY; shelves?:number; openingMechanism?:'standard'|'TIP-ON'|'BLUMOTION' }){
   const ref = useRef<HTMLDivElement>(null)
   useEffect(()=>{
     // Wait until our container is available
@@ -78,6 +78,7 @@ export default function Cabinet3D({ widthMM, heightMM, depthMM, drawers, gaps, d
         cabGroup.add(shelf)
       }
     }
+    const showHandle = openingMechanism !== 'TIP-ON'
     // Front: if drawers > 0, split into drawer fronts; otherwise full door
     if (drawers > 0) {
       // Determine heights of drawer fronts
@@ -92,16 +93,18 @@ export default function Cabinet3D({ widthMM, heightMM, depthMM, drawers, gaps, d
         // Position each drawer front; note: y is bottom of front + h/2
         frontMesh.position.set(W / 2, currentY + h / 2, -T / 2)
         cabGroup.add(frontMesh)
-        // Add handle for each drawer: small dark box centered horizontally
-        const handleWidth = Math.min(0.4, W * 0.5)
-        const handleHeight = 0.02
-        const handleDepth = 0.03
-        const handleGeo = new THREE.BoxGeometry(handleWidth, handleHeight, handleDepth)
-        const handleMat = new THREE.MeshStandardMaterial({ color: 0x333333, metalness:0.8, roughness:0.4 })
-        const handleMesh = new THREE.Mesh(handleGeo, handleMat)
-        // Position handle near top of drawer front
-        handleMesh.position.set(W / 2, currentY + h - handleHeight * 1.5, 0.01)
-        cabGroup.add(handleMesh)
+        if (showHandle) {
+          // Add handle for each drawer: small dark box centered horizontally
+          const handleWidth = Math.min(0.4, W * 0.5)
+          const handleHeight = 0.02
+          const handleDepth = 0.03
+          const handleGeo = new THREE.BoxGeometry(handleWidth, handleHeight, handleDepth)
+          const handleMat = new THREE.MeshStandardMaterial({ color: 0x333333, metalness:0.8, roughness:0.4 })
+          const handleMesh = new THREE.Mesh(handleGeo, handleMat)
+          // Position handle near top of drawer front
+          handleMesh.position.set(W / 2, currentY + h - handleHeight * 1.5, 0.01)
+          cabGroup.add(handleMesh)
+        }
         // Move up by this front's height for the next drawer
         currentY += h
       }
@@ -111,15 +114,25 @@ export default function Cabinet3D({ widthMM, heightMM, depthMM, drawers, gaps, d
       const door = new THREE.Mesh(doorGeo, frontMat)
       door.position.set(W / 2, H / 2, -T / 2)
       cabGroup.add(door)
-      // Handle: horizontal bar
-      const handleWidth = Math.min(0.4, W * 0.5)
-      const handleHeight = 0.02
-      const handleDepth = 0.03
-      const handleGeo = new THREE.BoxGeometry(handleWidth, handleHeight, handleDepth)
-      const handleMat = new THREE.MeshStandardMaterial({ color: 0x333333, metalness:0.8, roughness:0.4 })
-      const handle = new THREE.Mesh(handleGeo, handleMat)
-      handle.position.set(W / 2, H * 0.7, 0.01)
-      cabGroup.add(handle)
+      if (showHandle) {
+        // Handle: horizontal bar
+        const handleWidth = Math.min(0.4, W * 0.5)
+        const handleHeight = 0.02
+        const handleDepth = 0.03
+        const handleGeo = new THREE.BoxGeometry(handleWidth, handleHeight, handleDepth)
+        const handleMat = new THREE.MeshStandardMaterial({ color: 0x333333, metalness:0.8, roughness:0.4 })
+        const handle = new THREE.Mesh(handleGeo, handleMat)
+        handle.position.set(W / 2, H * 0.7, 0.01)
+        cabGroup.add(handle)
+      }
+      if (openingMechanism === 'BLUMOTION') {
+        const hingeGeo = new THREE.CylinderGeometry(0.01, 0.01, 0.02, 8)
+        const hingeMat = new THREE.MeshStandardMaterial({ color: 0x0000ff, metalness:0.4, roughness:0.6 })
+        const hinge = new THREE.Mesh(hingeGeo, hingeMat)
+        hinge.rotation.z = Math.PI / 2
+        hinge.position.set(T / 2, H / 2, -T / 2)
+        cabGroup.add(hinge)
+      }
     }
     // Legs: only for base and tall cabinets
     if (family === FAMILY.BASE || family === FAMILY.TALL) {
@@ -146,6 +159,6 @@ export default function Cabinet3D({ widthMM, heightMM, depthMM, drawers, gaps, d
     return () => {
       renderer.dispose()
     }
-  }, [widthMM, heightMM, depthMM, drawers, gaps, drawerFronts, family, shelves])
+  }, [widthMM, heightMM, depthMM, drawers, gaps, drawerFronts, family, shelves, openingMechanism])
   return <div ref={ref} style={{ width: 260, height: 190, border: '1px solid #E5E7EB', borderRadius: 8, background: '#fff' }} />
 }

--- a/src/ui/panels/GlobalSettings.tsx
+++ b/src/ui/panels/GlobalSettings.tsx
@@ -35,6 +35,7 @@ export default function GlobalSettings(){
             <Field label="Głębokość (mm)" value={g.depth} onChange={(v)=>set({depth:v})} />
             <Field label="Rodzaj płyty" type="select" value={g.boardType} onChange={(v)=>set({boardType:v})} options={Object.keys(store.prices.board)} />
             <Field label="Rodzaj frontu" type="select" value={g.frontType} onChange={(v)=>set({frontType:v})} options={Object.keys(store.prices.front)} />
+            <Field label="Mechanizm otwierania" type="select" value={g.openingMechanism||'standard'} onChange={(v)=>set({openingMechanism:v})} options={Object.keys(store.prices.openingMechanism||{})} />
             {fam===FAMILY.BASE && (<>
               <Field label="Nóżki" type="select" value={g.legsType} onChange={(v)=>set({legsType:v})} options={Object.keys(store.prices.legs)} />
               <Field label="Odsunięcie od ściany (mm)" value={g.offsetWall||0} onChange={(v)=>set({offsetWall:v})} />


### PR DESCRIPTION
## Summary
- support `openingMechanism` in global settings and module data
- show push-to-open and BLUMOTION hinges in 3D previews
- include mechanism pricing in cost calculations

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1709371608322b5b573b0c80425ae