### PR TITLE
Add global settings tab

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -24,7 +24,8 @@
       "cab": "Kitchen",
       "room": "Room",
       "costs": "Costs",
-      "cut": "Cutlist"
+      "cut": "Cutlist",
+      "global": "Settings"
     },
     "cabinetType": "Cabinet type",
     "subcategories": "Subcategories ({{family}})",

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -24,7 +24,8 @@
       "cab": "Kuchnia",
       "room": "Pomieszczenie",
       "costs": "Koszty",
-      "cut": "Formatki"
+      "cut": "Formatki",
+      "global": "Ustawienia"
     },
     "cabinetType": "Typ szafki",
     "subcategories": "Podkategorie ({{family}})",

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { FAMILY, Kind, Variant } from '../core/catalog';
 import { usePlannerStore } from '../state/store';
-import GlobalSettings from './panels/GlobalSettings';
 import SceneViewer from './SceneViewer';
 import useCabinetConfig from './useCabinetConfig';
 import TopBar from './TopBar';
@@ -35,7 +34,7 @@ export default function App() {
     doAutoOnSelectedWall,
   } = useCabinetConfig(family, kind, variant, selWall, setVariant);
 
-  const [tab, setTab] = useState<'cab' | 'room' | 'costs' | 'cut' | null>(null);
+  const [tab, setTab] = useState<'cab' | 'room' | 'costs' | 'cut' | 'global' | null>(null);
   const [boardL, setBoardL] = useState(2800);
   const [boardW, setBoardW] = useState(2070);
   const [boardKerf, setBoardKerf] = useState(3);
@@ -60,7 +59,6 @@ export default function App() {
 
   return (
     <div className="app">
-      <GlobalSettings />
       <div className="mainTabs">
         <MainTabs
           t={t}

--- a/src/ui/MainTabs.tsx
+++ b/src/ui/MainTabs.tsx
@@ -8,11 +8,12 @@ import CostsTab from './panels/CostsTab';
 import CutlistTab from './panels/CutlistTab';
 import { CabinetConfig } from './types';
 import SlidingPanel from './components/SlidingPanel';
+import GlobalSettings from './panels/GlobalSettings';
 
 interface MainTabsProps {
   t: (key: string, opts?: any) => string;
-  tab: 'cab' | 'room' | 'costs' | 'cut' | null;
-  setTab: (t: 'cab' | 'room' | 'costs' | 'cut' | null) => void;
+  tab: 'cab' | 'room' | 'costs' | 'cut' | 'global' | null;
+  setTab: (t: 'cab' | 'room' | 'costs' | 'cut' | 'global' | null) => void;
   family: FAMILY;
   setFamily: (f: FAMILY) => void;
   kind: Kind | null;
@@ -64,7 +65,7 @@ export default function MainTabs({
   boardHasGrain,
   setBoardHasGrain,
 }: MainTabsProps) {
-  const toggleTab = (name: 'cab' | 'room' | 'costs' | 'cut') => {
+  const toggleTab = (name: 'cab' | 'room' | 'costs' | 'cut' | 'global') => {
     setTab(tab === name ? null : name);
   };
 
@@ -82,6 +83,9 @@ export default function MainTabs({
         </button>
         <button className={`tabBtn ${tab === 'cut' ? 'active' : ''}`} onClick={() => toggleTab('cut')}>
           {t('app.tabs.cut')}
+        </button>
+        <button className={`tabBtn ${tab === 'global' ? 'active' : ''}`} onClick={() => toggleTab('global')}>
+          {t('app.tabs.global')}
         </button>
       </div>
 
@@ -162,6 +166,7 @@ export default function MainTabs({
             setBoardHasGrain={setBoardHasGrain}
           />
         )}
+        {tab === 'global' && <GlobalSettings />}
       </SlidingPanel>
     </>
   );


### PR DESCRIPTION
## Summary
- move GlobalSettings into MainTabs as a dedicated 'Settings' tab
- support 'global' tab state in App and MainTabs
- add English and Polish translations for the new tab label

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b346c2a5088322b759a30adcf6f698