### PR TITLE
Inject pricing data into computeModuleCost and add tests

### DIFF
--- a/src/core/pricing.ts
+++ b/src/core/pricing.ts
@@ -1,14 +1,16 @@
 import { FAMILY } from './catalog'
-import { usePlannerStore } from '../state/store'
 export type Parts = { board:number; front:number; edging:number; cut:number; hinges:number; slides:number; legs:number; hangers:number; aventos:number; cargo:number; kits:number; labor:number }
 export type Price = { total:number; parts: Parts; counts:any }
 function hingeCountPerDoor(doorHeightMM:number){ if (doorHeightMM<=900) return 2; if (doorHeightMM<=1500) return 3; return 4 }
-export function computeModuleCost(params: {
-  family: FAMILY; kind:string; variant:string; width:number;
-  adv: { height:number; depth:number; boardType:string; frontType:string; gaps?: any; backPanel?:'full'|'split'|'none' };
-}): Price {
-  const P = usePlannerStore.getState().prices
-  const base = usePlannerStore.getState().globals[params.family]
+export function computeModuleCost(
+  params: {
+    family: FAMILY; kind:string; variant:string; width:number;
+    adv: { height:number; depth:number; boardType:string; frontType:string; gaps?: any; backPanel?:'full'|'split'|'none' };
+  },
+  data: { prices:any; globals:any }
+): Price {
+  const P = data.prices
+  const base = data.globals[params.family]
   const g = { ...base, ...params.adv, gaps: { ...base.gaps, ...(params.adv.gaps||{}) } }
   const hMM = g.height
   const dMM = g.depth

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -523,7 +523,10 @@ export default function App(){
     const g = { ...store.globals[family], ...advLocal, gaps: { ...store.globals[family].gaps, ...(advLocal?.gaps||{}) } }
     const h = (g.height)/1000, d=(g.depth)/1000, w=(widthMM)/1000
     const id = `mod_${Date.now()}_${Math.floor(Math.random()*1e6)}`
-    const price = computeModuleCost({ family, kind:kind.key, variant:variant.key, width: widthMM, adv:{ height:g.height, depth:g.depth, boardType:g.boardType, frontType:g.frontType, gaps:g.gaps, backPanel:g.backPanel } })
+    const price = computeModuleCost(
+      { family, kind:kind.key, variant:variant.key, width: widthMM, adv:{ height:g.height, depth:g.depth, boardType:g.boardType, frontType:g.frontType, gaps:g.gaps, backPanel:g.backPanel } },
+      { prices: store.prices, globals: store.globals }
+    )
     const snap = snapToWalls({ w, h, d }, family)
     // Augment advanced settings with defaults for hinge, drawer slide type and animation speed if missing.
     // Additionally, compute drawer front heights based on the selected variant if none were provided.
@@ -613,7 +616,10 @@ export default function App(){
     placed.forEach((pl,i)=>{
       const wmm = widths[i]; const w=wmm/1000
       const id = `auto_${Date.now()}_${i}_${Math.floor(Math.random()*1e6)}`
-      const price = computeModuleCost({ family, kind:(KIND_SETS[family][0]?.key)||'doors', variant:'d1', width: wmm, adv:{ height:g.height, depth:g.depth, boardType:g.boardType, frontType:g.frontType, gaps:g.gaps, backPanel:g.backPanel } })
+      const price = computeModuleCost(
+        { family, kind:(KIND_SETS[family][0]?.key)||'doors', variant:'d1', width: wmm, adv:{ height:g.height, depth:g.depth, boardType:g.boardType, frontType:g.frontType, gaps:g.gaps, backPanel:g.backPanel } },
+        { prices: store.prices, globals: store.globals }
+      )
       let mod:any = { id, label:'Auto', family, kind:(KIND_SETS[family][0]?.key)||'doors', size:{ w,h,d }, position:[pl.center[0]/1000, h/2, pl.center[1]/1000], rotationY:pl.rot, segIndex: selWall, price, adv:g }
       mod = resolveCollisions(mod)
       store.addModule(mod)

--- a/tests/pricing.test.ts
+++ b/tests/pricing.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest'
+import { computeModuleCost } from '../src/core/pricing'
+import { FAMILY } from '../src/core/catalog'
+import { defaultPrices, defaultGlobal } from '../src/state/store'
+
+// Helper to build adv object for a family
+function advFor(fam: FAMILY) {
+  const g = defaultGlobal[fam]
+  return {
+    height: g.height,
+    depth: g.depth,
+    boardType: g.boardType,
+    frontType: g.frontType,
+    gaps: g.gaps,
+    backPanel: g.backPanel,
+  }
+}
+
+describe('computeModuleCost', () => {
+  it('calculates hinge cost for double-door base cabinet', () => {
+    const price = computeModuleCost(
+      {
+        family: FAMILY.BASE,
+        kind: 'doors',
+        variant: 'd2',
+        width: 600,
+        adv: advFor(FAMILY.BASE),
+      },
+      { prices: defaultPrices, globals: defaultGlobal }
+    )
+    expect(price.counts.doors).toBe(2)
+    expect(price.parts.hinges).toBe(64)
+  })
+
+  it('includes slide costs for three-drawer module', () => {
+    const price = computeModuleCost(
+      {
+        family: FAMILY.BASE,
+        kind: 'drawers',
+        variant: 's3',
+        width: 600,
+        adv: advFor(FAMILY.BASE),
+      },
+      { prices: defaultPrices, globals: defaultGlobal }
+    )
+    expect(price.counts.drawers).toBe(3)
+    expect(price.parts.slides).toBe(defaultPrices.drawerSlide['BLUM LEGRABOX'] * 3)
+  })
+
+  it('adds aventos cost for wall cabinet with HK lift', () => {
+    const price = computeModuleCost(
+      {
+        family: FAMILY.WALL,
+        kind: 'doors',
+        variant: 'avHK',
+        width: 600,
+        adv: advFor(FAMILY.WALL),
+      },
+      { prices: defaultPrices, globals: defaultGlobal }
+    )
+    expect(price.parts.aventos).toBe(defaultPrices.aventos.HK)
+  })
+
+  it('uses four hinges per door for tall cabinets', () => {
+    const price = computeModuleCost(
+      {
+        family: FAMILY.TALL,
+        kind: 'tall',
+        variant: 't2',
+        width: 600,
+        adv: advFor(FAMILY.TALL),
+      },
+      { prices: defaultPrices, globals: defaultGlobal }
+    )
+    expect(price.counts.hinges).toBe(8)
+  })
+})
+


### PR DESCRIPTION
## Summary
- refactor pricing to accept `prices` and `globals` params
- update module creation to pass required pricing data
- add unit tests for multiple cabinet configurations

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1b3d28f1c8322ba99d21426b93343