### PR TITLE
Add i18n with language switcher

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,11 @@
       "name": "kitchi",
       "version": "8.0.1",
       "dependencies": {
+        "i18next": "^25.4.2",
         "jspdf": "^2.5.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-i18next": "^15.7.3",
         "three": "^0.161.0",
         "zustand": "^4.5.2"
       },
@@ -1904,6 +1906,15 @@
         "node": ">=18"
       }
     },
+    "node_modules/html-parse-stringify": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
+      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
+      "license": "MIT",
+      "dependencies": {
+        "void-elements": "3.1.0"
+      }
+    },
     "node_modules/html2canvas": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
@@ -1954,6 +1965,37 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=16.17.0"
+      }
+    },
+    "node_modules/i18next": {
+      "version": "25.4.2",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.4.2.tgz",
+      "integrity": "sha512-gD4T25a6ovNXsfXY1TwHXXXLnD/K2t99jyYMCSimSCBnBRJVQr5j+VAaU83RJCPzrTGhVQ6dqIga66xO2rtd5g==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://locize.com"
+        },
+        {
+          "type": "individual",
+          "url": "https://locize.com/i18next.html"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.6"
+      },
+      "peerDependencies": {
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/iconv-lite": {
@@ -2464,6 +2506,32 @@
         "loose-envify": "^1.1.0"
       }
     },
