### PR TITLE
Add pivot groups for cabinet fronts and track open state

### DIFF
--- a/src/ui/SceneViewer.tsx
+++ b/src/ui/SceneViewer.tsx
@@ -45,6 +45,7 @@ const SceneViewer: React.FC<Props> = ({ threeRef, addCountertop }) => {
     const adv: ModuleAdv = mod.adv ?? {}
     const legHeight = getLegHeight(mod, store.globals)
     const drawers = Array.isArray(adv.drawerFronts) ? adv.drawerFronts.length : 0
+    const hinge = (adv as any).hinge as 'left' | 'right' | undefined
     const group = buildCabinetMesh({
       width: W,
       height: H,
@@ -56,9 +57,14 @@ const SceneViewer: React.FC<Props> = ({ threeRef, addCountertop }) => {
       shelves: adv.shelves,
       backPanel: adv.backPanel,
       legHeight,
-      showHandles: true
+      showHandles: true,
+      hinge
     })
     group.userData.kind = 'cab'
+    const fg = group.userData.frontGroups || []
+    group.userData.openStates = mod.openStates?.slice(0, fg.length) || new Array(fg.length).fill(false)
+    group.userData.openProgress = new Array(fg.length).fill(0)
+    group.userData.animSpeed = (adv as any).animationSpeed ?? 0.15
     return group
   }
 

--- a/tests/cabinetBuilder.test.ts
+++ b/tests/cabinetBuilder.test.ts
@@ -16,7 +16,7 @@ describe('buildCabinetMesh', () => {
       family: FAMILY.BASE,
     })
     expect(g).toBeInstanceOf(THREE.Group)
-    expect(g.children.length).toBe(9)
+    expect(g.children.length).toBe(7)
   })
 
   it('returns group with expected children for doors', () => {
@@ -28,7 +28,7 @@ describe('buildCabinetMesh', () => {
       gaps: { top: 0, bottom: 0 },
       family: FAMILY.BASE,
     })
-    expect(g.children.length).toBe(8)
+    expect(g.children.length).toBe(7)
   })
 
   it('matches provided dimensions', () => {


### PR DESCRIPTION
## Summary
- Wrap each drawer front and door in its own `THREE.Group` as an animation pivot
- Track pivot groups, open states and progress on cabinet groups and tag with drawer/door metadata
- Initialize these arrays in `SceneViewer` and pass hinge side for doors
- Update unit tests for new group structure

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b22998612883229df2ef00598cbfcc