### PR TITLE
refactor: extract app UI sections

### DIFF
--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react'
+import React, { useEffect, useMemo, useRef, useState } from 'react'
 import useLocalStorageState from './hooks/useLocalStorageState'
 import { FAMILY, FAMILY_LABELS, Kind, Variant } from '../core/catalog'
 import { usePlannerStore } from '../state/store'
@@ -14,6 +14,7 @@ import { CabinetConfig } from './types'
 import TopBar from './components/TopBar'
 import SheetSettingsPanel from './components/SheetSettingsPanel'
 import MainTabs from './components/MainTabs'
+import { createTranslator, Lang } from './i18n'
 
 export default function App(){
   const [boardL, setBoardL] = useLocalStorageState<number>('boardL', 2800)
@@ -29,6 +30,9 @@ export default function App(){
   const [selWall, setSelWall] = useState(0)
   const [addCountertop] = useState(true)
   const threeRef = useRef<any>({})
+
+  const [lang, setLang] = useLocalStorageState<Lang>('lang', 'pl')
+  const t = useMemo(() => createTranslator(lang), [lang])
 
   const {
     cfgTab,
@@ -77,14 +81,32 @@ export default function App(){
     <div className="app">
       <div className="canvasWrap">
         <SceneViewer threeRef={threeRef} addCountertop={addCountertop} />
-        <TopBar selWall={selWall} setSelWall={setSelWall} onResetSelection={()=>{ setVariant(null); setKind(null); }} doAutoOnSelectedWall={doAutoOnSelectedWall} />
+        <TopBar
+          selWall={selWall}
+          setSelWall={setSelWall}
+          onResetSelection={() => { setVariant(null); setKind(null); }}
+          doAutoOnSelectedWall={doAutoOnSelectedWall}
+          lang={lang}
+          setLang={setLang}
+          t={t}
+        />
       </div>
       <aside className="sidebar">
-        <SheetSettingsPanel boardL={boardL} boardW={boardW} boardKerf={boardKerf} boardHasGrain={boardHasGrain} setBoardL={setBoardL} setBoardW={setBoardW} setBoardKerf={setBoardKerf} setBoardHasGrain={setBoardHasGrain} />
+        <SheetSettingsPanel
+          boardL={boardL}
+          boardW={boardW}
+          boardKerf={boardKerf}
+          boardHasGrain={boardHasGrain}
+          setBoardL={setBoardL}
+          setBoardW={setBoardW}
+          setBoardKerf={setBoardKerf}
+          setBoardHasGrain={setBoardHasGrain}
+          t={t}
+        />
 
         <GlobalSettings />
 
-        <MainTabs tab={tab} setTab={setTab} />
+        <MainTabs tab={tab} setTab={setTab} t={t} />
 
         {tab==='cab' && (<>
           <div>

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -6,13 +6,14 @@ import GlobalSettings from './panels/GlobalSettings'
 import RoomTab from './panels/RoomTab'
 import CostsTab from './panels/CostsTab'
 import TypePicker, { KindTabs, VariantList } from './panels/CatalogPicker'
-import { getWallSegments } from '../utils/walls'
 import CutlistTab from './panels/CutlistTab'
-import SingleMMInput from './components/SingleMMInput'
 import SceneViewer from './SceneViewer'
 import CabinetConfigurator from './CabinetConfigurator'
 import useCabinetConfig from './useCabinetConfig'
 import { CabinetConfig } from './types'
+import TopBar from './components/TopBar'
+import SheetSettingsPanel from './components/SheetSettingsPanel'
+import MainTabs from './components/MainTabs'
 
 export default function App(){
   const [boardL, setBoardL] = useLocalStorageState<number>('boardL', 2800)
@@ -76,60 +77,14 @@ export default function App(){
     <div className="app">
       <div className="canvasWrap">
         <SceneViewer threeRef={threeRef} addCountertop={addCountertop} />
-        <div className="topbar row">
-          <button className="btnGhost" onClick={()=>store.setRole(store.role==='stolarz'?'klient':'stolarz')}>Tryb: {store.role=='stolarz'?'Stolarz':'Klient'}</button>
-          <button className="btnGhost" onClick={()=>{ setVariant(null); setKind(null); }}>Reset wyboru</button>
-          <button className="btnGhost" onClick={()=>store.undo()} disabled={store.past.length===0}>Cofnij</button>
-          <button className="btnGhost" onClick={()=>store.redo()} disabled={store.future.length===0}>Ponów</button>
-          <button className="btnGhost" onClick={()=>store.clear()}>Wyczyść</button>
-          <select className="btnGhost" value={selWall} onChange={e=>setSelWall(Number((e.target as HTMLSelectElement).value)||0)}>
-            {getWallSegments().map((s,i)=> <option key={i} value={i}>Ściana {i+1} ({Math.round(s.length)} mm)</option>)}
-          </select>
-          <button className="btn" onClick={doAutoOnSelectedWall}>Auto pod ścianę</button>
-        </div>
+        <TopBar selWall={selWall} setSelWall={setSelWall} onResetSelection={()=>{ setVariant(null); setKind(null); }} doAutoOnSelectedWall={doAutoOnSelectedWall} />
       </div>
       <aside className="sidebar">
-        <div className="section card">
-          <div className="row" style={{ justifyContent:'space-between', alignItems:'center' }}>
-            <div className="h2">Materiał (arkusz)</div>
-          </div>
-          <div style={{display:'grid', gridTemplateColumns:'repeat(4, minmax(120px, 1fr))', gap:12, marginTop:10}}>
-            <div>
-              <div className="small">Wysokość arkusza L (mm)</div>
-              <SingleMMInput value={boardL} onChange={v=>setBoardL(v)} max={4000} />
-            </div>
-            <div>
-              <div className="small">Szerokość arkusza W (mm)</div>
-              <SingleMMInput value={boardW} onChange={v=>setBoardW(v)} max={4000} />
-            </div>
-            <div>
-              <div className="small">Kerf (mm)</div>
-              <input className="input" type="number" min={0} max={10} step={0.1}
-                    value={boardKerf}
-                    onChange={e=>setBoardKerf(Math.max(0, Math.min(10, Number(e.target.value)||0)))} />
-            </div>
-            <div style={{display:'flex', alignItems:'end'}}>
-              <label className="small" style={{display:'flex', gap:8, alignItems:'center'}}>
-                <input type="checkbox" checked={boardHasGrain} onChange={e=>setBoardHasGrain(e.target.checked)} />
-                Płyta ma usłojenie
-              </label>
-            </div>
-          </div>
-          <div className="tiny muted" style={{marginTop:6}}>
-            Bez usłojenia: formatki można obracać (muszą się zmieścić w {boardL}×{boardW} lub {boardW}×{boardL}).
-            Z usłojeniem: elementy wymagające słojów bez rotacji (h≤{boardL}, w≤{boardW}).
-          </div>
-        </div>
+        <SheetSettingsPanel boardL={boardL} boardW={boardW} boardKerf={boardKerf} boardHasGrain={boardHasGrain} setBoardL={setBoardL} setBoardW={setBoardW} setBoardKerf={setBoardKerf} setBoardHasGrain={setBoardHasGrain} />
 
         <GlobalSettings />
 
-        <div className="tabs">
-          <button className={`tabBtn ${tab==='cab'?'active':''}`} onClick={()=>setTab('cab')}>Kuchnia</button>
-          <button className={`tabBtn ${tab==='room'?'active':''}`} onClick={()=>setTab('room')}>Pomieszczenie</button>
-          <button className={`tabBtn ${tab==='costs'?'active':''}`} onClick={()=>setTab('costs')}>Koszty</button>
-          <button className={`tabBtn ${tab==='cut'?'active':''}`} onClick={()=>setTab('cut')}>Formatki</button>
-            {/* placeholder removed */}
-        </div>
+        <MainTabs tab={tab} setTab={setTab} />
 
         {tab==='cab' && (<>
           <div>

--- a/src/ui/components/MainTabs.tsx
+++ b/src/ui/components/MainTabs.tsx
@@ -1,0 +1,19 @@
+import React from 'react'
+
+type Tab = 'cab' | 'room' | 'costs' | 'cut'
+
+type Props = {
+  tab: Tab
+  setTab: (t:Tab)=>void
+}
+
+export default function MainTabs({ tab, setTab }: Props){
+  return (
+    <div className="tabs">
+      <button className={`tabBtn ${tab==='cab'?'active':''}`} onClick={()=>setTab('cab')}>Kuchnia</button>
+      <button className={`tabBtn ${tab==='room'?'active':''}`} onClick={()=>setTab('room')}>Pomieszczenie</button>
+      <button className={`tabBtn ${tab==='costs'?'active':''}`} onClick={()=>setTab('costs')}>Koszty</button>
+      <button className={`tabBtn ${tab==='cut'?'active':''}`} onClick={()=>setTab('cut')}>Formatki</button>
+    </div>
+  )
+}

--- a/src/ui/components/MainTabs.tsx
+++ b/src/ui/components/MainTabs.tsx
@@ -5,15 +5,16 @@ type Tab = 'cab' | 'room' | 'costs' | 'cut'
 type Props = {
   tab: Tab
   setTab: (t:Tab)=>void
+  t: (key: string, vars?: Record<string, any>) => string
 }
 
-export default function MainTabs({ tab, setTab }: Props){
+export default function MainTabs({ tab, setTab, t }: Props){
   return (
     <div className="tabs">
-      <button className={`tabBtn ${tab==='cab'?'active':''}`} onClick={()=>setTab('cab')}>Kuchnia</button>
-      <button className={`tabBtn ${tab==='room'?'active':''}`} onClick={()=>setTab('room')}>Pomieszczenie</button>
-      <button className={`tabBtn ${tab==='costs'?'active':''}`} onClick={()=>setTab('costs')}>Koszty</button>
-      <button className={`tabBtn ${tab==='cut'?'active':''}`} onClick={()=>setTab('cut')}>Formatki</button>
+      <button className={`tabBtn ${tab==='cab'?'active':''}`} onClick={()=>setTab('cab')}>{t('app.tabs.cab')}</button>
+      <button className={`tabBtn ${tab==='room'?'active':''}`} onClick={()=>setTab('room')}>{t('app.tabs.room')}</button>
+      <button className={`tabBtn ${tab==='costs'?'active':''}`} onClick={()=>setTab('costs')}>{t('app.tabs.costs')}</button>
+      <button className={`tabBtn ${tab==='cut'?'active':''}`} onClick={()=>setTab('cut')}>{t('app.tabs.cut')}</button>
     </div>
   )
 }

--- a/src/ui/components/SheetSettingsPanel.tsx
+++ b/src/ui/components/SheetSettingsPanel.tsx
@@ -1,0 +1,58 @@
+import React from 'react'
+import SingleMMInput from './SingleMMInput'
+
+type Props = {
+  boardL: number
+  boardW: number
+  boardKerf: number
+  boardHasGrain: boolean
+  setBoardL: (n:number)=>void
+  setBoardW: (n:number)=>void
+  setBoardKerf: (n:number)=>void
+  setBoardHasGrain: (v:boolean)=>void
+}
+
+export default function SheetSettingsPanel({
+  boardL,
+  boardW,
+  boardKerf,
+  boardHasGrain,
+  setBoardL,
+  setBoardW,
+  setBoardKerf,
+  setBoardHasGrain,
+}: Props){
+  return (
+    <div className="section card">
+      <div className="row" style={{ justifyContent:'space-between', alignItems:'center' }}>
+        <div className="h2">Materiał (arkusz)</div>
+      </div>
+      <div style={{display:'grid', gridTemplateColumns:'repeat(4, minmax(120px, 1fr))', gap:12, marginTop:10}}>
+        <div>
+          <div className="small">Wysokość arkusza L (mm)</div>
+          <SingleMMInput value={boardL} onChange={v=>setBoardL(v)} max={4000} />
+        </div>
+        <div>
+          <div className="small">Szerokość arkusza W (mm)</div>
+          <SingleMMInput value={boardW} onChange={v=>setBoardW(v)} max={4000} />
+        </div>
+        <div>
+          <div className="small">Kerf (mm)</div>
+          <input className="input" type="number" min={0} max={10} step={0.1}
+                 value={boardKerf}
+                 onChange={e=>setBoardKerf(Math.max(0, Math.min(10, Number(e.target.value)||0)))} />
+        </div>
+        <div style={{display:'flex', alignItems:'end'}}>
+          <label className="small" style={{display:'flex', gap:8, alignItems:'center'}}>
+            <input type="checkbox" checked={boardHasGrain} onChange={e=>setBoardHasGrain(e.target.checked)} />
+            Płyta ma usłojenie
+          </label>
+        </div>
+      </div>
+      <div className="tiny muted" style={{marginTop:6}}>
+        Bez usłojenia: formatki można obracać (muszą się zmieścić w {boardL}×{boardW} lub {boardW}×{boardL}).
+        Z usłojeniem: elementy wymagające słojów bez rotacji (h≤{boardL}, w≤{boardW}).
+      </div>
+    </div>
+  )
+}

--- a/src/ui/components/SheetSettingsPanel.tsx
+++ b/src/ui/components/SheetSettingsPanel.tsx
@@ -10,6 +10,7 @@ type Props = {
   setBoardW: (n:number)=>void
   setBoardKerf: (n:number)=>void
   setBoardHasGrain: (v:boolean)=>void
+  t: (key: string, vars?: Record<string, any>) => string
 }
 
 export default function SheetSettingsPanel({
@@ -21,23 +22,24 @@ export default function SheetSettingsPanel({
   setBoardW,
   setBoardKerf,
   setBoardHasGrain,
+  t,
 }: Props){
   return (
     <div className="section card">
       <div className="row" style={{ justifyContent:'space-between', alignItems:'center' }}>
-        <div className="h2">Materiał (arkusz)</div>
+        <div className="h2">{t('app.material.title')}</div>
       </div>
       <div style={{display:'grid', gridTemplateColumns:'repeat(4, minmax(120px, 1fr))', gap:12, marginTop:10}}>
         <div>
-          <div className="small">Wysokość arkusza L (mm)</div>
+          <div className="small">{t('app.material.boardHeight')}</div>
           <SingleMMInput value={boardL} onChange={v=>setBoardL(v)} max={4000} />
         </div>
         <div>
-          <div className="small">Szerokość arkusza W (mm)</div>
+          <div className="small">{t('app.material.boardWidth')}</div>
           <SingleMMInput value={boardW} onChange={v=>setBoardW(v)} max={4000} />
         </div>
         <div>
-          <div className="small">Kerf (mm)</div>
+          <div className="small">{t('app.material.kerf')}</div>
           <input className="input" type="number" min={0} max={10} step={0.1}
                  value={boardKerf}
                  onChange={e=>setBoardKerf(Math.max(0, Math.min(10, Number(e.target.value)||0)))} />
@@ -45,13 +47,12 @@ export default function SheetSettingsPanel({
         <div style={{display:'flex', alignItems:'end'}}>
           <label className="small" style={{display:'flex', gap:8, alignItems:'center'}}>
             <input type="checkbox" checked={boardHasGrain} onChange={e=>setBoardHasGrain(e.target.checked)} />
-            Płyta ma usłojenie
+            {t('app.material.grain')}
           </label>
         </div>
       </div>
       <div className="tiny muted" style={{marginTop:6}}>
-        Bez usłojenia: formatki można obracać (muszą się zmieścić w {boardL}×{boardW} lub {boardW}×{boardL}).
-        Z usłojeniem: elementy wymagające słojów bez rotacji (h≤{boardL}, w≤{boardW}).
+        {t('app.material.info', { l: boardL, w: boardW })}
       </div>
     </div>
   )

--- a/src/ui/components/TopBar.tsx
+++ b/src/ui/components/TopBar.tsx
@@ -1,0 +1,30 @@
+import React from 'react'
+import { usePlannerStore } from '../../state/store'
+import { getWallSegments } from '../../utils/walls'
+
+type Props = {
+  selWall: number
+  setSelWall: (n:number)=>void
+  onResetSelection: () => void
+  doAutoOnSelectedWall: () => void
+}
+
+export default function TopBar({ selWall, setSelWall, onResetSelection, doAutoOnSelectedWall }: Props){
+  const store = usePlannerStore()
+
+  return (
+    <div className="topbar row">
+      <button className="btnGhost" onClick={()=>store.setRole(store.role==='stolarz'?'klient':'stolarz')}>
+        Tryb: {store.role==='stolarz'?'Stolarz':'Klient'}
+      </button>
+      <button className="btnGhost" onClick={onResetSelection}>Reset wyboru</button>
+      <button className="btnGhost" onClick={()=>store.undo()} disabled={store.past.length===0}>Cofnij</button>
+      <button className="btnGhost" onClick={()=>store.redo()} disabled={store.future.length===0}>Ponów</button>
+      <button className="btnGhost" onClick={()=>store.clear()}>Wyczyść</button>
+      <select className="btnGhost" value={selWall} onChange={e=>setSelWall(Number((e.target as HTMLSelectElement).value)||0)}>
+        {getWallSegments().map((s,i)=> <option key={i} value={i}>Ściana {i+1} ({Math.round(s.length)} mm)</option>)}
+      </select>
+      <button className="btn" onClick={doAutoOnSelectedWall}>Auto pod ścianę</button>
+    </div>
+  )
+}

--- a/src/ui/components/TopBar.tsx
+++ b/src/ui/components/TopBar.tsx
@@ -1,30 +1,50 @@
 import React from 'react'
 import { usePlannerStore } from '../../state/store'
 import { getWallSegments } from '../../utils/walls'
+import { Lang } from '../i18n'
 
 type Props = {
   selWall: number
-  setSelWall: (n:number)=>void
+  setSelWall: (n: number) => void
   onResetSelection: () => void
   doAutoOnSelectedWall: () => void
+  lang: Lang
+  setLang: (l: Lang) => void
+  t: (key: string, vars?: Record<string, any>) => string
 }
 
-export default function TopBar({ selWall, setSelWall, onResetSelection, doAutoOnSelectedWall }: Props){
+export default function TopBar({
+  selWall,
+  setSelWall,
+  onResetSelection,
+  doAutoOnSelectedWall,
+  lang,
+  setLang,
+  t,
+}: Props){
   const store = usePlannerStore()
 
   return (
     <div className="topbar row">
       <button className="btnGhost" onClick={()=>store.setRole(store.role==='stolarz'?'klient':'stolarz')}>
-        Tryb: {store.role==='stolarz'?'Stolarz':'Klient'}
+        {t('app.mode')}: {t(`app.roles.${store.role}`)}
       </button>
-      <button className="btnGhost" onClick={onResetSelection}>Reset wyboru</button>
-      <button className="btnGhost" onClick={()=>store.undo()} disabled={store.past.length===0}>Cofnij</button>
-      <button className="btnGhost" onClick={()=>store.redo()} disabled={store.future.length===0}>Ponów</button>
-      <button className="btnGhost" onClick={()=>store.clear()}>Wyczyść</button>
+      <button className="btnGhost" onClick={onResetSelection}>{t('app.resetSelection')}</button>
+      <button className="btnGhost" onClick={()=>store.undo()} disabled={store.past.length===0}>{t('app.undo')}</button>
+      <button className="btnGhost" onClick={()=>store.redo()} disabled={store.future.length===0}>{t('app.redo')}</button>
+      <button className="btnGhost" onClick={()=>store.clear()}>{t('app.clear')}</button>
       <select className="btnGhost" value={selWall} onChange={e=>setSelWall(Number((e.target as HTMLSelectElement).value)||0)}>
-        {getWallSegments().map((s,i)=> <option key={i} value={i}>Ściana {i+1} ({Math.round(s.length)} mm)</option>)}
+        {getWallSegments().map((s,i)=> (
+          <option key={i} value={i}>
+            {t('app.wallLabel', { num: i+1, len: Math.round(s.length) })}
+          </option>
+        ))}
       </select>
-      <button className="btn" onClick={doAutoOnSelectedWall}>Auto pod ścianę</button>
+      <button className="btn" onClick={doAutoOnSelectedWall}>{t('app.autoWall')}</button>
+      <select className="btnGhost" value={lang} onChange={e=>setLang((e.target as HTMLSelectElement).value as Lang)}>
+        <option value="pl">PL</option>
+        <option value="en">EN</option>
+      </select>
     </div>
   )
 }

--- a/src/ui/i18n.ts
+++ b/src/ui/i18n.ts
@@ -1,0 +1,53 @@
+export type Lang = 'pl' | 'en'
+
+const translations: Record<Lang, Record<string, string>> = {
+  pl: {
+    'app.mode': 'Tryb',
+    'app.roles.stolarz': 'Stolarz',
+    'app.roles.klient': 'Klient',
+    'app.resetSelection': 'Reset wyboru',
+    'app.undo': 'Cofnij',
+    'app.redo': 'Ponów',
+    'app.clear': 'Wyczyść',
+    'app.wallLabel': 'Ściana {{num}} ({{len}} mm)',
+    'app.autoWall': 'Auto pod ścianę',
+    'app.material.title': 'Materiał (arkusz)',
+    'app.material.boardHeight': 'Wysokość arkusza L (mm)',
+    'app.material.boardWidth': 'Szerokość arkusza W (mm)',
+    'app.material.kerf': 'Kerf (mm)',
+    'app.material.grain': 'Płyta ma usłojenie',
+    'app.material.info': 'Bez usłojenia: formatki można obracać (muszą się zmieścić w {{l}}×{{w}} lub {{w}}×{{l}}). Z usłojeniem: elementy wymagające słojów bez rotacji (h≤{{l}}, w≤{{w}}).',
+    'app.tabs.cab': 'Kuchnia',
+    'app.tabs.room': 'Pomieszczenie',
+    'app.tabs.costs': 'Koszty',
+    'app.tabs.cut': 'Formatki'
+  },
+  en: {
+    'app.mode': 'Mode',
+    'app.roles.stolarz': 'Carpenter',
+    'app.roles.klient': 'Client',
+    'app.resetSelection': 'Reset selection',
+    'app.undo': 'Undo',
+    'app.redo': 'Redo',
+    'app.clear': 'Clear',
+    'app.wallLabel': 'Wall {{num}} ({{len}} mm)',
+    'app.autoWall': 'Auto wall',
+    'app.material.title': 'Material (sheet)',
+    'app.material.boardHeight': 'Board height L (mm)',
+    'app.material.boardWidth': 'Board width W (mm)',
+    'app.material.kerf': 'Kerf (mm)',
+    'app.material.grain': 'Board has grain',
+    'app.material.info': 'Without grain: parts may rotate (must fit within {{l}}×{{w}} or {{w}}×{{l}}). With grain: parts requiring grain must not rotate (h≤{{l}}, w≤{{w}}).',
+    'app.tabs.cab': 'Cabinets',
+    'app.tabs.room': 'Room',
+    'app.tabs.costs': 'Costs',
+    'app.tabs.cut': 'Cut list'
+  }
+}
+
+export function createTranslator(lang: Lang){
+  return (key: string, vars: Record<string, any> = {}) => {
+    const template = translations[lang]?.[key] ?? key
+    return template.replace(/\{\{(\w+)\}\}/g, (_, v) => String(vars[v] ?? ''))
+  }
+}


### PR DESCRIPTION
## Summary
- move top toolbar, sheet settings panel, and main tabs into dedicated components
- streamline App imports to reflect new structure

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b23e2b40d883228377c7f917a3b6fd