### PR TITLE
chore: switch to non-commercial license

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## [8.0.2] - 2025-08-30
+### Changed
+- Projekt przelicencjonowano na **MebloPlan Non-Commercial License 1.0**. Wszystkie wcześniejsze wersje pozostają na licencji MIT.

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,12 @@
-MIT License
+MebloPlan Non-Commercial License 1.0
 
-Copyright (c) 2025 iniemamocny
+Copyright (c) 2025 MebloPlan contributors
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Permission is hereby granted to any person obtaining a copy of this software and associated documentation files (the "Software"), to use, copy, modify, merge, publish, and distribute the Software for **non-commercial purposes only**, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+1. The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+2. Commercial use of the Software or derivative works is prohibited without prior written permission from all contributors.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+This license applies to versions of the Software released after 2025-08-30. Previous versions remain available under the MIT License.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![CI](https://github.com/iniemamocny/MebloPlan/actions/workflows/ci.yml/badge.svg)](https://github.com/iniemamocny/MebloPlan/actions/workflows/ci.yml)
 [![Pages](https://github.com/iniemamocny/MebloPlan/actions/workflows/pages.yml/badge.svg)](https://github.com/iniemamocny/MebloPlan/actions/workflows/pages.yml)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![License: NonCommercial](https://img.shields.io/badge/License-NonCommercial-blue.svg)](LICENSE)
 
 
 # MebloPlan (Kitchi)
@@ -30,4 +30,10 @@ npm ci
 npm run dev
 ```
 Port 5173 otworzy się automatycznie.
+
+## Licencja
+
+Projekt jest udostępniany na licencji **MebloPlan Non-Commercial License 1.0**. Użytkowanie, kopiowanie oraz modyfikacja kodu są dozwolone wyłącznie w celach niekomercyjnych i przy zachowaniu informacji o autorach. Wykorzystanie komercyjne wymaga wcześniejszej zgody wszystkich współautorów.
+
+Wszyscy współautorzy wyrazili zgodę na zmianę licencji. Zmiana obowiązuje jedynie dla wersji opublikowanych po 2025-08-30; wcześniejsze wydania pozostają na licencji MIT.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kitchi",
-  "version": "8.0.1",
+  "version": "8.0.2",
   "private": true,
   "type": "module",
   "scripts": {
@@ -33,5 +33,6 @@
     "typescript": "^5.5.4",
     "vite": "^5.2.0",
     "vitest": "^1.6.0"
-  }
+  },
+  "license": "SEE LICENSE IN LICENSE"
 }


### PR DESCRIPTION
## Summary
- replace MIT license with MebloPlan Non-Commercial License 1.0 and document co-author agreement
- add license section to README and bump package version to 8.0.2
- record license change in changelog

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b32c1fdee08322924b03b7cb979b9b