### PR TITLE
feat: offset cabinet fronts

### DIFF
--- a/src/scene/cabinetBuilder.ts
+++ b/src/scene/cabinetBuilder.ts
@@ -38,6 +38,8 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
     backThickness: backT = 0.003,
   } = opts
 
+  const FRONT_OFFSET = 0.002
+
   const carcColour = new THREE.Color(0xf5f5f5)
   const frontColour = new THREE.Color(FAMILY_COLORS[family])
   const backColour = new THREE.Color(0xf0f0f0)
@@ -111,7 +113,7 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
       const h = arr[i] / 1000
       const frontGeo = new THREE.BoxGeometry(W, h, T)
       const frontMesh = new THREE.Mesh(frontGeo, frontMat)
-      frontMesh.position.set(W / 2, currentY + h / 2, -T / 2)
+      frontMesh.position.set(W / 2, currentY + h / 2, FRONT_OFFSET - T / 2)
       group.add(frontMesh)
       if (showHandles) {
         const handleWidth = Math.min(0.4, W * 0.5)
@@ -119,7 +121,7 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
         const handleDepth = 0.03
         const handleGeo = new THREE.BoxGeometry(handleWidth, handleHeight, handleDepth)
         const handle = new THREE.Mesh(handleGeo, handleMat)
-        handle.position.set(W / 2, currentY + h - handleHeight * 1.5, 0.01)
+        handle.position.set(W / 2, currentY + h - handleHeight * 1.5, 0.01 + FRONT_OFFSET)
         group.add(handle)
       }
       currentY += h
@@ -127,7 +129,7 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
   } else {
     const doorGeo = new THREE.BoxGeometry(W, H, T)
     const door = new THREE.Mesh(doorGeo, frontMat)
-    door.position.set(W / 2, legHeight + H / 2, -T / 2)
+    door.position.set(W / 2, legHeight + H / 2, FRONT_OFFSET - T / 2)
     group.add(door)
     if (showHandles) {
       const handleWidth = Math.min(0.4, W * 0.5)
@@ -135,7 +137,7 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
       const handleDepth = 0.03
       const handleGeo = new THREE.BoxGeometry(handleWidth, handleHeight, handleDepth)
       const handle = new THREE.Mesh(handleGeo, handleMat)
-      handle.position.set(W / 2, legHeight + H * 0.7, 0.01)
+      handle.position.set(W / 2, legHeight + H * 0.7, 0.01 + FRONT_OFFSET)
       group.add(handle)
     }
   }

--- a/tests/cabinetBuilder.test.ts
+++ b/tests/cabinetBuilder.test.ts
@@ -3,6 +3,8 @@ import * as THREE from 'three'
 import { buildCabinetMesh } from '../src/scene/cabinetBuilder'
 import { FAMILY } from '../src/core/catalog'
 
+const FRONT_OFFSET = 0.002
+
 describe('buildCabinetMesh', () => {
   it('returns group with expected children for drawers', () => {
     const g = buildCabinetMesh({
@@ -47,6 +49,6 @@ describe('buildCabinetMesh', () => {
     const size = box.getSize(new THREE.Vector3())
     expect(size.x).toBeCloseTo(width, 5)
     expect(size.y).toBeCloseTo(height, 5)
-    expect(size.z).toBeCloseTo(depth, 5)
+    expect(size.z).toBeCloseTo(depth + FRONT_OFFSET, 5)
   })
 })


### PR DESCRIPTION
## Summary
- offset cabinet fronts by a small constant to sit slightly proud of the carcass
- keep drawer and door handles aligned with new front offset
- adjust cabinet builder tests for updated depth

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2288d5f3c8322a8e239cc9f215971