### PR TITLE
Add tests for cutlist aggregation and grain-aware validation

### DIFF
--- a/tests/cutlist.test.ts
+++ b/tests/cutlist.test.ts
@@ -11,4 +11,22 @@ describe('aggregateCutlist', () => {
     expect(result).toHaveLength(1);
     expect(result[0]).toMatchObject({ material: 'Mat', part: 'Panel', w: 50, h: 100, qty: 3 });
   });
+
+  it('groups by material and part and sums quantities', () => {
+    const items: CutItem[] = [
+      { moduleId: 'm1', moduleLabel: 'M1', material: 'Mat1', part: 'Panel', qty: 2, w: 100, h: 50 },
+      { moduleId: 'm2', moduleLabel: 'M2', material: 'Mat1', part: 'Panel', qty: 3, w: 50, h: 100 },
+      { moduleId: 'm3', moduleLabel: 'M3', material: 'Mat1', part: 'Drzwi', qty: 1, w: 100, h: 50 },
+      { moduleId: 'm4', moduleLabel: 'M4', material: 'Mat2', part: 'Panel', qty: 1, w: 100, h: 50 },
+    ];
+    const result = aggregateCutlist(items);
+    expect(result).toHaveLength(3);
+    expect(result).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ material: 'Mat1', part: 'Panel', w: 50, h: 100, qty: 5 }),
+        expect.objectContaining({ material: 'Mat1', part: 'Drzwi', w: 50, h: 100, qty: 1 }),
+        expect.objectContaining({ material: 'Mat2', part: 'Panel', w: 50, h: 100, qty: 1 }),
+      ])
+    );
+  });
 });

--- a/tests/format.test.ts
+++ b/tests/format.test.ts
@@ -17,3 +17,25 @@ describe('validateParts', () => {
     expect(res.ok).toBe(false);
   });
 });
+
+describe('validateParts with grain awareness', () => {
+  const board: Board = { L: 200, W: 100, kerf: 2, hasGrain: true };
+
+  it('rejects rotation when requireGrain is true', () => {
+    const parts: Part[] = [{ w: 120, h: 90, name: 'G', requireGrain: true }];
+    const res = validateParts(board, parts);
+    expect(res.ok).toBe(false);
+  });
+
+  it('accepts part with requireGrain when it fits without rotation', () => {
+    const parts: Part[] = [{ w: 90, h: 180, name: 'H', requireGrain: true }];
+    const res = validateParts(board, parts);
+    expect(res.ok).toBe(true);
+  });
+
+  it('allows rotation when requireGrain is false', () => {
+    const parts: Part[] = [{ w: 120, h: 90, name: 'I' }];
+    const res = validateParts(board, parts);
+    expect(res.ok).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- expand aggregateCutlist tests to cover different materials/parts and quantity summing
- add validateParts tests for boards with grain and parts requiring grain, checking rotation restrictions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1a98adf6c832292960d5f6ca54cf2