### PR TITLE
test: add cabinet builder mesh tests

### DIFF
--- a/tests/cabinetBuilder.test.ts
+++ b/tests/cabinetBuilder.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest'
+import * as THREE from 'three'
+import { buildCabinetMesh } from '../src/scene/cabinetBuilder'
+import { FAMILY } from '../src/core/catalog'
+
+describe('buildCabinetMesh', () => {
+  it('returns group with expected children for drawers', () => {
+    const g = buildCabinetMesh({
+      width: 1,
+      height: 0.9,
+      depth: 0.5,
+      drawers: 2,
+      gaps: { top: 0, bottom: 0 },
+      family: FAMILY.BASE,
+    })
+    expect(g).toBeInstanceOf(THREE.Group)
+    expect(g.children.length).toBe(9)
+  })
+
+  it('returns group with expected children for doors', () => {
+    const g = buildCabinetMesh({
+      width: 1,
+      height: 0.9,
+      depth: 0.5,
+      drawers: 0,
+      gaps: { top: 0, bottom: 0 },
+      family: FAMILY.BASE,
+    })
+    expect(g.children.length).toBe(8)
+  })
+
+  it('matches provided dimensions', () => {
+    const width = 0.8
+    const height = 0.7
+    const depth = 0.6
+    const g = buildCabinetMesh({
+      width,
+      height,
+      depth,
+      drawers: 0,
+      gaps: { top: 0, bottom: 0 },
+      family: FAMILY.BASE,
+      showHandles: false,
+    })
+    g.updateMatrixWorld(true)
+    const box = new THREE.Box3().setFromObject(g)
+    const size = box.getSize(new THREE.Vector3())
+    expect(size.x).toBeCloseTo(width, 5)
+    expect(size.y).toBeCloseTo(height, 5)
+    expect(size.z).toBeCloseTo(depth, 5)
+  })
+})


### PR DESCRIPTION
## Summary
- add tests for cabinet builder verifying drawer vs door child counts
- ensure generated meshes respect provided dimensions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b21c30d48c8322a88de1de80065062