### PR TITLE
refactor: add types for pricing and modules

### DIFF
--- a/src/core/builders.ts
+++ b/src/core/builders.ts
@@ -1,11 +1,12 @@
 import * as THREE from 'three'
+import { ModuleAdv } from '../types'
 
 export interface BuilderOpts {
   width: number // in millimetres
   height: number // in millimetres
   depth: number // in millimetres
-  adv?: any
-  hardware?: any
+  adv?: ModuleAdv
+  hardware?: Record<string, number>
 }
 
 /**

--- a/src/core/cutlist.ts
+++ b/src/core/cutlist.ts
@@ -1,4 +1,5 @@
 import { FAMILY } from './catalog'
+import { Module3D, Globals, PriceCounts } from '../types'
 
 function parseThickness(boardType:string): number{
   const m = boardType?.match(/(\d+)(?=\s*mm)/i)
@@ -16,7 +17,7 @@ const tol = {
   shelfFrontSetback: 0
 } as const
 
-export function cutlistForModule(m:any, globals:any): { items: CutItem[]; edges: EdgeItem[] } {
+export function cutlistForModule(m: Module3D, globals: Globals): { items: CutItem[]; edges: EdgeItem[] } {
   const base = globals[m.family] || {}
   const g = m.adv ? { ...base, ...m.adv, gaps: { ...base.gaps, ...(m.adv.gaps||{}) } } : base
   const gaps = (g.gaps)||{ left:2,right:2,top:2,bottom:2,between:3 }
@@ -73,7 +74,7 @@ export function cutlistForModule(m:any, globals:any): { items: CutItem[]; edges:
     addStandardBox(); addShelves()
   }
 
-  const counts = m.price?.counts || { doors:0, drawers:0 }
+  const counts: PriceCounts = m.price?.counts || { doors:0, drawers:0, legs:0, hangers:0, hinges:0 }
   const availWforFront = W - gaps.left - gaps.right
   const availHforFront = H - gaps.top - gaps.bottom
 

--- a/src/core/pricing.ts
+++ b/src/core/pricing.ts
@@ -1,13 +1,14 @@
 import { FAMILY } from './catalog'
-export type Parts = { board:number; front:number; edging:number; cut:number; hinges:number; slides:number; legs:number; hangers:number; aventos:number; cargo:number; kits:number; labor:number }
-export type Price = { total:number; parts: Parts; counts:any }
+import { Parts, Price, PricingData, ModuleAdv, PriceCounts } from '../types'
 function hingeCountPerDoor(doorHeightMM:number){ if (doorHeightMM<=900) return 2; if (doorHeightMM<=1500) return 3; return 4 }
+type AdvParams = Required<Pick<ModuleAdv,'height'|'depth'|'boardType'|'frontType'>> & Omit<ModuleAdv,'height'|'depth'|'boardType'|'frontType'>
+
 export function computeModuleCost(
   params: {
     family: FAMILY; kind:string; variant:string; width:number;
-    adv: { height:number; depth:number; boardType:string; frontType:string; gaps?: any; backPanel?:'full'|'split'|'none' };
+    adv: AdvParams;
   },
-  data: { prices:any; globals:any }
+  data: PricingData
 ): Price {
   const P = data.prices
   const base = data.globals[params.family]
@@ -50,8 +51,9 @@ export function computeModuleCost(
   const edgingCost = edgeMeters * (edgingPrice||0)
   const cutCost = (edgeMeters) * (P.cut||4)
   const labor = P.labor||0
-  const parts = { board: Math.round(boardCost), front: Math.round(frontCost), edging: Math.round(edgingCost), cut: Math.round(cutCost), hinges: Math.round(hingesCost), slides: Math.round(slidesCost), legs: Math.round(legsCost), hangers: Math.round(hangersCost), aventos: Math.round(aventosCost), cargo: Math.round(cargoCost), kits: Math.round(kits), labor: Math.round(labor) }
+  const parts: Parts = { board: Math.round(boardCost), front: Math.round(frontCost), edging: Math.round(edgingCost), cut: Math.round(cutCost), hinges: Math.round(hingesCost), slides: Math.round(slidesCost), legs: Math.round(legsCost), hangers: Math.round(hangersCost), aventos: Math.round(aventosCost), cargo: Math.round(cargoCost), kits: Math.round(kits), labor: Math.round(labor) }
   const subtotal = Object.values(parts).reduce((s,n)=>s+(n||0),0)
   const total = Math.round(subtotal*(1+(P.margin||0)))
-  return { total, parts, counts:{ doors, drawers, legs:legsCount, hangers:hangersCount, hinges:hingesPerDoor*doors } }
+  const counts: PriceCounts = { doors, drawers, legs:legsCount, hangers:hangersCount, hinges:hingesPerDoor*doors }
+  return { total, parts, counts }
 }

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -1,14 +1,8 @@
 import { create } from 'zustand'
 import { FAMILY } from '../core/catalog'
+import { Module3D, Room, Globals, Prices, Opening, Gaps } from '../types'
 
-export type Gaps = { left:number; right:number; top:number; bottom:number; between:number }
 export const defaultGaps: Gaps = { left:2, right:2, top:2, bottom:2, between:3 }
-
-export type Globals = Record<FAMILY, {
-  height:number; depth:number; boardType:string; frontType:string;
-  gaps: Gaps; legsType?:string; hangerType?:string; offsetWall?:number; shelves?:number;
-  backPanel?:'full'|'split'|'none';
-}>
 
 export const defaultGlobal: Globals = {
   [FAMILY.BASE]: { height:800, depth:600, boardType:'Płyta 18mm', frontType:'Laminat', gaps:{...defaultGaps}, legsType:'Standard 10cm', offsetWall:30, shelves:1, backPanel:'full' },
@@ -17,7 +11,7 @@ export const defaultGlobal: Globals = {
   [FAMILY.TALL]: { height:2100, depth:600, boardType:'Płyta 18mm', frontType:'Laminat', gaps:{...defaultGaps}, shelves:4, backPanel:'full' }
 }
 
-export const defaultPrices = {
+export const defaultPrices: Prices = {
   board: { 'Płyta 18mm': 120, 'Płyta 19mm': 140, 'Płyta 25mm': 200 },
   front: { Laminat: 220, Lakier: 420, Fornir: 520 },
   edging: { 'ABS 1mm': 2.5, 'ABS 2mm': 3.2 },
@@ -41,33 +35,17 @@ const persisted = (()=>{
   try{ return JSON.parse(localStorage.getItem('kv7_state')||'null') }catch{ return null }
 })()
 
-type Module3D = {
-  id:string; label:string; family:FAMILY; kind:string;
-  size:{ w:number; h:number; d:number }; position:[number,number,number]; rotationY?:number;
-  price?: any; fittings?: any
-  segIndex?: number | null
-  adv?: { height?:number; depth?:number; boardType?:string; frontType?:string; gaps?: Gaps; drawerFronts?: number[]; shelves?:number; backPanel?:'full'|'split'|'none' }
-    /**
-     * Array of booleans indicating whether each front on this module is open.
-     * A single-element array corresponds to a single door; multiple elements
-     * correspond to drawers.  If undefined, the cabinet is assumed closed.
-     */
-    openStates?: boolean[]
-}
-
-type Room = { walls: { length:number; angle:number }[]; openings: any[]; height:number }
-
 type Store = {
   role: 'stolarz'|'klient'
   globals: Globals
-  prices: any
+  prices: Prices
   modules: Module3D[]
   past: Module3D[][]
   future: Module3D[][]
   room: Room
   setRole:(r:'stolarz'|'klient')=>void
   updateGlobals:(fam:FAMILY, patch:Partial<Globals[FAMILY]>)=>void
-  updatePrices:(patch:any)=>void
+  updatePrices:(patch:Partial<Prices>)=>void
   addModule:(m:Module3D)=>void
   updateModule:(id:string,patch:Partial<Module3D>)=>void
   removeModule:(id:string)=>void
@@ -76,7 +54,7 @@ type Store = {
   redo:()=>void
   setRoom:(patch:Partial<Room>)=>void
   addWall:(w:{length:number; angle:number})=>void
-  addOpening:(op:any)=>void
+  addOpening:(op: Opening)=>void
 }
 
 export const usePlannerStore = create<Store>((set,get)=>({

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,107 @@
+import { FAMILY } from './core/catalog'
+
+export type Gaps = { left:number; right:number; top:number; bottom:number; between:number }
+
+export interface GlobalsItem {
+  height:number
+  depth:number
+  boardType:string
+  frontType:string
+  gaps: Gaps
+  legsType?:string
+  hangerType?:string
+  offsetWall?:number
+  shelves?:number
+  backPanel?:'full'|'split'|'none'
+}
+
+export type Globals = Record<FAMILY, GlobalsItem>
+
+export interface Prices {
+  board: Record<string, number>
+  front: Record<string, number>
+  edging: Record<string, number>
+  cut: number
+  legs: Record<string, number>
+  hangers: Record<string, number>
+  hinges: Record<string, number>
+  drawerSlide: Record<string, number>
+  aventos: Record<string, number>
+  cargo: Record<string, number>
+  hoodKit: number
+  sinkKit: number
+  dwKit: number
+  fridgeKit: number
+  handle: Record<string, number>
+  labor: number
+  margin: number
+}
+
+export interface Parts {
+  board:number
+  front:number
+  edging:number
+  cut:number
+  hinges:number
+  slides:number
+  legs:number
+  hangers:number
+  aventos:number
+  cargo:number
+  kits:number
+  labor:number
+}
+
+export interface PriceCounts {
+  doors:number
+  drawers:number
+  legs:number
+  hangers:number
+  hinges:number
+}
+
+export interface Price {
+  total:number
+  parts: Parts
+  counts: PriceCounts
+}
+
+export interface ModuleAdv {
+  height?:number
+  depth?:number
+  boardType?:string
+  frontType?:string
+  gaps?: Gaps
+  drawerFronts?: number[]
+  shelves?:number
+  backPanel?:'full'|'split'|'none'
+}
+
+export interface Module3D {
+  id:string
+  label:string
+  family:FAMILY
+  kind:string
+  size:{ w:number; h:number; d:number }
+  position:[number,number,number]
+  rotationY?:number
+  price?: Price
+  fittings?: Record<string, number>
+  segIndex?: number | null
+  adv?: ModuleAdv
+  openStates?: boolean[]
+}
+
+export type Opening = Record<string, number>
+
+export interface Room {
+  walls: { length:number; angle:number }[]
+  openings: Opening[]
+  height:number
+}
+
+export interface PricingData {
+  prices: Prices
+  globals: Globals
+}
+


### PR DESCRIPTION
## Summary
- define shared interfaces for module, pricing, and room data
- use these types across state store, pricing, cutlist, and builders
- remove remaining `any` from core logic

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b21a057e708322b18d7c2b9b0cf91c