### PR TITLE
chore: localize ui strings

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -11,6 +11,7 @@
     "clear": "Clear",
     "wallLabel": "Wall {{num}} ({{len}} mm)",
     "autoWall": "Auto for wall",
+    "auto": "Auto",
     "material": {
       "title": "Material (sheet)",
       "boardHeight": "Sheet height L (mm)",
@@ -39,7 +40,8 @@
     "angle": "Angle (°)",
     "addWall": "Add wall",
     "addWindow": "Add window",
-    "addDoor": "Add door"
+    "addDoor": "Add door",
+    "noWalls": "No walls"
   },
   "global": {
     "title": "Global settings",
@@ -104,7 +106,8 @@
       "item": "Item",
       "amount": "Amount (PLN)",
       "total": "Total"
-    }
+    },
+    "currency": "PLN"
   },
   "cutlist": {
     "validation": "Validation for sheet {{width}}×{{height}}",
@@ -128,6 +131,19 @@
       "h": "H (mm)",
       "length": "Length (mm)",
       "lengthMb": "Length (m)"
+    },
+    "sheetPreview": {
+      "title": "Sheet preview {{W}}×{{L}} mm",
+      "count": "Number of sheets: {{count}}",
+      "sheetLabel": "Sheet {{index}}",
+      "note": "Preview arrangement (strip nesting). Full optimizer to be added later."
+    },
+    "multiMaterialPreview": {
+      "title": "Cut preview — grouped by material",
+      "count": "Sheets: {{count}}",
+      "sheetLabel": "Sheet {{index}}",
+      "legend": "Legend:",
+      "note": "\"Guillotine\" heuristic (preview). Full nesting will be added later."
     }
   }
 }

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -11,6 +11,7 @@
     "clear": "Wyczyść",
     "wallLabel": "Ściana {{num}} ({{len}} mm)",
     "autoWall": "Auto pod ścianę",
+    "auto": "Auto",
     "material": {
       "title": "Materiał (arkusz)",
       "boardHeight": "Wysokość arkusza L (mm)",
@@ -39,7 +40,8 @@
     "angle": "Kąt (°)",
     "addWall": "Dodaj ścianę",
     "addWindow": "Dodaj okno",
-    "addDoor": "Dodaj drzwi"
+    "addDoor": "Dodaj drzwi",
+    "noWalls": "Brak ścian"
   },
   "global": {
     "title": "Ustawienia ogólne",
@@ -104,7 +106,8 @@
       "item": "Pozycja",
       "amount": "Kwota (zł)",
       "total": "Razem"
-    }
+    },
+    "currency": "zł"
   },
   "cutlist": {
     "validation": "Walidacja formatu {{width}}×{{height}}",
@@ -128,6 +131,19 @@
       "h": "H (mm)",
       "length": "Długość (mm)",
       "lengthMb": "Długość (mb)"
+    },
+    "sheetPreview": {
+      "title": "Podgląd arkuszy {{W}}×{{L}} mm",
+      "count": "Liczba arkuszy: {{count}}",
+      "sheetLabel": "Arkusz {{index}}",
+      "note": "Rozmieszczenie poglądowe (strip nesting). Pełny optimizer wdrożymy później."
+    },
+    "multiMaterialPreview": {
+      "title": "Podgląd rozkroju — grupowanie wg materiału",
+      "count": "Arkuszy: {{count}}",
+      "sheetLabel": "Arkusz {{index}}",
+      "legend": "Legenda:",
+      "note": "Heurystyka \"guillotine\" (poglądowa). Dokładny nesting dodamy później."
     }
   }
 }

--- a/src/ui/components/MultiMaterialPreview.tsx
+++ b/src/ui/components/MultiMaterialPreview.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { useTranslation } from 'react-i18next'
 import { packByMaterial, type Part, type Board } from '../../core/format'
 
 type Agg = { w:number, h:number, part?:string, material?:string, qty?:number, requireGrain?:boolean }
