### PR TITLE
feat: add back panel style options

### DIFF
--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -137,6 +137,7 @@ export default function App(){
       back.position.set(W / 2, legHeight + H / 2, -D + backT / 2)
       group.add(back)
     } else if (backStyle === 'split') {
+      // Two-piece back panel with a 2 mm gap between halves
       const gap = 0.002
       const halfH = (H - gap) / 2
       const backGeo = new THREE.BoxGeometry(W, halfH, backT)
@@ -146,6 +147,8 @@ export default function App(){
       const topBack = new THREE.Mesh(backGeo.clone(), backMat)
       topBack.position.set(W / 2, legHeight + H - halfH / 2, -D + backT / 2)
       group.add(topBack)
+    } else if (backStyle === 'none') {
+      // No back panel requested
     }
     const gaps = adv.gaps || { top: 0, bottom: 0 }
     // Determine if the cabinet has drawers (presence of drawerFronts array)


### PR DESCRIPTION
## Summary
- allow cabinets to render with no back panel when `adv.backPanel` is "none"
- split the back panel into two pieces with a 2 mm gap when `adv.backPanel` is "split"

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1ba05f4588322ad6bc1acb7de3ebd