### PR TITLE
feat(ui): add sliding panel for main tabs

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -34,3 +34,6 @@
 .tiny{font-size:11px}
 .muted{color:#64748b}
 .card.danger{border-color:#ef4444;box-shadow:0 0 0 1px #ef4444 inset}
+.slidingPanelOverlay{position:fixed;inset:0;background:rgba(0,0,0,.3);display:flex;justify-content:flex-end;z-index:50}
+.slidingPanel{background:#fff;width:400px;max-width:100%;height:100%;box-shadow:-2px 0 8px rgba(0,0,0,.2);padding:16px;overflow-y:auto;position:relative}
+.slidingPanelClose{position:absolute;top:8px;right:12px;border:none;background:none;font-size:20px;cursor:pointer}

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -35,7 +35,7 @@ export default function App() {
     doAutoOnSelectedWall,
   } = useCabinetConfig(family, kind, variant, selWall, setVariant);
 
-  const [tab, setTab] = useState<'cab' | 'room' | 'costs' | 'cut'>('cab');
+  const [tab, setTab] = useState<'cab' | 'room' | 'costs' | 'cut' | null>(null);
   const [boardL, setBoardL] = useState(2800);
   const [boardW, setBoardW] = useState(2070);
   const [boardKerf, setBoardKerf] = useState(3);

--- a/src/ui/MainTabs.tsx
+++ b/src/ui/MainTabs.tsx
@@ -7,11 +7,12 @@ import RoomTab from './panels/RoomTab';
 import CostsTab from './panels/CostsTab';
 import CutlistTab from './panels/CutlistTab';
 import { CabinetConfig } from './types';
+import SlidingPanel from './components/SlidingPanel';
 
 interface MainTabsProps {
   t: (key: string, opts?: any) => string;
-  tab: 'cab' | 'room' | 'costs' | 'cut';
-  setTab: (t: 'cab' | 'room' | 'costs' | 'cut') => void;
+  tab: 'cab' | 'room' | 'costs' | 'cut' | null;
+  setTab: (t: 'cab' | 'room' | 'costs' | 'cut' | null) => void;
   family: FAMILY;
   setFamily: (f: FAMILY) => void;
   kind: Kind | null;
@@ -63,99 +64,105 @@ export default function MainTabs({
   boardHasGrain,
   setBoardHasGrain,
 }: MainTabsProps) {
+  const toggleTab = (name: 'cab' | 'room' | 'costs' | 'cut') => {
+    setTab(tab === name ? null : name);
+  };
+
   return (
     <>
       <div className="tabs">
-        <button className={`tabBtn ${tab === 'cab' ? 'active' : ''}`} onClick={() => setTab('cab')}>
+        <button className={`tabBtn ${tab === 'cab' ? 'active' : ''}`} onClick={() => toggleTab('cab')}>
           {t('app.tabs.cab')}
         </button>
-        <button className={`tabBtn ${tab === 'room' ? 'active' : ''}`} onClick={() => setTab('room')}>
+        <button className={`tabBtn ${tab === 'room' ? 'active' : ''}`} onClick={() => toggleTab('room')}>
           {t('app.tabs.room')}
         </button>
-        <button className={`tabBtn ${tab === 'costs' ? 'active' : ''}`} onClick={() => setTab('costs')}>
+        <button className={`tabBtn ${tab === 'costs' ? 'active' : ''}`} onClick={() => toggleTab('costs')}>
           {t('app.tabs.costs')}
         </button>
-        <button className={`tabBtn ${tab === 'cut' ? 'active' : ''}`} onClick={() => setTab('cut')}>
+        <button className={`tabBtn ${tab === 'cut' ? 'active' : ''}`} onClick={() => toggleTab('cut')}>
           {t('app.tabs.cut')}
         </button>
       </div>
 
-      {tab === 'cab' && (
-        <>
-          <div>
-            <div className="h1">{t('app.cabinetType')}</div>
-            <TypePicker
-              family={family}
-              setFamily={(f: FAMILY) => {
-                setFamily(f);
-                setKind(null);
-                setVariant(null);
-              }}
-            />
-          </div>
-
-          <div className="section">
-            <div className="hd">
-              <div>
-                <div className="h1">{t('app.subcategories', { family: FAMILY_LABELS[family] })}</div>
-              </div>
-            </div>
-            <div className="bd">
-              <KindTabs
+      <SlidingPanel isOpen={tab !== null} onClose={() => setTab(null)}>
+        {tab === 'cab' && (
+          <>
+            <div>
+              <div className="h1">{t('app.cabinetType')}</div>
+              <TypePicker
                 family={family}
-                kind={kind}
-                setKind={(k: Kind) => {
-                  setKind(k);
+                setFamily={(f: FAMILY) => {
+                  setFamily(f);
+                  setKind(null);
                   setVariant(null);
                 }}
               />
             </div>
-          </div>
 
-          {kind && (
             <div className="section">
               <div className="hd">
                 <div>
-                  <div className="h1">{t('app.variant')}</div>
+                  <div className="h1">{t('app.subcategories', { family: FAMILY_LABELS[family] })}</div>
                 </div>
               </div>
               <div className="bd">
-                <VariantList kind={kind} onPick={(v: Variant) => { setVariant(v); setCfgTab('basic'); }} />
+                <KindTabs
+                  family={family}
+                  kind={kind}
+                  setKind={(k: Kind) => {
+                    setKind(k);
+                    setVariant(null);
+                  }}
+                />
               </div>
             </div>
-          )}
 
-          {variant && (
-            <CabinetConfigurator
-              family={family}
-              kind={kind}
-              variant={variant}
-              cfgTab={cfgTab}
-              setCfgTab={setCfgTab}
-              widthMM={widthMM}
-              setWidthMM={setWidthMM}
-              gLocal={gLocal}
-              setAdv={setAdv}
-              onAdd={onAdd}
-            />
-          )}
-        </>
-      )}
+            {kind && (
+              <div className="section">
+                <div className="hd">
+                  <div>
+                    <div className="h1">{t('app.variant')}</div>
+                  </div>
+                </div>
+                <div className="bd">
+                  <VariantList kind={kind} onPick={(v: Variant) => { setVariant(v); setCfgTab('basic'); }} />
+                </div>
+              </div>
+            )}
 
-      {tab === 'room' && <RoomTab three={threeRef} />}
-      {tab === 'costs' && <CostsTab />}
-      {tab === 'cut' && (
-        <CutlistTab
-          boardL={boardL}
-          setBoardL={setBoardL}
-          boardW={boardW}
-          setBoardW={setBoardW}
-          boardKerf={boardKerf}
-          setBoardKerf={setBoardKerf}
-          boardHasGrain={boardHasGrain}
-          setBoardHasGrain={setBoardHasGrain}
-        />
-      )}
+            {variant && (
+              <CabinetConfigurator
+                family={family}
+                kind={kind}
+                variant={variant}
+                cfgTab={cfgTab}
+                setCfgTab={setCfgTab}
+                widthMM={widthMM}
+                setWidthMM={setWidthMM}
+                gLocal={gLocal}
+                setAdv={setAdv}
+                onAdd={onAdd}
+              />
+            )}
+          </>
+        )}
+
+        {tab === 'room' && <RoomTab three={threeRef} />}
+        {tab === 'costs' && <CostsTab />}
+        {tab === 'cut' && (
+          <CutlistTab
+            boardL={boardL}
+            setBoardL={setBoardL}
+            boardW={boardW}
+            setBoardW={setBoardW}
+            boardKerf={boardKerf}
+            setBoardKerf={setBoardKerf}
+            boardHasGrain={boardHasGrain}
+            setBoardHasGrain={setBoardHasGrain}
+          />
+        )}
+      </SlidingPanel>
     </>
   );
 }

--- a/src/ui/components/SlidingPanel.tsx
+++ b/src/ui/components/SlidingPanel.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+interface SlidingPanelProps {
+  isOpen: boolean;
+  onClose: () => void;
+  children: React.ReactNode;
+}
+
+export default function SlidingPanel({ isOpen, onClose, children }: SlidingPanelProps) {
+  if (!isOpen) return null;
+  return (
+    <div className="slidingPanelOverlay" onClick={onClose}>
+      <div className="slidingPanel" onClick={(e) => e.stopPropagation()}>
+        <button className="slidingPanelClose" onClick={onClose}>
+          ×
+        </button>
+        {children}
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add reusable `SlidingPanel` component with backdrop and close controls
- show tab content inside sliding panel and toggle visibility on tab click
- include basic styles for overlay and panel

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b340167ed08322a3b6343808ebb801