### PR TITLE
feat: separate legs height in globals

### DIFF
--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -5,10 +5,49 @@ import { Module3D, Room, Globals, Prices, Opening, Gaps } from '../types'
 export const defaultGaps: Gaps = { left:2, right:2, top:2, bottom:2, between:3 }
 
 export const defaultGlobal: Globals = {
-  [FAMILY.BASE]: { height:800, depth:600, boardType:'Płyta 18mm', frontType:'Laminat', gaps:{...defaultGaps}, legsType:'Standard 10cm', offsetWall:30, shelves:1, backPanel:'full' },
-  [FAMILY.WALL]: { height:720, depth:320, boardType:'Płyta 18mm', frontType:'Laminat', gaps:{...defaultGaps}, hangerType:'Standard', offsetWall:20, shelves:1, backPanel:'full' },
-  [FAMILY.PAWLACZ]: { height:400, depth:600, boardType:'Płyta 18mm', frontType:'Laminat', gaps:{...defaultGaps}, hangerType:'Wzmocnione', offsetWall:30, shelves:1, backPanel:'full' },
-  [FAMILY.TALL]: { height:2100, depth:600, boardType:'Płyta 18mm', frontType:'Laminat', gaps:{...defaultGaps}, shelves:4, backPanel:'full' }
+  [FAMILY.BASE]: {
+    height:800,
+    depth:600,
+    boardType:'Płyta 18mm',
+    frontType:'Laminat',
+    gaps:{...defaultGaps},
+    legsType:'Standard 10cm',
+    legsHeight:100,
+    offsetWall:30,
+    shelves:1,
+    backPanel:'full'
+  },
+  [FAMILY.WALL]: {
+    height:720,
+    depth:320,
+    boardType:'Płyta 18mm',
+    frontType:'Laminat',
+    gaps:{...defaultGaps},
+    hangerType:'Standard',
+    offsetWall:20,
+    shelves:1,
+    backPanel:'full'
+  },
+  [FAMILY.PAWLACZ]: {
+    height:400,
+    depth:600,
+    boardType:'Płyta 18mm',
+    frontType:'Laminat',
+    gaps:{...defaultGaps},
+    hangerType:'Wzmocnione',
+    offsetWall:30,
+    shelves:1,
+    backPanel:'full'
+  },
+  [FAMILY.TALL]: {
+    height:2100,
+    depth:600,
+    boardType:'Płyta 18mm',
+    frontType:'Laminat',
+    gaps:{...defaultGaps},
+    shelves:4,
+    backPanel:'full'
+  }
 }
 
 export const defaultPrices: Prices = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,7 @@ export interface GlobalsItem {
   frontType:string
   gaps: Gaps
   legsType?:string
+  legsHeight?:number
   hangerType?:string
   offsetWall?:number
   shelves?:number

--- a/src/ui/SceneViewer.tsx
+++ b/src/ui/SceneViewer.tsx
@@ -20,12 +20,11 @@ interface Props {
   addCountertop: boolean
 }
 
-const getLegHeight = (mod: Module3D, globals: Globals): number => {
+export const getLegHeight = (mod: Module3D, globals: Globals): number => {
   if (mod.family !== FAMILY.BASE) return 0
   const famGlobal = globals[mod.family]
-  const label: string = famGlobal?.legsType || ''
-  const match = label.match(/(\d+\.?\d*)/)
-  if (match) return parseFloat(match[1]) / 100
+  const legHeight = famGlobal?.legsHeight
+  if (typeof legHeight === 'number') return legHeight / 1000
   return 0.1
 }
 

--- a/src/ui/panels/GlobalSettings.tsx
+++ b/src/ui/panels/GlobalSettings.tsx
@@ -37,7 +37,17 @@ export default function GlobalSettings(){
             <Field label="Rodzaj frontu" type="select" value={g.frontType} onChange={(v)=>set({frontType:v})} options={Object.keys(store.prices.front)} />
             <Field label="Plecy" type="select" value={g.backPanel||'full'} onChange={(v)=>set({backPanel:v})} options={['full','split','none']} />
             {fam===FAMILY.BASE && (<>
-              <Field label="Nóżki" type="select" value={g.legsType} onChange={(v)=>set({legsType:v})} options={Object.keys(store.prices.legs)} />
+              <Field
+                label="Nóżki"
+                type="select"
+                value={g.legsType}
+                onChange={(v)=>{
+                  const m = v.match(/(\d+)/)
+                  set({ legsType:v, legsHeight: m ? Number(m[1])*10 : g.legsHeight })
+                }}
+                options={Object.keys(store.prices.legs)}
+              />
+              <Field label="Wysokość nóżek (mm)" value={g.legsHeight||0} onChange={(v)=>set({legsHeight:v})} />
               <Field label="Odsunięcie od ściany (mm)" value={g.offsetWall||0} onChange={(v)=>set({offsetWall:v})} />
             </>)}
             {(fam===FAMILY.WALL || fam===FAMILY.PAWLACZ) && (<>

--- a/tests/getLegHeight.test.ts
+++ b/tests/getLegHeight.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest'
+import { getLegHeight } from '../src/ui/SceneViewer'
+import { FAMILY } from '../src/core/catalog'
+import type { Module3D, Globals } from '../src/types'
+
+describe('getLegHeight', () => {
+  it('uses legsHeight from globals for base modules', () => {
+    const mod: Module3D = {
+      id: '1',
+      label: 'test',
+      family: FAMILY.BASE,
+      kind: 'x',
+      size: { w: 1, h: 1, d: 1 },
+      position: [0, 0, 0]
+    }
+    const globals: Globals = {
+      [FAMILY.BASE]: {
+        height: 800,
+        depth: 600,
+        boardType: '',
+        frontType: '',
+        gaps: { left:0, right:0, top:0, bottom:0, between:0 },
+        legsType: 'Standard 12cm',
+        legsHeight: 120
+      },
+      [FAMILY.WALL]: { height:0, depth:0, boardType:'', frontType:'', gaps:{ left:0, right:0, top:0, bottom:0, between:0 } },
+      [FAMILY.PAWLACZ]: { height:0, depth:0, boardType:'', frontType:'', gaps:{ left:0, right:0, top:0, bottom:0, between:0 } },
+      [FAMILY.TALL]: { height:0, depth:0, boardType:'', frontType:'', gaps:{ left:0, right:0, top:0, bottom:0, between:0 } }
+    }
+    expect(getLegHeight(mod, globals)).toBe(0.12)
+  })
+
+  it('returns 0 for non-base modules', () => {
+    const mod: Module3D = {
+      id: '2',
+      label: 'test',
+      family: FAMILY.WALL,
+      kind: 'x',
+      size: { w: 1, h: 1, d: 1 },
+      position: [0, 0, 0]
+    }
+    const globals: Globals = {
+      [FAMILY.BASE]: {
+        height: 800,
+        depth: 600,
+        boardType: '',
+        frontType: '',
+        gaps: { left:0, right:0, top:0, bottom:0, between:0 },
+        legsType: 'Standard 10cm',
+        legsHeight: 100
+      },
+      [FAMILY.WALL]: { height:0, depth:0, boardType:'', frontType:'', gaps:{ left:0, right:0, top:0, bottom:0, between:0 } },
+      [FAMILY.PAWLACZ]: { height:0, depth:0, boardType:'', frontType:'', gaps:{ left:0, right:0, top:0, bottom:0, between:0 } },
+      [FAMILY.TALL]: { height:0, depth:0, boardType:'', frontType:'', gaps:{ left:0, right:0, top:0, bottom:0, between:0 } }
+    }
+    expect(getLegHeight(mod, globals)).toBe(0)
+  })
+})


### PR DESCRIPTION
## Summary
- track base cabinet leg height in new `legsHeight` field
- update global settings UI and `getLegHeight` helper
- cover leg height handling with unit tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b23e29c57083229db9139ee806c478