### PR TITLE
Implement sink cabinet geometry with cutout and tests

### DIFF
--- a/src/core/builders.ts
+++ b/src/core/builders.ts
@@ -33,13 +33,53 @@ export function buildCornerCabinet(opts: BuilderOpts): THREE.Group {
 }
 
 /**
- * Sink cabinet – placeholder implementation without cutouts.  Keeping the
- * builder separate allows UI and hardware options to reference this type.
+ * Sink cabinet – builds a basic box with a rectangular cut‑out in the worktop
+ * where a sink would be mounted.
  */
-export function buildSinkCabinet(opts: BuilderOpts): THREE.Group {
-  const g = buildBasicCabinet(opts)
-  g.userData.type = 'sink'
-  return g
+export function buildSinkCabinet({ width, height, depth }: BuilderOpts): THREE.Group {
+  const group = new THREE.Group()
+
+  // Dimensions converted to metres for Three.js
+  const W = width / 1000
+  const H = height / 1000
+  const D = depth / 1000
+
+  // Create a rectangular shape with an inner hole representing the sink cut‑out
+  const outer = new THREE.Shape()
+  outer.moveTo(0, 0)
+  outer.lineTo(W, 0)
+  outer.lineTo(W, D)
+  outer.lineTo(0, D)
+  outer.lineTo(0, 0)
+
+  // Simple centered hole – half the cabinet width and 40% of its depth
+  const hole = new THREE.Path()
+  const sinkW = W * 0.5
+  const sinkD = D * 0.4
+  const hx1 = (W - sinkW) / 2
+  const hx2 = hx1 + sinkW
+  const hz1 = (D - sinkD) / 2
+  const hz2 = hz1 + sinkD
+  hole.moveTo(hx1, hz1)
+  hole.lineTo(hx2, hz1)
+  hole.lineTo(hx2, hz2)
+  hole.lineTo(hx1, hz2)
+  hole.lineTo(hx1, hz1)
+  outer.holes.push(hole)
+
+  // Extrude the shape to create the cabinet volume
+  const geo = new THREE.ExtrudeGeometry(outer, { depth: H, bevelEnabled: false })
+  geo.rotateX(-Math.PI / 2) // align so height is along +Y and depth along -Z
+
+  const mat = new THREE.MeshStandardMaterial({ color: 0xcccccc })
+  const mesh = new THREE.Mesh(geo, mat)
+  group.add(mesh)
+
+  // Tag so the UI knows this is a sink cabinet
+  group.userData.type = 'sink'
+  group.userData.hasSinkCutout = true
+
+  return group
 }
 
 /**

--- a/tests/builders.test.ts
+++ b/tests/builders.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest'
+import * as THREE from 'three'
+import { buildSinkCabinet } from '../src/core/builders'
+
+describe('buildSinkCabinet', () => {
+  it('creates hole for sink and sets userData', () => {
+    const width = 600
+    const height = 720
+    const depth = 500
+    const g = buildSinkCabinet({ width, height, depth })
+    expect(g.userData.type).toBe('sink')
+    expect(g.userData.hasSinkCutout).toBe(true)
+
+    // Raycast straight down through the centre of the top – should miss due to cut-out
+    const mesh = g.children[0] as THREE.Mesh
+    const ray = new THREE.Raycaster(
+      new THREE.Vector3(width / 2000, height / 1000 + 0.1, -depth / 2000),
+      new THREE.Vector3(0, -1, 0)
+    )
+    const hits = ray.intersectObject(mesh)
+    expect(hits.length).toBe(0)
+  })
+})


### PR DESCRIPTION
## Summary
- build sink cabinet using extruded shape with central cutout
- tag sink cabinets via userData for UI detection
- add unit test validating sink cutout and userData

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1a956df0c8322adf508f1eacf186c