### PR TITLE
Remove duplicate cabinet preview in advanced tab

### DIFF
--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -569,10 +569,17 @@ const drawScene = () => {
                       />
                     </div>
                     <div className="row" style={{marginTop:8}}>
-                      <Cabinet3D family={family} widthMM={widthMM} heightMM={gLocal.height} depthMM={gLocal.depth} drawers={variant?.key?.startsWith('s') ? Number(variant.key.slice(1)) : (variant?.key?.includes('+drawer') ? 1 : 0)} gaps={{top:gLocal.gaps.top, bottom:gLocal.gaps.bottom}} drawerFronts={gLocal.drawerFronts} shelves={gLocal.shelves} backPanel={gLocal.backPanel} />
-                    </div>
-                    <div className="row" style={{marginTop:8}}>
-                      <Cabinet3D family={family} widthMM={widthMM} heightMM={gLocal.height} depthMM={gLocal.depth} drawers={variant?.key?.startsWith('s') ? Number(variant.key.slice(1)) : (variant?.key?.includes('+drawer') ? 1 : 0)} gaps={{top:gLocal.gaps.top, bottom:gLocal.gaps.bottom}} drawerFronts={gLocal.drawerFronts} shelves={gLocal.shelves} backPanel={gLocal.backPanel} />
+                      <Cabinet3D
+                        family={family}
+                        widthMM={widthMM}
+                        heightMM={gLocal.height}
+                        depthMM={gLocal.depth}
+                        drawers={variant?.key?.startsWith('s') ? Number(variant.key.slice(1)) : (variant?.key?.includes('+drawer') ? 1 : 0)}
+                        gaps={{ top: gLocal.gaps.top, bottom: gLocal.gaps.bottom }}
+                        drawerFronts={gLocal.drawerFronts}
+                        shelves={gLocal.shelves}
+                        backPanel={gLocal.backPanel}
+                      />
                     </div>
                     <div className="row" style={{marginTop:8}}>
                       <button className="btn" onClick={()=>onAdd(widthMM, gLocal)}>Wstaw szafkę</button>


### PR DESCRIPTION
## Summary
- remove duplicate Cabinet3D preview in advanced config so only a single preview remains

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b21710daec83228ec44573834626c7