### PR TITLE
Add grain-aware and overflow format tests

### DIFF
--- a/tests/format.test.ts
+++ b/tests/format.test.ts
@@ -32,4 +32,29 @@ describe('packGuillotine', () => {
     expect(sheets[1].placed[0]).toMatchObject({ x: 0, y: 0, _w: 100, _h: 50 });
     expect(sheets[1].placed[1]).toMatchObject({ x: 0, y: 50, _w: 100, _h: 50 });
   });
+
+  it('avoids rotating grain-required parts on boards with grain', () => {
+    const board: Board = { L: 100, W: 100, kerf: 0, hasGrain: true };
+    const parts: Part[] = [
+      { w: 60, h: 40, name: 'A', requireGrain: true },
+      { w: 40, h: 30, name: 'B', requireGrain: true },
+    ];
+    const sheets = packGuillotine(board, parts);
+    expect(sheets.length).toBe(2);
+    const placed = sheets[1].placed;
+    expect(placed).toHaveLength(2);
+    const pA = placed.find(p => p.name === 'A');
+    const pB = placed.find(p => p.name === 'B');
+    expect(pA).toMatchObject({ x: 0, y: 0, _w: 60, _h: 40 });
+    expect(pB).toMatchObject({ x: 60, y: 0, _w: 40, _h: 30 });
+  });
+
+  it('marks sheet as overflow when part does not fit any sheet', () => {
+    const board: Board = { L: 100, W: 100, kerf: 0, hasGrain: true };
+    const parts: Part[] = [{ w: 200, h: 150, name: 'X', requireGrain: true }];
+    const sheets = packGuillotine(board, parts);
+    const overflowSheet = sheets.find(s => s.overflow);
+    expect(overflowSheet).toBeDefined();
+    expect(overflowSheet?.placed).toHaveLength(0);
+  });
 });


### PR DESCRIPTION
## Summary
- expand packGuillotine tests for grain alignment
- add overflow scenario when part exceeds board size

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b23e2827a4832294e31f1782bd3da8