### PR TITLE
feat: add configurable leg height

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -58,6 +58,7 @@
     "frontType": "Front type",
     "backPanel": "Back",
     "legs": "Legs",
+    "legsHeight": "Leg height (mm)",
     "offsetWall": "Offset from wall (mm)",
     "hanger": "Hangers",
     "gapsTitle": "Gaps (mm)",

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -58,6 +58,7 @@
     "frontType": "Rodzaj frontu",
     "backPanel": "Plecy",
     "legs": "Nóżki",
+    "legsHeight": "Wysokość nóżek (mm)",
     "offsetWall": "Odsunięcie od ściany (mm)",
     "hanger": "Zawieszki",
     "gapsTitle": "Szczeliny (mm)",

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -18,6 +18,7 @@ export const defaultGlobal: Globals = {
     frontType: 'Laminat',
     gaps: { ...defaultGaps },
     legsType: 'Standard 10cm',
+    legsHeight: 100,
     offsetWall: 30,
     shelves: 1,
     backPanel: 'full',

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,7 @@ export interface GlobalsItem {
   frontType:string
   gaps: Gaps
   legsType?:string
+  legsHeight?:number
   hangerType?:string
   offsetWall?:number
   shelves?:number

--- a/src/ui/SceneViewer.tsx
+++ b/src/ui/SceneViewer.tsx
@@ -20,12 +20,11 @@ interface Props {
   addCountertop: boolean
 }
 
-const getLegHeight = (mod: Module3D, globals: Globals): number => {
+export const getLegHeight = (mod: Module3D, globals: Globals): number => {
   if (mod.family !== FAMILY.BASE) return 0
   const famGlobal = globals[mod.family]
-  const label: string = famGlobal?.legsType || ''
-  const match = label.match(/(\d+\.?\d*)/)
-  if (match) return parseFloat(match[1]) / 100
+  const h = famGlobal?.legsHeight
+  if (typeof h === 'number') return h / 1000
   return 0.1
 }
 

--- a/src/ui/panels/GlobalSettings.tsx
+++ b/src/ui/panels/GlobalSettings.tsx
@@ -40,6 +40,7 @@ export default function GlobalSettings(){
             <Field label={t('global.backPanel')} type="select" value={g.backPanel||'full'} onChange={(v)=>set({backPanel:v})} options={['full','split','none']} />
             {fam===FAMILY.BASE && (<>
               <Field label={t('global.legs')} type="select" value={g.legsType} onChange={(v)=>set({legsType:v})} options={Object.keys(store.prices.legs)} />
+              <Field label={t('global.legsHeight')} value={g.legsHeight||0} onChange={(v)=>set({legsHeight:v})} />
               <Field label={t('global.offsetWall')} value={g.offsetWall||0} onChange={(v)=>set({offsetWall:v})} />
             </>)}
             {(fam===FAMILY.WALL || fam===FAMILY.PAWLACZ) && (<>

--- a/tests/sceneViewer.test.ts
+++ b/tests/sceneViewer.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest'
+import { getLegHeight } from '../src/ui/SceneViewer'
+import { FAMILY } from '../src/core/catalog'
+import { Module3D, Globals } from '../src/types'
+import { defaultGlobal } from '../src/state/store'
+
+describe('getLegHeight', () => {
+  it('converts legsHeight from mm to meters for base cabinets', () => {
+    const mod = { family: FAMILY.BASE } as Module3D
+    const globals: Globals = {
+      ...defaultGlobal,
+      [FAMILY.BASE]: { ...defaultGlobal[FAMILY.BASE], legsHeight: 150 }
+    }
+    expect(getLegHeight(mod, globals)).toBe(0.15)
+  })
+
+  it('defaults to 0.1m when legsHeight is not specified', () => {
+    const mod = { family: FAMILY.BASE } as Module3D
+    const globals: Globals = {
+      ...defaultGlobal,
+      [FAMILY.BASE]: { ...defaultGlobal[FAMILY.BASE], legsHeight: undefined as any }
+    }
+    expect(getLegHeight(mod, globals)).toBe(0.1)
+  })
+})


### PR DESCRIPTION
## Summary
- allow global configuration of cabinet leg height
- read leg height directly from globals when rendering cabinets
- test leg height conversion and default behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2eb7e487483228088b0f517847890