### PR TITLE
Use typed CabinetConfig for cabinet setup

### DIFF
--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -11,6 +11,7 @@ import SingleMMInput from './components/SingleMMInput'
 import SceneViewer from './SceneViewer'
 import CabinetConfigurator from './CabinetConfigurator'
 import useCabinetConfig from './useCabinetConfig'
+import { CabinetConfig } from './types'
 
 export default function App(){
   const [boardL, setBoardL] = useState<number>(()=>{ try{ return Number(localStorage.getItem('boardL')||2800) }catch{ return 2800 } })
@@ -32,7 +33,25 @@ export default function App(){
   const [addCountertop] = useState(true)
   const threeRef = useRef<any>({})
 
-  const { cfgTab, setCfgTab, widthMM, setWidthMM, setAdv, gLocal, onAdd, doAutoOnSelectedWall } = useCabinetConfig(
+  const {
+    cfgTab,
+    setCfgTab,
+    widthMM,
+    setWidthMM,
+    setAdv,
+    gLocal,
+    onAdd,
+    doAutoOnSelectedWall
+  }: {
+    cfgTab: 'basic' | 'adv'
+    setCfgTab: (t: 'basic' | 'adv') => void
+    widthMM: number
+    setWidthMM: (n: number) => void
+    setAdv: (v: CabinetConfig) => void
+    gLocal: CabinetConfig
+    onAdd: (width: number, adv: CabinetConfig) => void
+    doAutoOnSelectedWall: () => void
+  } = useCabinetConfig(
     family,
     kind,
     variant,
@@ -113,19 +132,19 @@ export default function App(){
           <button className={`tabBtn ${tab==='room'?'active':''}`} onClick={()=>setTab('room')}>Pomieszczenie</button>
           <button className={`tabBtn ${tab==='costs'?'active':''}`} onClick={()=>setTab('costs')}>Koszty</button>
           <button className={`tabBtn ${tab==='cut'?'active':''}`} onClick={()=>setTab('cut')}>Formatki</button>
-          <button className={`tabBtn ${tab==='phase8'?'active':''}`} onClick={()=>setTab('cab')}></button>
+            {/* placeholder removed */}
         </div>
 
         {tab==='cab' && (<>
           <div>
             <div className="h1">Typ szafki</div>
-            <TypePicker family={family} setFamily={(f)=>{ setFamily(f); setKind(null); setVariant(null); }} />
+              <TypePicker family={family} setFamily={(f: FAMILY)=>{ setFamily(f); setKind(null); setVariant(null); }} />
           </div>
 
           <div className="section">
             <div className="hd"><div><div className="h1">Podkategorie ({FAMILY_LABELS[family]})</div></div></div>
             <div className="bd">
-              <KindTabs family={family} kind={kind} setKind={(k)=>{ setKind(k); setVariant(null); }} />
+                <KindTabs family={family} kind={kind} setKind={(k: Kind)=>{ setKind(k); setVariant(null); }} />
             </div>
           </div>
 
@@ -133,7 +152,7 @@ export default function App(){
             <div className="section">
               <div className="hd"><div><div className="h1">Wariant</div></div></div>
               <div className="bd">
-                <VariantList kind={kind} onPick={(v)=>{ setVariant(v); setCfgTab('basic'); }} />
+                  <VariantList kind={kind} onPick={(v: Variant)=>{ setVariant(v); setCfgTab('basic'); }} />
               </div>
             </div>
           )}

--- a/src/ui/CabinetConfigurator.tsx
+++ b/src/ui/CabinetConfigurator.tsx
@@ -3,6 +3,8 @@ import { FAMILY, Kind, Variant } from '../core/catalog'
 import { usePlannerStore } from '../state/store'
 import TechDrawing from './components/TechDrawing'
 import Cabinet3D from './components/Cabinet3D'
+import { CabinetConfig } from './types'
+import { Gaps } from '../types'
 
 interface Props {
   family: FAMILY
@@ -12,9 +14,9 @@ interface Props {
   setCfgTab: (t: 'basic' | 'adv') => void
   widthMM: number
   setWidthMM: (n: number) => void
-  gLocal: any
-  setAdv: (v: any) => void
-  onAdd: (width: number, adv: any) => void
+  gLocal: CabinetConfig
+  setAdv: (v: CabinetConfig) => void
+  onAdd: (width: number, adv: CabinetConfig) => void
 }
 
 const CabinetConfigurator: React.FC<Props> = ({
@@ -112,8 +114,8 @@ const CabinetConfigurator: React.FC<Props> = ({
                 gaps={gLocal.gaps}
                 drawers={variant?.key?.startsWith('s') ? Number(variant.key.slice(1)) : (variant?.key?.includes('+drawer') ? 1 : 0)}
                 drawerFronts={gLocal.drawerFronts}
-                onChangeGaps={(gg)=>setAdv({ ...gLocal, gaps: gg })}
-                onChangeDrawerFronts={(arr)=>setAdv({ ...gLocal, drawerFronts: arr })}
+                onChangeGaps={(gg: Gaps) => setAdv({ ...gLocal, gaps: gg })}
+                onChangeDrawerFronts={(arr: number[]) => setAdv({ ...gLocal, drawerFronts: arr })}
               />
             </div>
             <div className="row" style={{marginTop:8}}>

--- a/src/ui/types.ts
+++ b/src/ui/types.ts
@@ -1,0 +1,13 @@
+import { Gaps } from '../types'
+
+export interface CabinetConfig {
+  height: number
+  depth: number
+  boardType: string
+  frontType: string
+  gaps: Gaps
+  shelves?: number
+  backPanel?: 'full' | 'split' | 'none'
+  drawerFronts?: number[]
+}
+

--- a/src/ui/useCabinetConfig.ts
+++ b/src/ui/useCabinetConfig.ts
@@ -4,6 +4,7 @@ import { computeModuleCost } from '../core/pricing'
 import { usePlannerStore } from '../state/store'
 import { getWallSegments, projectPointToSegment } from '../utils/walls'
 import { autoWidthsForRun, placeAlongWall } from '../utils/auto'
+import { CabinetConfig } from './types'
 
 export function useCabinetConfig(
   family: FAMILY,
@@ -15,12 +16,12 @@ export function useCabinetConfig(
   const store = usePlannerStore()
   const [cfgTab, setCfgTab] = useState<'basic' | 'adv'>('basic')
   const [widthMM, setWidthMM] = useState(600)
-  const [adv, setAdv] = useState<any>(null)
+  const [adv, setAdvState] = useState<CabinetConfig | null>(null)
 
   useEffect(() => {
     const g = store.globals[family]
     const defaultShelves = family === FAMILY.TALL ? 4 : 1
-    setAdv({
+    setAdvState({
       height: g.height,
       depth: g.depth,
       boardType: g.boardType,
@@ -90,7 +91,7 @@ export function useCabinetConfig(
     return rest
   }
 
-  const onAdd = (widthLocal: number, advLocal: any) => {
+  const onAdd = (widthLocal: number, advLocal: CabinetConfig) => {
     if (!kind || !variant) return
     const g = {
       ...store.globals[family],
@@ -235,7 +236,7 @@ export function useCabinetConfig(
     })
   }
 
-  const gLocal = adv || store.globals[family]
+  const gLocal: CabinetConfig = adv || (store.globals[family] as CabinetConfig)
 
   return {
     cfgTab,
@@ -243,7 +244,7 @@ export function useCabinetConfig(
     widthMM,
     setWidthMM,
     adv,
-    setAdv,
+    setAdv: (v: CabinetConfig) => setAdvState(v),
     gLocal,
     onAdd,
     doAutoOnSelectedWall


### PR DESCRIPTION
## Summary
- introduce `CabinetConfig` interface describing cabinet options
- update CabinetConfigurator, hook, and App to use `CabinetConfig` instead of `any`
- add explicit type annotations for handler parameters and remove placeholder tab

## Testing
- `npx tsc --noEmit --strict` *(fails: Property 'label' does not exist on type 'IntrinsicAttributes & Props', missing module declarations for 'three', etc.)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b220124228832296993468b6bc9c44