@@ -8,6 +9,7 @@ type Props = {
 }
 
 export default function MultiMaterialPreview({ L, W, kerf, hasGrain, items }: Props){
+  const { t } = useTranslation()
   const board: Board = { L, W, kerf, hasGrain }
   // przygotuj listę części wraz z wymaganiem usłojenia
   const parts: (Part & {material?:string})[] = items.map((r, idx)=> ({
@@ -22,20 +24,20 @@ export default function MultiMaterialPreview({ L, W, kerf, hasGrain, items }: Pr
 
   return (
     <div className="card" style={{padding:8}}>
-      <div className="h2" style={{marginBottom:8}}>Podgląd rozkroju — grupowanie wg materiału</div>
+      <div className="h2" style={{marginBottom:8}}>{t('cutlist.multiMaterialPreview.title')}</div>
       <div style={{display:'grid', gap:16}}>
         {groups.map((g, gi)=> (
           <div key={gi} className="card" style={{padding:8}}>
             <div className="row" style={{justifyContent:'space-between', alignItems:'baseline'}}>
               <div className="h2">{g.material}</div>
-              <div className="small">Arkuszy: {g.sheets.length}</div>
+              <div className="small">{t('cutlist.multiMaterialPreview.count', { count: g.sheets.length })}</div>
             </div>
             <div style={{display:'grid', gap:12}}>
               {g.sheets.map((s:any)=>{
                 const vb = `0 0 ${W} ${L}`
                 return (
                   <div key={s.index} className="card" style={{padding:6}}>
-                    <div className="small" style={{marginBottom:6}}>Arkusz {s.index}</div>
+                    <div className="small" style={{marginBottom:6}}>{t('cutlist.multiMaterialPreview.sheetLabel', { index: s.index })}</div>
                     <svg viewBox={vb} width="100%" style={{maxHeight:380, border:'1px solid #e5e7eb', background:'#fff'}}>
                       {/* definicje wzorów do wizualizacji usłojenia */}
                       <defs>
@@ -72,7 +74,7 @@ export default function MultiMaterialPreview({ L, W, kerf, hasGrain, items }: Pr
                       })}
                     </svg>
                     <div className="tiny muted" style={{marginTop:6}}>
-                      Legenda:
+                      {t('cutlist.multiMaterialPreview.legend')}
                       <span> </span>
                       {s.placed.map((p:any,i:number)=> (
                         <span key={i} style={{marginRight:10}}>#{p.idx ?? (i+1)} {p.name}</span>
@@ -85,7 +87,7 @@ export default function MultiMaterialPreview({ L, W, kerf, hasGrain, items }: Pr
           </div>
         ))}
       </div>
-      <div className="tiny muted" style={{marginTop:6}}>Heurystyka „guillotine” (poglądowa). Dokładny nesting dodamy później.</div>
+      <div className="tiny muted" style={{marginTop:6}}>{t('cutlist.multiMaterialPreview.note')}</div>
     </div>
   )
 }

--- a/src/ui/components/SheetPreview.tsx
+++ b/src/ui/components/SheetPreview.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { useTranslation } from 'react-i18next'
 import { packIntoSheets, type Part, type Board } from '../../core/format'
 
 type Agg = { w:number, h:number, part?:string, material?:string, qty?:number, requireGrain?:boolean }
@@ -8,6 +9,7 @@ type Props = {
 }
 
 export default function SheetPreview({ L, W, kerf, hasGrain, items }: Props){
+  const { t } = useTranslation()
   const board: Board = { L, W, kerf, hasGrain }
   const parts: Part[] = items.map((r, idx)=> ({
     w: Math.round(r.w||0),
@@ -21,15 +23,15 @@ export default function SheetPreview({ L, W, kerf, hasGrain, items }: Props){
   return (
     <div className="card" style={{padding:8}}>
       <div className="row" style={{justifyContent:'space-between', alignItems:'baseline'}}>
-        <div className="h2">Podgląd arkuszy {W}×{L} mm</div>
-        <div className="small">Liczba arkuszy: {sheets.length}</div>
+        <div className="h2">{t('cutlist.sheetPreview.title', { W, L })}</div>
+        <div className="small">{t('cutlist.sheetPreview.count', { count: sheets.length })}</div>
       </div>
       <div style={{display:'grid', gap:12}}>
         {sheets.map((s)=>{
           const vb = `0 0 ${W} ${L}`
           return (
             <div key={s.index} className="card" style={{padding:6}}>
-              <div className="small" style={{marginBottom:6}}>Arkusz {s.index}</div>
+              <div className="small" style={{marginBottom:6}}>{t('cutlist.sheetPreview.sheetLabel', { index: s.index })}</div>
               <svg viewBox={vb} width="100%" style={{maxHeight:360, border:'1px solid #e5e7eb', background:'#fff'}}>
                 <rect x={0} y={0} width={W} height={L} fill="#fafafa" stroke="#94a3b8" />
                 {s.placed.map((p,i)=> (
@@ -44,7 +46,7 @@ export default function SheetPreview({ L, W, kerf, hasGrain, items }: Props){
           )
         })}
       </div>
-      <div className="tiny muted" style={{marginTop:6}}>Rozmieszczenie poglądowe (strip nesting). Pełny optimizer wdrożymy później.</div>
+      <div className="tiny muted" style={{marginTop:6}}>{t('cutlist.sheetPreview.note')}</div>
     </div>
   )
 }

--- a/src/ui/panels/CostsTab.tsx
+++ b/src/ui/panels/CostsTab.tsx
@@ -36,7 +36,7 @@ export default function CostsTab(){
           <thead><tr><th>{t('costs.summary.item')}</th><th>{t('costs.summary.amount')}</th></tr></thead>
           <tbody>
             {Object.entries(totals).filter(([k])=>k!=='total').map(([k,v])=> <tr key={k}><td>{k}</td><td>{(v as number).toLocaleString('pl-PL')}</td></tr>)}
-            <tr><td><b>{t('costs.summary.total')}</b></td><td><b>{(totals.total||0).toLocaleString('pl-PL')} zł</b></td></tr>
+            <tr><td><b>{t('costs.summary.total')}</b></td><td><b>{(totals.total||0).toLocaleString('pl-PL')} {t('costs.currency')}</b></td></tr>
           </tbody>
         </table>
       </div>

--- a/src/ui/useCabinetConfig.ts
+++ b/src/ui/useCabinetConfig.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
 import { FAMILY, Kind, Variant, KIND_SETS } from '../core/catalog';
 import { computeModuleCost } from '../core/pricing';
 import { usePlannerStore } from '../state/store';
@@ -18,6 +19,7 @@ export function useCabinetConfig(
   const [cfgTab, setCfgTab] = useState<'basic' | 'adv'>('basic');
   const [widthMM, setWidthMM] = useState(600);
   const [adv, setAdvState] = useState<CabinetConfig | null>(null);
+  const { t } = useTranslation();
 
   useEffect(() => {
     const g = store.globals[family];
@@ -213,7 +215,7 @@ export function useCabinetConfig(
 
   const doAutoOnSelectedWall = () => {
     const segs = getWallSegments();
-    if (segs.length === 0) return alert('Brak ścian');
+    if (segs.length === 0) return alert(t('room.noWalls'));
     const seg = segs[0 + (selWall % segs.length)];
     const len = seg.length;
     const widths = autoWidthsForRun(len);
@@ -244,7 +246,7 @@ export function useCabinetConfig(
       );
       let mod: Module3D = {
         id,
-        label: 'Auto',
+        label: t('app.auto'),
         family,
         kind: KIND_SETS[family][0]?.key || 'doors',
         size: { w, h, d },


### PR DESCRIPTION
## Summary
- internationalize cabinet configuration warnings
- replace hardcoded preview texts with translations
- add currency symbol to translation files

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b25ff767fc8322ab37137d59298850