### PR TITLE
Fix duplicate Cabinet3D preview

### DIFF
--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -518,10 +518,17 @@ const drawScene = () => {
                       />
                     </div>
                     <div className="row" style={{marginTop:8}}>
-                      <Cabinet3D family={family} widthMM={widthMM} heightMM={gLocal.height} depthMM={gLocal.depth} drawers={variant?.key?.startsWith('s') ? Number(variant.key.slice(1)) : (variant?.key?.includes('+drawer') ? 1 : 0)} gaps={{top:gLocal.gaps.top, bottom:gLocal.gaps.bottom}} drawerFronts={gLocal.drawerFronts} shelves={gLocal.shelves} backPanel={gLocal.backPanel} />
-                    </div>
-                    <div className="row" style={{marginTop:8}}>
-                      <Cabinet3D family={family} widthMM={widthMM} heightMM={gLocal.height} depthMM={gLocal.depth} drawers={variant?.key?.startsWith('s') ? Number(variant.key.slice(1)) : (variant?.key?.includes('+drawer') ? 1 : 0)} gaps={{top:gLocal.gaps.top, bottom:gLocal.gaps.bottom}} drawerFronts={gLocal.drawerFronts} shelves={gLocal.shelves} backPanel={gLocal.backPanel} />
+                      <Cabinet3D
+                        family={family}
+                        widthMM={widthMM}
+                        heightMM={gLocal.height}
+                        depthMM={gLocal.depth}
+                        drawers={variant?.key?.startsWith('s') ? Number(variant.key.slice(1)) : (variant?.key?.includes('+drawer') ? 1 : 0)}
+                        gaps={{ top: gLocal.gaps.top, bottom: gLocal.gaps.bottom }}
+                        drawerFronts={gLocal.drawerFronts}
+                        shelves={gLocal.shelves}
+                        backPanel={gLocal.backPanel}
+                      />
                     </div>
                   </div>
                 )}


### PR DESCRIPTION
## Summary
- remove extra Cabinet3D instance in the basic cabinet configuration tab so only one 3D preview is shown

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b213ac35c48322a77e1907dfeb0f19