### PR TITLE
Add typed interfaces for cutlist validation

### DIFF
--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -1,0 +1,10 @@
+import type { SheetPlan } from '../core/format'
+
+declare global {
+  interface Window {
+    __packedSheetsLen?: number
+    __lastPlan?: SheetPlan
+  }
+}
+
+export {}


### PR DESCRIPTION
## Summary
- define BoardConfig and CutItem interfaces in CutlistTab to type board and cut items
- remove `any` casts and convert items to `Part` before calling `validateParts`
- declare global window fields for debug plan data

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b23e0c12d0832288e5f098e046d29d