+    "node_modules/react-i18next": {
+      "version": "15.7.3",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-15.7.3.tgz",
+      "integrity": "sha512-AANws4tOE+QSq/IeMF/ncoHlMNZaVLxpa5uUGW1wjike68elVYr0018L9xYoqBr1OFO7G7boDPrbn0HpMCJxTw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.6",
+        "html-parse-stringify": "^3.0.1"
+      },
+      "peerDependencies": {
+        "i18next": ">= 25.4.1",
+        "react": ">= 16.8.0",
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -2798,7 +2866,7 @@
       "version": "5.9.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -3012,6 +3080,15 @@
         "jsdom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/void-elements": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/w3c-xmlserializer": {

--- a/package.json
+++ b/package.json
@@ -10,9 +10,11 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "i18next": "^25.4.2",
     "jspdf": "^2.5.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-i18next": "^15.7.3",
     "three": "^0.161.0",
     "zustand": "^4.5.2"
   },

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1,0 +1,133 @@
+{
+  "app": {
+    "mode": "Mode",
+    "roles": {
+      "stolarz": "Carpenter",
+      "klient": "Client"
+    },
+    "resetSelection": "Reset selection",
+    "undo": "Undo",
+    "redo": "Redo",
+    "clear": "Clear",
+    "wallLabel": "Wall {{num}} ({{len}} mm)",
+    "autoWall": "Auto for wall",
+    "material": {
+      "title": "Material (sheet)",
+      "boardHeight": "Sheet height L (mm)",
+      "boardWidth": "Sheet width W (mm)",
+      "kerf": "Kerf (mm)",
+      "grain": "Board has grain",
+      "info": "Without grain: pieces can rotate (must fit in {{l}}×{{w}} or {{w}}×{{l}}). With grain: elements requiring grain without rotation (h≤{{l}}, w≤{{w}})."
+    },
+    "tabs": {
+      "cab": "Kitchen",
+      "room": "Room",
+      "costs": "Costs",
+      "cut": "Cutlist"
+    },
+    "cabinetType": "Cabinet type",
+    "subcategories": "Subcategories ({{family}})",
+    "variant": "Variant"
+  },
+  "catalog": {
+    "choose": "Choose"
+  },
+  "room": {
+    "title": "Room — walls",
+    "height": "Height (mm)",
+    "wallLength": "Wall length (mm)",
+    "angle": "Angle (°)",
+    "addWall": "Add wall",
+    "addWindow": "Add window",
+    "addDoor": "Add door"
+  },
+  "global": {
+    "title": "Global settings",
+    "settings": "Settings — {{family}}",
+    "collapse": "Collapse",
+    "expand": "Expand",
+    "margin": "Margin (0–1)",
+    "labor": "Labor (PLN)",
+    "cut": "Cut (PLN/m)",
+    "pricing": "Pricing",
+    "height": "Height (mm)",
+    "depth": "Depth (mm)",
+    "boardType": "Board type",
+    "frontType": "Front type",
+    "backPanel": "Back",
+    "legs": "Legs",
+    "offsetWall": "Offset from wall (mm)",
+    "hanger": "Hangers",
+    "gapsTitle": "Gaps (mm)",
+    "gapLeft": "Left gap",
+    "gapRight": "Right gap",
+    "gapTop": "Top gap",
+    "gapBottom": "Bottom gap",
+    "gapBetween": "Gap between fronts"
+  },
+  "configurator": {
+    "title": "Configuration — {{variant}}",
+    "basic": "Basic",
+    "advanced": "Advanced",
+    "width": "Width (mm)",
+    "insertCabinet": "Insert cabinet",
+    "height": "Height (mm)",
+    "depth": "Depth (mm)",
+    "board": "Board",
+    "front": "Front",
+    "back": "Back",
+    "shelves": "Number of shelves",
+    "gapsTitle": "Gaps and front heights (set graphically)",
+    "backOptions": {
+      "full": "full",
+      "split": "split",
+      "none": "none"
+    },
+    "backToBasic": "← Basic"
+  },
+  "forms": {
+    "width": "Width",
+    "height": "Height",
+    "depth": "Depth"
+  },
+  "costs": {
+    "title": "Costs",
+    "table": {
+      "module": "Module",
+      "width": "Width (mm)",
+      "family": "Type",
+      "doors": "Doors",
+      "drawers": "Drawers",
+      "total": "Total (PLN)"
+    },
+    "summary": {
+      "item": "Item",
+      "amount": "Amount (PLN)",
+      "total": "Total"
+    }
+  },
+  "cutlist": {
+    "validation": "Validation for sheet {{width}}×{{height}}",
+    "sheets": "Sheets: {{sheets}}",
+    "warning": "Warning: part does not fit",
+    "grainInfo": {
+      "with": "Material has grain: elements requiring grain without rotation (h≤{{l}}, w≤{{w}}).",
+      "without": "Material without grain: rotation allowed for all elements."
+    },
+    "title": "Cutlist",
+    "exportCsv": "Export CSV — detailed",
+    "exportCsvAgg": "Export CSV — aggregated",
+    "exportPdf": "Export PDF",
+    "preview": "Preview (aggregated)",
+    "edge": "Edgebanding (ABS 1mm/2mm)",
+    "headers": {
+      "material": "Material",
+      "part": "Part",
+      "qty": "Qty",
+      "w": "W (mm)",
+      "h": "H (mm)",
+      "length": "Length (mm)",
+      "lengthMb": "Length (m)"
+    }
+  }
+}

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1,0 +1,20 @@
+import i18n from 'i18next';
+import { initReactI18next } from 'react-i18next';
+import en from './en.json';
+import pl from './pl.json';
+
+const saved = typeof window !== 'undefined' ? localStorage.getItem('lang') : 'pl';
+
+void i18n
+  .use(initReactI18next)
+  .init({
+    resources: {
+      en: { translation: en },
+      pl: { translation: pl }
+    },
+    lng: saved || 'pl',
+    fallbackLng: 'pl',
+    interpolation: { escapeValue: false }
+  });
+
+export default i18n;

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -1,0 +1,133 @@
+{
+  "app": {
+    "mode": "Tryb",
+    "roles": {
+      "stolarz": "Stolarz",
+      "klient": "Klient"
+    },
+    "resetSelection": "Reset wyboru",
+    "undo": "Cofnij",
+    "redo": "Ponów",
+    "clear": "Wyczyść",
+    "wallLabel": "Ściana {{num}} ({{len}} mm)",
+    "autoWall": "Auto pod ścianę",
+    "material": {
+      "title": "Materiał (arkusz)",
+      "boardHeight": "Wysokość arkusza L (mm)",
+      "boardWidth": "Szerokość arkusza W (mm)",
+      "kerf": "Kerf (mm)",
+      "grain": "Płyta ma usłojenie",
+      "info": "Bez usłojenia: formatki można obracać (muszą się zmieścić w {{l}}×{{w}} lub {{w}}×{{l}}). Z usłojeniem: elementy wymagające słojów bez rotacji (h≤{{l}}, w≤{{w}})."
+    },
+    "tabs": {
+      "cab": "Kuchnia",
+      "room": "Pomieszczenie",
+      "costs": "Koszty",
+      "cut": "Formatki"
+    },
+    "cabinetType": "Typ szafki",
+    "subcategories": "Podkategorie ({{family}})",
+    "variant": "Wariant"
+  },
+  "catalog": {
+    "choose": "Wybierz"
+  },
+  "room": {
+    "title": "Pomieszczenie — ściany",
+    "height": "Wysokość (mm)",
+    "wallLength": "Długość ściany (mm)",
+    "angle": "Kąt (°)",
+    "addWall": "Dodaj ścianę",
+    "addWindow": "Dodaj okno",
+    "addDoor": "Dodaj drzwi"
+  },
+  "global": {
+    "title": "Ustawienia ogólne",
+    "settings": "Ustawienia — {{family}}",
+    "collapse": "Zwiń",
+    "expand": "Rozwiń",
+    "margin": "Marża (0–1)",
+    "labor": "Robocizna (zł)",
+    "cut": "Cięcie (zł/mb)",
+    "pricing": "Cennik",
+    "height": "Wysokość (mm)",
+    "depth": "Głębokość (mm)",
+    "boardType": "Rodzaj płyty",
+    "frontType": "Rodzaj frontu",
+    "backPanel": "Plecy",
+    "legs": "Nóżki",
+    "offsetWall": "Odsunięcie od ściany (mm)",
+    "hanger": "Zawieszki",
+    "gapsTitle": "Szczeliny (mm)",
+    "gapLeft": "Szczelina lewa",
+    "gapRight": "Szczelina prawa",
+    "gapTop": "Szczelina górna",
+    "gapBottom": "Szczelina dolna",
+    "gapBetween": "Szczelina między frontami"
+  },
+  "configurator": {
+    "title": "Konfiguracja — {{variant}}",
+    "basic": "Podstawowe",
+    "advanced": "Zaawansowane",
+    "width": "Szerokość (mm)",
+    "insertCabinet": "Wstaw szafkę",
+    "height": "Wysokość (mm)",
+    "depth": "Głębokość (mm)",
+    "board": "Płyta",
+    "front": "Front",
+    "back": "Plecy",
+    "shelves": "Liczba półek",
+    "gapsTitle": "Szczeliny i wysokości frontów (ustawiaj graficznie)",
+    "backOptions": {
+      "full": "full",
+      "split": "split",
+      "none": "none"
+    },
+    "backToBasic": "← Podstawowe"
+  },
+  "forms": {
+    "width": "Szerokość",
+    "height": "Wysokość",
+    "depth": "Głębokość"
+  },
+  "costs": {
+    "title": "Koszty",
+    "table": {
+      "module": "Moduł",
+      "width": "Szer.(mm)",
+      "family": "Rodzaj",
+      "doors": "Drzwi",
+      "drawers": "Szufl.",
+      "total": "Razem (zł)"
+    },
+    "summary": {
+      "item": "Pozycja",
+      "amount": "Kwota (zł)",
+      "total": "Razem"
+    }
+  },
+  "cutlist": {
+    "validation": "Walidacja formatu {{width}}×{{height}}",
+    "sheets": "Arkusze: {{sheets}}",
+    "warning": "Uwaga: formatka nie mieści się",
+    "grainInfo": {
+      "with": "Materiał ma usłojenie: elementy wymagające słojów bez rotacji (h≤{{l}}, w≤{{w}}).",
+      "without": "Materiał bez usłojenia: rotacja dozwolona dla wszystkich elementów."
+    },
+    "title": "Formatki (rozkrój)",
+    "exportCsv": "Eksport CSV — szczegółowy",
+    "exportCsvAgg": "Eksport CSV — agregowany",
+    "exportPdf": "Eksport PDF",
+    "preview": "Podgląd (agregowany)",
+    "edge": "Okleina (ABS 1mm/2mm)",
+    "headers": {
+      "material": "Materiał",
+      "part": "Element",
+      "qty": "Ilość",
+      "w": "W (mm)",
+      "h": "H (mm)",
+      "length": "Długość (mm)",
+      "lengthMb": "Długość (mb)"
+    }
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,4 +2,6 @@ import React from 'react'
 import { createRoot } from 'react-dom/client'
 import App from './ui/App'
 import './styles.css'
+import './i18n'
+
 createRoot(document.getElementById('root')!).render(<App />)

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import useLocalStorageState from './hooks/useLocalStorageState'
 import { FAMILY, FAMILY_LABELS, Kind, Variant } from '../core/catalog'
 import { usePlannerStore } from '../state/store'
@@ -28,6 +29,9 @@ export default function App(){
   const [selWall, setSelWall] = useState(0)
   const [addCountertop] = useState(true)
   const threeRef = useRef<any>({})
+  const { t, i18n } = useTranslation()
+  const [lang, setLang] = useState(localStorage.getItem('lang') || i18n.language)
+  useEffect(() => { i18n.changeLanguage(lang); localStorage.setItem('lang', lang) }, [lang, i18n])
 
   const {
     cfgTab,
@@ -77,33 +81,37 @@ export default function App(){
       <div className="canvasWrap">
         <SceneViewer threeRef={threeRef} addCountertop={addCountertop} />
         <div className="topbar row">
-          <button className="btnGhost" onClick={()=>store.setRole(store.role==='stolarz'?'klient':'stolarz')}>Tryb: {store.role=='stolarz'?'Stolarz':'Klient'}</button>
-          <button className="btnGhost" onClick={()=>{ setVariant(null); setKind(null); }}>Reset wyboru</button>
-          <button className="btnGhost" onClick={()=>store.undo()} disabled={store.past.length===0}>Cofnij</button>
-          <button className="btnGhost" onClick={()=>store.redo()} disabled={store.future.length===0}>Ponów</button>
-          <button className="btnGhost" onClick={()=>store.clear()}>Wyczyść</button>
+          <button className="btnGhost" onClick={()=>store.setRole(store.role==='stolarz'?'klient':'stolarz')}>{t('app.mode')}: {t(`app.roles.${store.role}`)}</button>
+          <button className="btnGhost" onClick={()=>{ setVariant(null); setKind(null); }}>{t('app.resetSelection')}</button>
+          <button className="btnGhost" onClick={()=>store.undo()} disabled={store.past.length===0}>{t('app.undo')}</button>
+          <button className="btnGhost" onClick={()=>store.redo()} disabled={store.future.length===0}>{t('app.redo')}</button>
+          <button className="btnGhost" onClick={()=>store.clear()}>{t('app.clear')}</button>
           <select className="btnGhost" value={selWall} onChange={e=>setSelWall(Number((e.target as HTMLSelectElement).value)||0)}>
-            {getWallSegments().map((s,i)=> <option key={i} value={i}>Ściana {i+1} ({Math.round(s.length)} mm)</option>)}
+            {getWallSegments().map((s,i)=> <option key={i} value={i}>{t('app.wallLabel',{num:i+1,len:Math.round(s.length)})}</option>)}
           </select>
-          <button className="btn" onClick={doAutoOnSelectedWall}>Auto pod ścianę</button>
+          <button className="btn" onClick={doAutoOnSelectedWall}>{t('app.autoWall')}</button>
+          <select className="btnGhost" value={lang} onChange={e=>setLang((e.target as HTMLSelectElement).value)}>
+            <option value="pl">PL</option>
+            <option value="en">EN</option>
+          </select>
         </div>
       </div>
       <aside className="sidebar">
         <div className="section card">
           <div className="row" style={{ justifyContent:'space-between', alignItems:'center' }}>
-            <div className="h2">Materiał (arkusz)</div>
+            <div className="h2">{t('app.material.title')}</div>
           </div>
           <div style={{display:'grid', gridTemplateColumns:'repeat(4, minmax(120px, 1fr))', gap:12, marginTop:10}}>
             <div>
-              <div className="small">Wysokość arkusza L (mm)</div>
+              <div className="small">{t('app.material.boardHeight')}</div>
               <SingleMMInput value={boardL} onChange={v=>setBoardL(v)} max={4000} />
             </div>
             <div>
-              <div className="small">Szerokość arkusza W (mm)</div>
+              <div className="small">{t('app.material.boardWidth')}</div>
               <SingleMMInput value={boardW} onChange={v=>setBoardW(v)} max={4000} />
             </div>
             <div>
-              <div className="small">Kerf (mm)</div>
+              <div className="small">{t('app.material.kerf')}</div>
               <input className="input" type="number" min={0} max={10} step={0.1}
                     value={boardKerf}
                     onChange={e=>setBoardKerf(Math.max(0, Math.min(10, Number(e.target.value)||0)))} />
@@ -111,34 +119,33 @@ export default function App(){
             <div style={{display:'flex', alignItems:'end'}}>
               <label className="small" style={{display:'flex', gap:8, alignItems:'center'}}>
                 <input type="checkbox" checked={boardHasGrain} onChange={e=>setBoardHasGrain(e.target.checked)} />
-                Płyta ma usłojenie
+                {t('app.material.grain')}
               </label>
             </div>
           </div>
           <div className="tiny muted" style={{marginTop:6}}>
-            Bez usłojenia: formatki można obracać (muszą się zmieścić w {boardL}×{boardW} lub {boardW}×{boardL}).
-            Z usłojeniem: elementy wymagające słojów bez rotacji (h≤{boardL}, w≤{boardW}).
+            {t('app.material.info',{l:boardL,w:boardW})}
           </div>
         </div>
 
         <GlobalSettings />
 
         <div className="tabs">
-          <button className={`tabBtn ${tab==='cab'?'active':''}`} onClick={()=>setTab('cab')}>Kuchnia</button>
-          <button className={`tabBtn ${tab==='room'?'active':''}`} onClick={()=>setTab('room')}>Pomieszczenie</button>
-          <button className={`tabBtn ${tab==='costs'?'active':''}`} onClick={()=>setTab('costs')}>Koszty</button>
-          <button className={`tabBtn ${tab==='cut'?'active':''}`} onClick={()=>setTab('cut')}>Formatki</button>
+          <button className={`tabBtn ${tab==='cab'?'active':''}`} onClick={()=>setTab('cab')}>{t('app.tabs.cab')}</button>
+          <button className={`tabBtn ${tab==='room'?'active':''}`} onClick={()=>setTab('room')}>{t('app.tabs.room')}</button>
+          <button className={`tabBtn ${tab==='costs'?'active':''}`} onClick={()=>setTab('costs')}>{t('app.tabs.costs')}</button>
+          <button className={`tabBtn ${tab==='cut'?'active':''}`} onClick={()=>setTab('cut')}>{t('app.tabs.cut')}</button>
             {/* placeholder removed */}
         </div>
 
         {tab==='cab' && (<>
           <div>
-            <div className="h1">Typ szafki</div>
+            <div className="h1">{t('app.cabinetType')}</div>
               <TypePicker family={family} setFamily={(f: FAMILY)=>{ setFamily(f); setKind(null); setVariant(null); }} />
           </div>
 
           <div className="section">
-            <div className="hd"><div><div className="h1">Podkategorie ({FAMILY_LABELS[family]})</div></div></div>
+            <div className="hd"><div><div className="h1">{t('app.subcategories',{family:FAMILY_LABELS[family]})}</div></div></div>
             <div className="bd">
                 <KindTabs family={family} kind={kind} setKind={(k: Kind)=>{ setKind(k); setVariant(null); }} />
             </div>
@@ -146,7 +153,7 @@ export default function App(){
 
           {kind && (
             <div className="section">
-              <div className="hd"><div><div className="h1">Wariant</div></div></div>
+              <div className="hd"><div><div className="h1">{t('app.variant')}</div></div></div>
               <div className="bd">
                   <VariantList kind={kind} onPick={(v: Variant)=>{ setVariant(v); setCfgTab('basic'); }} />
               </div>

--- a/src/ui/CabinetConfigurator.tsx
+++ b/src/ui/CabinetConfigurator.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { useTranslation } from 'react-i18next'
 import { FAMILY, Kind, Variant } from '../core/catalog'
 import { usePlannerStore } from '../state/store'
 import TechDrawing from './components/TechDrawing'
@@ -32,13 +33,14 @@ const CabinetConfigurator: React.FC<Props> = ({
   onAdd
 }) => {
   const store = usePlannerStore()
+  const { t } = useTranslation()
   return (
     <div className="section">
       <div className="hd">
-        <div><div className="h1">Konfiguracja — {variant.label}</div></div>
+        <div><div className="h1">{t('configurator.title',{variant:variant.label})}</div></div>
         <div className="tabs">
-          <button className={`tabBtn ${cfgTab==='basic'?'active':''}`} onClick={()=>setCfgTab('basic')}>Podstawowe</button>
-          <button className={`tabBtn ${cfgTab==='adv'?'active':''}`} onClick={()=>setCfgTab('adv')}>Zaawansowane</button>
+          <button className={`tabBtn ${cfgTab==='basic'?'active':''}`} onClick={()=>setCfgTab('basic')}>{t('configurator.basic')}</button>
+          <button className={`tabBtn ${cfgTab==='adv'?'active':''}`} onClick={()=>setCfgTab('adv')}>{t('configurator.advanced')}</button>
         </div>
       </div>
       <div className="bd">
@@ -46,11 +48,11 @@ const CabinetConfigurator: React.FC<Props> = ({
           <div>
             <div className="grid2">
               <div>
-                <div className="small">Szerokość (mm)</div>
+                <div className="small">{t('configurator.width')}</div>
                 <input className="input" type="number" min={200} max={2400} step={1} value={widthMM} onChange={e=>setWidthMM(Number((e.target as HTMLInputElement).value)||0)} onKeyDown={(e)=>{ if (e.key==='Enter'){ const v = Number((e.target as HTMLInputElement).value)||0; if(v>0) onAdd(v, gLocal) } }} />
               </div>
               <div className="row" style={{alignItems:'flex-end'}}>
-                <button className="btn" onClick={()=>onAdd(widthMM, gLocal)}>Wstaw szafkę</button>
+                <button className="btn" onClick={()=>onAdd(widthMM, gLocal)}>{t('configurator.insertCabinet')}</button>
               </div>
             </div>
             <div style={{marginTop:8}}>
@@ -85,24 +87,24 @@ const CabinetConfigurator: React.FC<Props> = ({
         {cfgTab==='adv' && (
           <div>
             <div className="grid4">
-              <div><div className="small">Wysokość (mm)</div><input className="input" type="number" value={gLocal.height} onChange={e=>setAdv({...gLocal, height:Number((e.target as HTMLInputElement).value)||0})} /></div>
-              <div><div className="small">Głębokość (mm)</div><input className="input" type="number" value={gLocal.depth} onChange={e=>setAdv({...gLocal, depth:Number((e.target as HTMLInputElement).value)||0})} /></div>
-              <div><div className="small">Płyta</div><select className="input" value={gLocal.boardType} onChange={e=>setAdv({...gLocal, boardType:(e.target as HTMLSelectElement).value})}>{Object.keys(store.prices.board).map(k=><option key={k} value={k}>{k}</option>)}</select></div>
-              <div><div className="small">Front</div><select className="input" value={gLocal.frontType} onChange={e=>setAdv({...gLocal, frontType:(e.target as HTMLSelectElement).value})}>{Object.keys(store.prices.front).map(k=><option key={k} value={k}>{k}</option>)}</select></div>
-              <div><div className="small">Plecy</div><select className="input" value={gLocal.backPanel||'full'} onChange={e=>setAdv({...gLocal, backPanel:(e.target as HTMLSelectElement).value})}>
-                <option value="full">full</option>
-                <option value="split">split</option>
-                <option value="none">none</option>
+              <div><div className="small">{t('configurator.height')}</div><input className="input" type="number" value={gLocal.height} onChange={e=>setAdv({...gLocal, height:Number((e.target as HTMLInputElement).value)||0})} /></div>
+              <div><div className="small">{t('configurator.depth')}</div><input className="input" type="number" value={gLocal.depth} onChange={e=>setAdv({...gLocal, depth:Number((e.target as HTMLInputElement).value)||0})} /></div>
+              <div><div className="small">{t('configurator.board')}</div><select className="input" value={gLocal.boardType} onChange={e=>setAdv({...gLocal, boardType:(e.target as HTMLSelectElement).value})}>{Object.keys(store.prices.board).map(k=><option key={k} value={k}>{k}</option>)}</select></div>
+              <div><div className="small">{t('configurator.front')}</div><select className="input" value={gLocal.frontType} onChange={e=>setAdv({...gLocal, frontType:(e.target as HTMLSelectElement).value})}>{Object.keys(store.prices.front).map(k=><option key={k} value={k}>{k}</option>)}</select></div>
+              <div><div className="small">{t('configurator.back')}</div><select className="input" value={gLocal.backPanel||'full'} onChange={e=>setAdv({...gLocal, backPanel:(e.target as HTMLSelectElement).value})}>
+                <option value="full">{t('configurator.backOptions.full')}</option>
+                <option value="split">{t('configurator.backOptions.split')}</option>
+                <option value="none">{t('configurator.backOptions.none')}</option>
               </select></div>
             </div>
             {!(variant?.key?.startsWith('s')) && (
               <div style={{marginTop:8}}>
-                <div className="small">Liczba półek</div>
+                <div className="small">{t('configurator.shelves')}</div>
                 <input className="input" type="number" min={0} value={gLocal.shelves||0} onChange={e=>setAdv({...gLocal, shelves:Number((e.target as HTMLInputElement).value)||0})} />
               </div>
             )}
             <div style={{marginTop:8}}>
-              <div className="small">Szczeliny i wysokości frontów (ustawiaj graficznie)</div>
+              <div className="small">{t('configurator.gapsTitle')}</div>
               <TechDrawing
                 mode="edit"
                 family={family}
@@ -132,8 +134,8 @@ const CabinetConfigurator: React.FC<Props> = ({
               />
             </div>
             <div className="row" style={{marginTop:8}}>
-              <button className="btn" onClick={()=>onAdd(widthMM, gLocal)}>Wstaw szafkę</button>
-              <button className="btnGhost" onClick={()=>setCfgTab('basic')}>← Podstawowe</button>
+              <button className="btn" onClick={()=>onAdd(widthMM, gLocal)}>{t('configurator.insertCabinet')}</button>
+              <button className="btnGhost" onClick={()=>setCfgTab('basic')}>{t('configurator.backToBasic')}</button>
             </div>
           </div>
         )}

--- a/src/ui/forms/ApplianceCabinetForm.tsx
+++ b/src/ui/forms/ApplianceCabinetForm.tsx
@@ -1,15 +1,17 @@
 import React from 'react'
+import { useTranslation } from 'react-i18next'
 import SingleMMInput from '../components/SingleMMInput'
 import { CabinetFormValues, CabinetFormProps } from './CornerCabinetForm'
 
 export default function ApplianceCabinetForm({ values, onChange }: CabinetFormProps){
+  const { t } = useTranslation()
   const { width, height, depth, adv, hardware } = values
   const update = (patch: Partial<CabinetFormValues>) => onChange({ ...values, ...patch })
   return (
     <div>
-      <SingleMMInput label="Szerokość" value={width} onChange={w=>update({ width:w })} />
-      <SingleMMInput label="Wysokość" value={height} onChange={h=>update({ height:h })} />
-      <SingleMMInput label="Głębokość" value={depth} onChange={d=>update({ depth:d })} />
+      <SingleMMInput label={t('forms.width')} value={width} onChange={w=>update({ width:w })} />
+      <SingleMMInput label={t('forms.height')} value={height} onChange={h=>update({ height:h })} />
+      <SingleMMInput label={t('forms.depth')} value={depth} onChange={d=>update({ depth:d })} />
       {/* Appliance specific options such as appliance type could be configured elsewhere. */}
       {adv && <pre style={{ display:'none' }}>{JSON.stringify(adv)}</pre>}
       {hardware && <pre style={{ display:'none' }}>{JSON.stringify(hardware)}</pre>}

--- a/src/ui/forms/CargoCabinetForm.tsx
+++ b/src/ui/forms/CargoCabinetForm.tsx
@@ -1,15 +1,17 @@
 import React from 'react'
+import { useTranslation } from 'react-i18next'
 import SingleMMInput from '../components/SingleMMInput'
 import { CabinetFormValues, CabinetFormProps } from './CornerCabinetForm'
 
 export default function CargoCabinetForm({ values, onChange }: CabinetFormProps){
+  const { t } = useTranslation()
   const { width, height, depth, adv, hardware } = values
   const update = (patch: Partial<CabinetFormValues>) => onChange({ ...values, ...patch })
   return (
     <div>
-      <SingleMMInput label="Szerokość" value={width} onChange={w=>update({ width:w })} />
-      <SingleMMInput label="Wysokość" value={height} onChange={h=>update({ height:h })} />
-      <SingleMMInput label="Głębokość" value={depth} onChange={d=>update({ depth:d })} />
+      <SingleMMInput label={t('forms.width')} value={width} onChange={w=>update({ width:w })} />
+      <SingleMMInput label={t('forms.height')} value={height} onChange={h=>update({ height:h })} />
+      <SingleMMInput label={t('forms.depth')} value={depth} onChange={d=>update({ depth:d })} />
       {/* Cargo specific options such as basket count could be added here. */}
       {adv && <pre style={{ display:'none' }}>{JSON.stringify(adv)}</pre>}
       {hardware && <pre style={{ display:'none' }}>{JSON.stringify(hardware)}</pre>}

--- a/src/ui/forms/CornerCabinetForm.tsx
+++ b/src/ui/forms/CornerCabinetForm.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { useTranslation } from 'react-i18next'
 import SingleMMInput from '../components/SingleMMInput'
 
 export interface CabinetFormValues {
@@ -15,13 +16,14 @@ export interface CabinetFormProps {
 }
 
 export default function CornerCabinetForm({ values, onChange }: CabinetFormProps){
+  const { t } = useTranslation()
   const { width, height, depth, adv, hardware } = values
   const update = (patch: Partial<CabinetFormValues>) => onChange({ ...values, ...patch })
   return (
     <div>
-      <SingleMMInput label="Szerokość" value={width} onChange={w=>update({ width:w })} />
-      <SingleMMInput label="Wysokość" value={height} onChange={h=>update({ height:h })} />
-      <SingleMMInput label="Głębokość" value={depth} onChange={d=>update({ depth:d })} />
+      <SingleMMInput label={t('forms.width')} value={width} onChange={w=>update({ width:w })} />
+      <SingleMMInput label={t('forms.height')} value={height} onChange={h=>update({ height:h })} />
+      <SingleMMInput label={t('forms.depth')} value={depth} onChange={d=>update({ depth:d })} />
       {/* Advanced settings and hardware options are passed through unchanged */}
       {adv && <pre style={{ display:'none' }}>{JSON.stringify(adv)}</pre>}
       {hardware && <pre style={{ display:'none' }}>{JSON.stringify(hardware)}</pre>}

--- a/src/ui/forms/SinkCabinetForm.tsx
+++ b/src/ui/forms/SinkCabinetForm.tsx
@@ -1,15 +1,17 @@
 import React from 'react'
+import { useTranslation } from 'react-i18next'
 import SingleMMInput from '../components/SingleMMInput'
 import { CabinetFormValues, CabinetFormProps } from './CornerCabinetForm'
 
 export default function SinkCabinetForm({ values, onChange }: CabinetFormProps){
+  const { t } = useTranslation()
   const { width, height, depth, adv, hardware } = values
   const update = (patch: Partial<CabinetFormValues>) => onChange({ ...values, ...patch })
   return (
     <div>
-      <SingleMMInput label="Szerokość" value={width} onChange={w=>update({ width:w })} />
-      <SingleMMInput label="Wysokość" value={height} onChange={h=>update({ height:h })} />
-      <SingleMMInput label="Głębokość" value={depth} onChange={d=>update({ depth:d })} />
+      <SingleMMInput label={t('forms.width')} value={width} onChange={w=>update({ width:w })} />
+      <SingleMMInput label={t('forms.height')} value={height} onChange={h=>update({ height:h })} />
+      <SingleMMInput label={t('forms.depth')} value={depth} onChange={d=>update({ depth:d })} />
       {/* Sink specific advanced settings may include bowl size or position. */}
       {adv && <pre style={{ display:'none' }}>{JSON.stringify(adv)}</pre>}
       {hardware && <pre style={{ display:'none' }}>{JSON.stringify(hardware)}</pre>}

--- a/src/ui/panels/CatalogPicker.tsx
+++ b/src/ui/panels/CatalogPicker.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { useTranslation } from 'react-i18next'
 import { FAMILY, FAMILY_LABELS, FAMILY_COLORS, KIND_SETS, Kind, Variant } from '../../core/catalog'
 export default function TypePicker({ family, setFamily }:{ family:FAMILY; setFamily:(f:FAMILY)=>void }){
   return (
@@ -26,6 +27,7 @@ export function KindTabs({ family, kind, setKind }:{ family:FAMILY; kind:Kind|nu
   )
 }
 export function VariantList({ kind, onPick }:{ kind:Kind|null; onPick:(v:Variant)=>void }){
+  const { t } = useTranslation()
   const variants = (kind?.variants||[])
   return (
     <div className="list">
@@ -33,7 +35,7 @@ export function VariantList({ kind, onPick }:{ kind:Kind|null; onPick:(v:Variant
         <div key={v.key} className="card">
           <div style={{fontWeight:700}}>{v.label}</div>
           <div className="row">
-            <button className="btn" onClick={()=>onPick(v)}>Wybierz</button>
+            <button className="btn" onClick={()=>onPick(v)}>{t('catalog.choose')}</button>
           </div>
         </div>
       ))}

--- a/src/ui/panels/CostsTab.tsx
+++ b/src/ui/panels/CostsTab.tsx
@@ -1,8 +1,10 @@
 import React from 'react'
+import { useTranslation } from 'react-i18next'
 import { usePlannerStore } from '../../state/store'
 
 export default function CostsTab(){
   const store = usePlannerStore()
+  const { t } = useTranslation()
   const totals = store.modules.reduce((acc,m:any)=>{
     const p = m.price?.parts||{}
     for (const k of Object.keys(p)){
@@ -13,10 +15,10 @@ export default function CostsTab(){
   }, { total:0 } as any)
   return (
     <div className="section">
-      <div className="hd"><div><div className="h1">Koszty</div></div></div>
+      <div className="hd"><div><div className="h1">{t('costs.title')}</div></div></div>
       <div className="bd">
         <table className="table" style={{marginBottom:12}}>
-          <thead><tr><th>Moduł</th><th>Szer.(mm)</th><th>Rodzaj</th><th>Drzwi</th><th>Szufl.</th><th>Razem (zł)</th></tr></thead>
+          <thead><tr><th>{t('costs.table.module')}</th><th>{t('costs.table.width')}</th><th>{t('costs.table.family')}</th><th>{t('costs.table.doors')}</th><th>{t('costs.table.drawers')}</th><th>{t('costs.table.total')}</th></tr></thead>
         <tbody>
           {store.modules.map((m:any)=> (
             <tr key={m.id}>
@@ -31,10 +33,10 @@ export default function CostsTab(){
         </tbody>
         </table>
         <table className="table">
-          <thead><tr><th>Pozycja</th><th>Kwota (zł)</th></tr></thead>
+          <thead><tr><th>{t('costs.summary.item')}</th><th>{t('costs.summary.amount')}</th></tr></thead>
           <tbody>
             {Object.entries(totals).filter(([k])=>k!=='total').map(([k,v])=> <tr key={k}><td>{k}</td><td>{(v as number).toLocaleString('pl-PL')}</td></tr>)}
-            <tr><td><b>Razem</b></td><td><b>{(totals.total||0).toLocaleString('pl-PL')} zł</b></td></tr>
+            <tr><td><b>{t('costs.summary.total')}</b></td><td><b>{(totals.total||0).toLocaleString('pl-PL')} zł</b></td></tr>
           </tbody>
         </table>
       </div>

--- a/src/ui/panels/CutlistTab.tsx
+++ b/src/ui/panels/CutlistTab.tsx
@@ -1,6 +1,7 @@
 import { validateParts, type Part } from '../../core/format'
 import MultiMaterialPreview from '../components/MultiMaterialPreview'
 import React, { useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
 import { usePlannerStore } from '../../state/store'
 import { cutlistForModule, aggregateCutlist, toCSV, aggregateEdgebanding } from '../../core/cutlist'
 import jsPDF from 'jspdf'
@@ -8,6 +9,7 @@ import useLocalStorageState from '../hooks/useLocalStorageState'
 
 export default function CutlistTab(){
   const store = usePlannerStore()
+  const { t } = useTranslation()
   const detailedPack = useMemo(()=> store.modules.map(m=>cutlistForModule(m, store.globals)), [store.modules, store.globals])
   const detailed = useMemo(()=> detailedPack.flatMap(p=>p.items), [detailedPack])
   const edgeAll = useMemo(()=> detailedPack.flatMap(p=>p.edges), [detailedPack])
@@ -28,16 +30,16 @@ export default function CutlistTab(){
     const doc = new jsPDF({ unit:'mm', format:'a4' })
     let y = 12
     const line = (txt:string) => { doc.text(txt, 12, y); y+=6; if (y>280){ doc.addPage(); y=12 } }
-    doc.setFontSize(14); line('Lista formatek — szczegółowa (z frontami i szufladami)')
-    doc.setFontSize(10); line('Moduł | Materiał | Element | Ilość | W (mm) | H (mm)')
+    doc.setFontSize(14); line(t('cutlist.title') + ' — ' + t('cutlist.exportCsv'))
+    doc.setFontSize(10); line(t('costs.table.module') + ' | ' + t('cutlist.headers.material') + ' | ' + t('cutlist.headers.part') + ' | ' + t('cutlist.headers.qty') + ' | ' + t('cutlist.headers.w') + ' | ' + t('cutlist.headers.h'))
     detailed.forEach(it=> line(`${it.moduleLabel} (${it.moduleId}) | ${it.material} | ${it.part} | ${it.qty} | ${it.w} | ${it.h}`))
     doc.addPage(); y=12
-    doc.setFontSize(14); line('Lista formatek — agregowana')
-    doc.setFontSize(10); line('Materiał | Element | Ilość | W (mm) | H (mm)')
+    doc.setFontSize(14); line(t('cutlist.preview'))
+    doc.setFontSize(10); line(t('cutlist.headers.material') + ' | ' + t('cutlist.headers.part') + ' | ' + t('cutlist.headers.qty') + ' | ' + t('cutlist.headers.w') + ' | ' + t('cutlist.headers.h'))
     aggregated.forEach(it=> line(`${it.material} | ${it.part} | ${it.qty} | ${it.w} | ${it.h}`))
     doc.addPage(); y=12
-    doc.setFontSize(14); line('Okleina — podsumowanie')
-    doc.setFontSize(10); line('Materiał | Długość (mm) | Długość (mb)')
+    doc.setFontSize(14); line(t('cutlist.edge'))
+    doc.setFontSize(10); line(t('cutlist.headers.material') + ' | ' + t('cutlist.headers.length') + ' | ' + t('cutlist.headers.lengthMb'))
     edgeAgg.forEach(e=> line(`${e.material} | ${Math.round(e.length)} | ${(e.length/1000).toFixed(2)}`))
     doc.save('cutlist.pdf')
   }
@@ -69,36 +71,36 @@ return (
 <div className="section">
       <div className={`card ${plan.ok ? '' : 'danger'}`} style={{ marginBottom: 8 }}>
         <div className="row" style={{ justifyContent:'space-between', alignItems:'baseline' }}>
-          <div className="h2">Walidacja formatu {board.W}×{board.L}</div>
-          <div className="small">{ plan.ok ? `Arkusze: ${plan.sheets}` : 'Uwaga: formatka nie mieści się' }</div>
+          <div className="h2">{t('cutlist.validation',{width:board.W,height:board.L})}</div>
+          <div className="small">{ plan.ok ? t('cutlist.sheets',{sheets:plan.sheets}) : t('cutlist.warning') }</div>
         </div>
         <div className="small">
           { board.hasGrain
-            ? 'Materiał ma usłojenie: elementy wymagające słojów bez rotacji (h≤L, w≤W).'
-            : 'Materiał bez usłojenia: rotacja dozwolona dla wszystkich elementów.' }
+            ? t('cutlist.grainInfo.with',{l:board.L,w:board.W})
+            : t('cutlist.grainInfo.without') }
         </div>
         { !plan.ok && <div className="small" style={{marginTop:4}}>{plan.reason}</div> }
       </div>
 
       <MultiMaterialPreview L={board.L} W={board.W} kerf={board.kerf} hasGrain={board.hasGrain} items={items} />
 
-      <div className="hd"><div><div className="h1">Formatki (rozkrój)</div></div></div>
+      <div className="hd"><div><div className="h1">{t('cutlist.title')}</div></div></div>
       <div className="bd">
         <div className="row" style={{marginBottom:8}}>
-          <button className="btn" onClick={exportCSV}>Eksport CSV — szczegółowy</button>
-          <button className="btnGhost" onClick={exportCSVagg}>Eksport CSV — agregowany</button>
-          <button className="btnGhost" onClick={exportPDF}>Eksport PDF</button>
+          <button className="btn" onClick={exportCSV}>{t('cutlist.exportCsv')}</button>
+          <button className="btnGhost" onClick={exportCSVagg}>{t('cutlist.exportCsvAgg')}</button>
+          <button className="btnGhost" onClick={exportPDF}>{t('cutlist.exportPdf')}</button>
         </div>
-        <div className="h1" style={{margin:'8px 0'}}>Podgląd (agregowany)</div>
+        <div className="h1" style={{margin:'8px 0'}}>{t('cutlist.preview')}</div>
         <table className="table" style={{marginBottom:12}}>
-          <thead><tr><th>Materiał</th><th>Element</th><th>Ilość</th><th>W (mm)</th><th>H (mm)</th></tr></thead>
+          <thead><tr><th>{t('cutlist.headers.material')}</th><th>{t('cutlist.headers.part')}</th><th>{t('cutlist.headers.qty')}</th><th>{t('cutlist.headers.w')}</th><th>{t('cutlist.headers.h')}</th></tr></thead>
           <tbody>
             {aggregated.map((it,i)=> <tr key={i}><td>{it.material}</td><td>{it.part}</td><td>{it.qty}</td><td>{it.w}</td><td>{it.h}</td></tr>)}
           </tbody>
         </table>
-        <div className="h1" style={{margin:'8px 0'}}>Okleina (ABS 1mm/2mm)</div>
+        <div className="h1" style={{margin:'8px 0'}}>{t('cutlist.edge')}</div>
         <table className="table">
-          <thead><tr><th>Materiał</th><th>Długość (mm)</th><th>Długość (mb)</th></tr></thead>
+          <thead><tr><th>{t('cutlist.headers.material')}</th><th>{t('cutlist.headers.length')}</th><th>{t('cutlist.headers.lengthMb')}</th></tr></thead>
           <tbody>
             {edgeAgg.map((e,i)=> <tr key={i}><td>{e.material}</td><td>{Math.round(e.length)}</td><td>{(e.length/1000).toFixed(2)}</td></tr>)}
           </tbody>

--- a/src/ui/panels/GlobalSettings.tsx
+++ b/src/ui/panels/GlobalSettings.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { usePlannerStore } from '../../state/store'
 import { FAMILY } from '../../core/catalog'
 
@@ -6,6 +7,7 @@ const FamList = [FAMILY.BASE, FAMILY.WALL, FAMILY.PAWLACZ, FAMILY.TALL]
 
 export default function GlobalSettings(){
   const store = usePlannerStore()
+  const { t } = useTranslation()
   const [open, setOpen] = useState(false)
   const [openFam, setOpenFam] = useState(FAMILY.BASE)
 
@@ -26,33 +28,33 @@ export default function GlobalSettings(){
     return (
       <div className="section" style={{marginTop:8}}>
         <div className="hd" onClick={()=>setOpenFam(prev=> prev===fam ? null : fam)}>
-          <div><div className="h1">Ustawienia — {fam}</div></div>
-          <button className="btnGhost">{isOpen?'Zwiń':'Rozwiń'}</button>
+          <div><div className="h1">{t('global.settings',{family:fam})}</div></div>
+          <button className="btnGhost">{isOpen?t('global.collapse'):t('global.expand')}</button>
         </div>
         {isOpen && <div className="bd">
           <div className="grid3">
-            <Field label="Wysokość (mm)" value={g.height} onChange={(v)=>set({height:v})} />
-            <Field label="Głębokość (mm)" value={g.depth} onChange={(v)=>set({depth:v})} />
-            <Field label="Rodzaj płyty" type="select" value={g.boardType} onChange={(v)=>set({boardType:v})} options={Object.keys(store.prices.board)} />
-            <Field label="Rodzaj frontu" type="select" value={g.frontType} onChange={(v)=>set({frontType:v})} options={Object.keys(store.prices.front)} />
-            <Field label="Plecy" type="select" value={g.backPanel||'full'} onChange={(v)=>set({backPanel:v})} options={['full','split','none']} />
+            <Field label={t('global.height')} value={g.height} onChange={(v)=>set({height:v})} />
+            <Field label={t('global.depth')} value={g.depth} onChange={(v)=>set({depth:v})} />
+            <Field label={t('global.boardType')} type="select" value={g.boardType} onChange={(v)=>set({boardType:v})} options={Object.keys(store.prices.board)} />
+            <Field label={t('global.frontType')} type="select" value={g.frontType} onChange={(v)=>set({frontType:v})} options={Object.keys(store.prices.front)} />
+            <Field label={t('global.backPanel')} type="select" value={g.backPanel||'full'} onChange={(v)=>set({backPanel:v})} options={['full','split','none']} />
             {fam===FAMILY.BASE && (<>
-              <Field label="Nóżki" type="select" value={g.legsType} onChange={(v)=>set({legsType:v})} options={Object.keys(store.prices.legs)} />
-              <Field label="Odsunięcie od ściany (mm)" value={g.offsetWall||0} onChange={(v)=>set({offsetWall:v})} />
+              <Field label={t('global.legs')} type="select" value={g.legsType} onChange={(v)=>set({legsType:v})} options={Object.keys(store.prices.legs)} />
+              <Field label={t('global.offsetWall')} value={g.offsetWall||0} onChange={(v)=>set({offsetWall:v})} />
             </>)}
             {(fam===FAMILY.WALL || fam===FAMILY.PAWLACZ) && (<>
-              <Field label="Zawieszki" type="select" value={g.hangerType} onChange={(v)=>set({hangerType:v})} options={Object.keys(store.prices.hangers)} />
-              <Field label="Odsunięcie od ściany (mm)" value={g.offsetWall||0} onChange={(v)=>set({offsetWall:v})} />
+              <Field label={t('global.hanger')} type="select" value={g.hangerType} onChange={(v)=>set({hangerType:v})} options={Object.keys(store.prices.hangers)} />
+              <Field label={t('global.offsetWall')} value={g.offsetWall||0} onChange={(v)=>set({offsetWall:v})} />
             </>)}
           </div>
           <div style={{marginTop:8}}>
-            <div className="h1" style={{fontSize:14, marginBottom:6}}>Szczeliny (mm)</div>
+            <div className="h1" style={{fontSize:14, marginBottom:6}}>{t('global.gapsTitle')}</div>
             <div className="grid3">
-              <Field label="Szczelina lewa" value={g.gaps.left} onChange={(v)=>set({ gaps:{ ...g.gaps, left:v } })} step="0.5" />
-              <Field label="Szczelina prawa" value={g.gaps.right} onChange={(v)=>set({ gaps:{ ...g.gaps, right:v } })} step="0.5" />
-              <Field label="Szczelina górna" value={g.gaps.top} onChange={(v)=>set({ gaps:{ ...g.gaps, top:v } })} step="0.5" />
-              <Field label="Szczelina dolna" value={g.gaps.bottom} onChange={(v)=>set({ gaps:{ ...g.gaps, bottom:v } })} step="0.5" />
-              <Field label="Szczelina między frontami" value={g.gaps.between} onChange={(v)=>set({ gaps:{ ...g.gaps, between:v } })} step="0.5" />
+              <Field label={t('global.gapLeft')} value={g.gaps.left} onChange={(v)=>set({ gaps:{ ...g.gaps, left:v } })} step="0.5" />
+              <Field label={t('global.gapRight')} value={g.gaps.right} onChange={(v)=>set({ gaps:{ ...g.gaps, right:v } })} step="0.5" />
+              <Field label={t('global.gapTop')} value={g.gaps.top} onChange={(v)=>set({ gaps:{ ...g.gaps, top:v } })} step="0.5" />
+              <Field label={t('global.gapBottom')} value={g.gaps.bottom} onChange={(v)=>set({ gaps:{ ...g.gaps, bottom:v } })} step="0.5" />
+              <Field label={t('global.gapBetween')} value={g.gaps.between} onChange={(v)=>set({ gaps:{ ...g.gaps, between:v } })} step="0.5" />
             </div>
           </div>
         </div>}
@@ -63,17 +65,17 @@ export default function GlobalSettings(){
   return (
     <div className="section">
       <div className="hd" onClick={()=>setOpen(o=>!o)}>
-        <div><div className="h1">Ustawienia ogólne</div></div>
-        <button className="btnGhost">{open?'Zwiń':'Rozwiń'}</button>
+        <div><div className="h1">{t('global.title')}</div></div>
+        <button className="btnGhost">{open?t('global.collapse'):t('global.expand')}</button>
       </div>
       {open && <div className="bd">
         {FamList.map(f=><SectionGroup key={f} fam={f} />)}
         <div className="section" style={{marginTop:8}}>
-          <div className="hd"><div className="h1">Cennik</div></div>
+          <div className="hd"><div className="h1">{t('global.pricing')}</div></div>
           <div className="bd grid3">
-            <div><div className="small">Marża (0–1)</div><input className="input" type="number" step="0.01" value={store.prices.margin} onChange={e=>store.updatePrices({margin: Math.max(0,Math.min(1, Number((e.target as HTMLInputElement).value)||0))})}/></div>
-            <div><div className="small">Robocizna (zł)</div><input className="input" type="number" step="1" value={store.prices.labor} onChange={e=>store.updatePrices({labor: Number((e.target as HTMLInputElement).value)||0})}/></div>
-            <div><div className="small">Cięcie (zł/mb)</div><input className="input" type="number" step="0.1" value={store.prices.cut} onChange={e=>store.updatePrices({cut: Number((e.target as HTMLInputElement).value)||0})}/></div>
+            <div><div className="small">{t('global.margin')}</div><input className="input" type="number" step="0.01" value={store.prices.margin} onChange={e=>store.updatePrices({margin: Math.max(0,Math.min(1, Number((e.target as HTMLInputElement).value)||0))})}/></div>
+            <div><div className="small">{t('global.labor')}</div><input className="input" type="number" step="1" value={store.prices.labor} onChange={e=>store.updatePrices({labor: Number((e.target as HTMLInputElement).value)||0})}/></div>
+            <div><div className="small">{t('global.cut')}</div><input className="input" type="number" step="0.1" value={store.prices.cut} onChange={e=>store.updatePrices({cut: Number((e.target as HTMLInputElement).value)||0})}/></div>
           </div>
         </div>
       </div>}

--- a/src/ui/panels/RoomTab.tsx
+++ b/src/ui/panels/RoomTab.tsx
@@ -1,8 +1,10 @@
 import React, { useEffect, useState } from 'react'
 import * as THREE from 'three'
+import { useTranslation } from 'react-i18next'
 import { usePlannerStore } from '../../state/store'
 export default function RoomTab({ three }:{ three: React.MutableRefObject<any> }){
   const store = usePlannerStore()
+  const { t } = useTranslation()
   const [len, setLen] = useState(3000)
   const [angle, setAngle] = useState(0)
   const [height, setHeight] = useState(store.room.height||2700)
@@ -31,26 +33,26 @@ export default function RoomTab({ three }:{ three: React.MutableRefObject<any> }
   const addDoor = () => store.addOpening({ type:'door', wall:0, offset:100, width:900, height:2100 })
   return (
     <div className="section">
-      <div className="hd"><div><div className="h1">Pomieszczenie — ściany</div></div></div>
+      <div className="hd"><div><div className="h1">{t('room.title')}</div></div></div>
       <div className="bd">
         <div className="grid3">
           <div>
-            <div className="small">Wysokość (mm)</div>
+            <div className="small">{t('room.height')}</div>
             <input className="input" type="number" step="1" value={height} onChange={e=>setHeight(Number((e.target as HTMLInputElement).value)||0)} />
           </div>
           <div>
-            <div className="small">Długość ściany (mm)</div>
+            <div className="small">{t('room.wallLength')}</div>
             <input className="input" type="number" step="1" value={len} onChange={e=>setLen(Number((e.target as HTMLInputElement).value)||0)} />
           </div>
           <div>
-            <div className="small">Kąt (°)</div>
+            <div className="small">{t('room.angle')}</div>
             <input className="input" type="number" step="1" value={angle} onChange={e=>setAngle(Number((e.target as HTMLInputElement).value)||0)} />
           </div>
         </div>
         <div className="row" style={{marginTop:8}}>
-          <button className="btn" onClick={addWall}>Dodaj ścianę</button>
-          <button className="btnGhost" onClick={addWindow}>Dodaj okno</button>
-          <button className="btnGhost" onClick={addDoor}>Dodaj drzwi</button>
+          <button className="btn" onClick={addWall}>{t('room.addWall')}</button>
+          <button className="btnGhost" onClick={addWindow}>{t('room.addWindow')}</button>
+          <button className="btnGhost" onClick={addDoor}>{t('room.addDoor')}</button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- integrate i18next with English and Polish translations
- replace hardcoded UI strings with translation keys
- add language switcher storing preference in localStorage

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b23e289e5c832289802ddd8975b29e