### PR TITLE
Remove stray cutlist sidebar text

### DIFF
--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -157,8 +157,6 @@ export default function App(){
         {tab==='room' && (<RoomTab three={threeRef} />)}
         {tab==='costs' && (<CostsTab />)}
         {tab==='cut' && (<CutlistTab />)}
-            provides a simplified cabinet builder with its own cutlist
-            and 3D viewer.
 
       </aside>
     </div>


### PR DESCRIPTION
## Summary
- remove leftover text after the cutlist tab in `App.tsx`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b21f3e4a8883229c8418579fff82d4