### PR TITLE
Move sheet settings into cutlist tab

### DIFF
--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -7,7 +7,6 @@ import SceneViewer from './SceneViewer';
 import useCabinetConfig from './useCabinetConfig';
 import { CabinetConfig } from './types';
 import TopBar from './TopBar';
-import SheetSettingsPanel from './SheetSettingsPanel';
 import MainTabs from './MainTabs';
 import { createTranslator } from './i18n';
 
@@ -87,18 +86,6 @@ export default function App() {
         />
       </div>
       <aside className="sidebar">
-        <SheetSettingsPanel
-          t={t}
-          boardL={boardL}
-          setBoardL={setBoardL}
-          boardW={boardW}
-          setBoardW={setBoardW}
-          boardKerf={boardKerf}
-          setBoardKerf={setBoardKerf}
-          boardHasGrain={boardHasGrain}
-          setBoardHasGrain={setBoardHasGrain}
-        />
-
         <GlobalSettings />
 
         <MainTabs
@@ -119,6 +106,14 @@ export default function App() {
           setAdv={setAdv}
           onAdd={onAdd}
           threeRef={threeRef}
+          boardL={boardL}
+          setBoardL={setBoardL}
+          boardW={boardW}
+          setBoardW={setBoardW}
+          boardKerf={boardKerf}
+          setBoardKerf={setBoardKerf}
+          boardHasGrain={boardHasGrain}
+          setBoardHasGrain={setBoardHasGrain}
         />
       </aside>
     </div>

--- a/src/ui/MainTabs.tsx
+++ b/src/ui/MainTabs.tsx
@@ -26,6 +26,14 @@ interface MainTabsProps {
   setAdv: (v: CabinetConfig) => void;
   onAdd: (width: number, adv: CabinetConfig) => void;
   threeRef: React.MutableRefObject<any>;
+  boardL: number;
+  setBoardL: (v: number) => void;
+  boardW: number;
+  setBoardW: (v: number) => void;
+  boardKerf: number;
+  setBoardKerf: (v: number) => void;
+  boardHasGrain: boolean;
+  setBoardHasGrain: (v: boolean) => void;
 }
 
 export default function MainTabs({
@@ -46,6 +54,14 @@ export default function MainTabs({
   setAdv,
   onAdd,
   threeRef,
+  boardL,
+  setBoardL,
+  boardW,
+  setBoardW,
+  boardKerf,
+  setBoardKerf,
+  boardHasGrain,
+  setBoardHasGrain,
 }: MainTabsProps) {
   return (
     <>
@@ -128,7 +144,18 @@ export default function MainTabs({
 
       {tab === 'room' && <RoomTab three={threeRef} />}
       {tab === 'costs' && <CostsTab />}
-      {tab === 'cut' && <CutlistTab />}
+      {tab === 'cut' && (
+        <CutlistTab
+          boardL={boardL}
+          setBoardL={setBoardL}
+          boardW={boardW}
+          setBoardW={setBoardW}
+          boardKerf={boardKerf}
+          setBoardKerf={setBoardKerf}
+          boardHasGrain={boardHasGrain}
+          setBoardHasGrain={setBoardHasGrain}
+        />
+      )}
     </>
   );
 }

--- a/src/ui/panels/CutlistTab.tsx
+++ b/src/ui/panels/CutlistTab.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next'
 import { usePlannerStore } from '../../state/store'
 import { cutlistForModule, aggregateCutlist, toCSV, aggregateEdgebanding } from '../../core/cutlist'
 import jsPDF from 'jspdf'
-import useLocalStorageState from '../hooks/useLocalStorageState'
+import SheetSettingsPanel from '../SheetSettingsPanel'
 
 interface BoardConfig {
   L: number
@@ -22,7 +22,27 @@ interface CutItem {
   requireGrain: boolean
 }
 
-export default function CutlistTab(){
+interface CutlistTabProps {
+  boardL: number
+  setBoardL: (v: number) => void
+  boardW: number
+  setBoardW: (v: number) => void
+  boardKerf: number
+  setBoardKerf: (v: number) => void
+  boardHasGrain: boolean
+  setBoardHasGrain: (v: boolean) => void
+}
+
+export default function CutlistTab({
+  boardL,
+  setBoardL,
+  boardW,
+  setBoardW,
+  boardKerf,
+  setBoardKerf,
+  boardHasGrain,
+  setBoardHasGrain
+}: CutlistTabProps){
   const store = usePlannerStore()
   const { t } = useTranslation()
   const detailedPack = useMemo(()=> store.modules.map(m=>cutlistForModule(m, store.globals)), [store.modules, store.globals])
@@ -60,12 +80,6 @@ export default function CutlistTab(){
   }
 
   
-  const [boardL] = useLocalStorageState<number>('boardL', 2800)
-  // Default board width changed from 2100 mm to 2070 mm to reflect updated sheet dimensions
-  const [boardW] = useLocalStorageState<number>('boardW', 2070)
-  const [boardKerf] = useLocalStorageState<number>('boardKerf', 3)
-  const [boardHasGrain] = useLocalStorageState<boolean>('boardHasGrain', true)
-
   const board: BoardConfig = {
     L: boardL,
     W: boardW,
@@ -90,6 +104,18 @@ export default function CutlistTab(){
   window.__lastPlan = plan
 
 return (
+<>
+  <SheetSettingsPanel
+    t={t}
+    boardL={boardL}
+    setBoardL={setBoardL}
+    boardW={boardW}
+    setBoardW={setBoardW}
+    boardKerf={boardKerf}
+    setBoardKerf={setBoardKerf}
+    boardHasGrain={boardHasGrain}
+    setBoardHasGrain={setBoardHasGrain}
+  />
 <div className="section">
       <div className={`card ${plan.ok ? '' : 'danger'}`} style={{ marginBottom: 8 }}>
         <div className="row" style={{ justifyContent:'space-between', alignItems:'baseline' }}>
@@ -129,5 +155,6 @@ return (
         </table>
       </div>
     </div>
+  </>
   )
 }


### PR DESCRIPTION
## Summary
- remove SheetSettingsPanel from App and pass board configuration through MainTabs
- expose board dimensions and grain settings to CutlistTab
- render SheetSettingsPanel at top of CutlistTab

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b339c5436483229ce26c1c96887581