### PR TITLE
feat: add configurable back panel

### DIFF
--- a/src/core/cutlist.ts
+++ b/src/core/cutlist.ts
@@ -40,7 +40,14 @@ export function cutlistForModule(m:any, globals:any): { items: CutItem[]; edges:
     addEdge('ABS 1mm', (W-2*t - tol.assembly), 'Wieniec górny — przód')
     add({ moduleId:m.id, moduleLabel:m.label, material:`Płyta ${t}mm`, part:'Wieniec dolny', qty:1, w:clampPos(W-2*t - tol.assembly), h:clampPos(D) })
     addEdge('ABS 1mm', (W-2*t - tol.assembly), 'Wieniec dolny — przód')
-    add({ moduleId:m.id, moduleLabel:m.label, material:`HDF ${backT}mm`, part:'Plecy', qty:1, w:clampPos(W-2*t - tol.backGroove), h:clampPos(H - tol.backGroove) })
+    if ((g.backPanel||'full') !== 'none') {
+      if ((g.backPanel||'full') === 'split') {
+        const hPiece = clampPos((H - tol.backGroove) / 2)
+        add({ moduleId:m.id, moduleLabel:m.label, material:`HDF ${backT}mm`, part:'Plecy', qty:2, w:clampPos(W-2*t - tol.backGroove), h:hPiece })
+      } else {
+        add({ moduleId:m.id, moduleLabel:m.label, material:`HDF ${backT}mm`, part:'Plecy', qty:1, w:clampPos(W-2*t - tol.backGroove), h:clampPos(H - tol.backGroove) })
+      }
+    }
   }
 
   const addShelves = () => {

--- a/src/core/pricing.ts
+++ b/src/core/pricing.ts
@@ -5,7 +5,7 @@ export type Price = { total:number; parts: Parts; counts:any }
 function hingeCountPerDoor(doorHeightMM:number){ if (doorHeightMM<=900) return 2; if (doorHeightMM<=1500) return 3; return 4 }
 export function computeModuleCost(params: {
   family: FAMILY; kind:string; variant:string; width:number;
-  adv: { height:number; depth:number; boardType:string; frontType:string; gaps?: any };
+  adv: { height:number; depth:number; boardType:string; frontType:string; backPanel?:'full'|'split'|'none'; gaps?: any };
 }): Price {
   const P = usePlannerStore.getState().prices
   const base = usePlannerStore.getState().globals[params.family]
@@ -39,7 +39,8 @@ export function computeModuleCost(params: {
   const hangersCost = hangersCount * (P.hangers['Standard']||0)
   const aventosCost = aventosType ? (P.aventos[aventosType]||0) : 0
   const cargoCost = cargoW ? (P.cargo[cargoW]||0) : 0
-  const boardArea = 2*(h*d)+2*(w*d)+1*(w*d)+0.4*(w*h)
+  const backFactor = g.backPanel === 'none' ? 0 : 1
+  const boardArea = 2*(h*d)+2*(w*d)+backFactor*(w*d)+0.4*(w*h)
   const boardCost = boardArea*boardPrice
   const frontArea = w*h
   const frontCost = frontArea*frontPrice

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -5,15 +5,15 @@ export type Gaps = { left:number; right:number; top:number; bottom:number; betwe
 export const defaultGaps: Gaps = { left:2, right:2, top:2, bottom:2, between:3 }
 
 export type Globals = Record<FAMILY, {
-  height:number; depth:number; boardType:string; frontType:string;
+  height:number; depth:number; boardType:string; frontType:string; backPanel:'full'|'split'|'none';
   gaps: Gaps; legsType?:string; hangerType?:string; offsetWall?:number; shelves?:number;
 }>
 
 export const defaultGlobal: Globals = {
-  [FAMILY.BASE]: { height:800, depth:600, boardType:'Płyta 18mm', frontType:'Laminat', gaps:{...defaultGaps}, legsType:'Standard 10cm', offsetWall:30, shelves:1 },
-  [FAMILY.WALL]: { height:720, depth:320, boardType:'Płyta 18mm', frontType:'Laminat', gaps:{...defaultGaps}, hangerType:'Standard', offsetWall:20, shelves:1 },
-  [FAMILY.PAWLACZ]: { height:400, depth:600, boardType:'Płyta 18mm', frontType:'Laminat', gaps:{...defaultGaps}, hangerType:'Wzmocnione', offsetWall:30, shelves:1 },
-  [FAMILY.TALL]: { height:2100, depth:600, boardType:'Płyta 18mm', frontType:'Laminat', gaps:{...defaultGaps}, shelves:4 }
+  [FAMILY.BASE]: { height:800, depth:600, boardType:'Płyta 18mm', frontType:'Laminat', backPanel:'full', gaps:{...defaultGaps}, legsType:'Standard 10cm', offsetWall:30, shelves:1 },
+  [FAMILY.WALL]: { height:720, depth:320, boardType:'Płyta 18mm', frontType:'Laminat', backPanel:'full', gaps:{...defaultGaps}, hangerType:'Standard', offsetWall:20, shelves:1 },
+  [FAMILY.PAWLACZ]: { height:400, depth:600, boardType:'Płyta 18mm', frontType:'Laminat', backPanel:'full', gaps:{...defaultGaps}, hangerType:'Wzmocnione', offsetWall:30, shelves:1 },
+  [FAMILY.TALL]: { height:2100, depth:600, boardType:'Płyta 18mm', frontType:'Laminat', backPanel:'full', gaps:{...defaultGaps}, shelves:4 }
 }
 
 export const defaultPrices = {
@@ -45,7 +45,7 @@ type Module3D = {
   size:{ w:number; h:number; d:number }; position:[number,number,number]; rotationY?:number;
   price?: any; fittings?: any
   segIndex?: number | null
-  adv?: { height?:number; depth?:number; boardType?:string; frontType?:string; gaps?: Gaps; drawerFronts?: number[]; shelves?:number }
+  adv?: { height?:number; depth?:number; boardType?:string; frontType?:string; backPanel?:'full'|'split'|'none'; gaps?: Gaps; drawerFronts?: number[]; shelves?:number }
     /**
      * Array of booleans indicating whether each front on this module is open.
      * A single-element array corresponds to a single door; multiple elements
@@ -99,6 +99,7 @@ export const usePlannerStore = create<Store>((set,get)=>({
       if (patch.depth !== undefined) newAdv.depth = patch.depth
       if (patch.boardType !== undefined) newAdv.boardType = patch.boardType
       if (patch.frontType !== undefined) newAdv.frontType = patch.frontType
+      if (patch.backPanel !== undefined) newAdv.backPanel = patch.backPanel
       if (patch.gaps !== undefined) newAdv.gaps = { ...(m.adv?.gaps||{}), ...patch.gaps }
       if (patch.shelves !== undefined) newAdv.shelves = patch.shelves
       const newSize = { ...m.size }

--- a/src/ui/components/Cabinet3D.tsx
+++ b/src/ui/components/Cabinet3D.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef } from 'react'
 import * as THREE from 'three'
 import { FAMILY, FAMILY_COLORS } from '../../core/catalog'
 
-export default function Cabinet3D({ widthMM, heightMM, depthMM, drawers, gaps, drawerFronts, family, shelves=1 }:{ widthMM:number;heightMM:number;depthMM:number;drawers:number;gaps:{top:number;bottom:number};drawerFronts?:number[];family:FAMILY; shelves?:number }){
+export default function Cabinet3D({ widthMM, heightMM, depthMM, drawers, gaps, drawerFronts, family, shelves=1, backPanel='full' }:{ widthMM:number;heightMM:number;depthMM:number;drawers:number;gaps:{top:number;bottom:number};drawerFronts?:number[];family:FAMILY; shelves?:number; backPanel?:'full'|'split'|'none' }){
   const ref = useRef<HTMLDivElement>(null)
   useEffect(()=>{
     // Wait until our container is available
@@ -63,10 +63,22 @@ export default function Cabinet3D({ widthMM, heightMM, depthMM, drawers, gaps, d
     topBoard.position.set(W / 2, H - T / 2, -D / 2)
     cabGroup.add(topBoard)
     // Back board
-    const backGeo = new THREE.BoxGeometry(W, H, backT)
-    const backBoard = new THREE.Mesh(backGeo, backMat)
-    backBoard.position.set(W / 2, H / 2, -D + backT / 2)
-    cabGroup.add(backBoard)
+    if (backPanel !== 'none') {
+      if (backPanel === 'split') {
+        const backGeo = new THREE.BoxGeometry(W, H / 2, backT)
+        const back1 = new THREE.Mesh(backGeo, backMat)
+        back1.position.set(W / 2, H / 4, -D + backT / 2)
+        cabGroup.add(back1)
+        const back2 = new THREE.Mesh(backGeo.clone(), backMat)
+        back2.position.set(W / 2, (3 * H) / 4, -D + backT / 2)
+        cabGroup.add(back2)
+      } else {
+        const backGeo = new THREE.BoxGeometry(W, H, backT)
+        const backBoard = new THREE.Mesh(backGeo, backMat)
+        backBoard.position.set(W / 2, H / 2, -D + backT / 2)
+        cabGroup.add(backBoard)
+      }
+    }
     // Shelves: simple horizontal boards (if drawers = 0) else skip
     if (drawers === 0) {
       const shelfGeo = new THREE.BoxGeometry(W - 2 * T, T, D)

--- a/src/ui/panels/GlobalSettings.tsx
+++ b/src/ui/panels/GlobalSettings.tsx
@@ -35,6 +35,7 @@ export default function GlobalSettings(){
             <Field label="Głębokość (mm)" value={g.depth} onChange={(v)=>set({depth:v})} />
             <Field label="Rodzaj płyty" type="select" value={g.boardType} onChange={(v)=>set({boardType:v})} options={Object.keys(store.prices.board)} />
             <Field label="Rodzaj frontu" type="select" value={g.frontType} onChange={(v)=>set({frontType:v})} options={Object.keys(store.prices.front)} />
+            <Field label="Plecy" type="select" value={g.backPanel} onChange={(v)=>set({backPanel:v})} options={['full','split','none']} />
             {fam===FAMILY.BASE && (<>
               <Field label="Nóżki" type="select" value={g.legsType} onChange={(v)=>set({legsType:v})} options={Object.keys(store.prices.legs)} />
               <Field label="Odsunięcie od ściany (mm)" value={g.offsetWall||0} onChange={(v)=>set({offsetWall:v})} />


### PR DESCRIPTION
## Summary
- add `backPanel` option to global and module settings
- render and price cabinets based on back-panel style
- support split back panels in cutlist and preview meshes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b17087979c83228fa9c47d53206cc9