### PR TITLE
Use stored closed drawer position for animations

### DIFF
--- a/src/scene/cabinetBuilder.ts
+++ b/src/scene/cabinetBuilder.ts
@@ -119,6 +119,7 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
       const frontMesh = new THREE.Mesh(frontGeo, frontMat)
       const fg = new THREE.Group()
       fg.position.set(W / 2, currentY + h / 2, FRONT_OFFSET - T / 2)
+      fg.userData.closedZ = FRONT_OFFSET - T / 2
       frontMesh.position.set(0, 0, 0)
       fg.add(frontMesh)
       fg.userData.type = 'drawer'

--- a/src/ui/SceneViewer.tsx
+++ b/src/ui/SceneViewer.tsx
@@ -174,7 +174,7 @@ const SceneViewer: React.FC<Props> = ({ threeRef, addCountertop }) => {
                     fg.rotation.y = (sign * Math.PI) / 2 * prog
                   } else if (fg.userData.type === 'drawer') {
                     const slide = fg.userData.slideDist || 0.45
-                    fg.position.z = -slide * prog
+                    fg.position.z = (fg.userData.closedZ ?? 0) - slide * prog
                   }
                 }
               }


### PR DESCRIPTION
## Summary
- store each drawer front's closed Z offset during cabinet construction
- animate drawers relative to their stored closed position so they remain 2 mm forward when shut

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b22dfd3d5c832284a3555fb20289c4