### PR TITLE
Refactor sliding panel to slide in with outside click close

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -34,6 +34,7 @@
 .tiny{font-size:11px}
 .muted{color:#64748b}
 .card.danger{border-color:#ef4444;box-shadow:0 0 0 1px #ef4444 inset}
-.slidingPanelOverlay{position:fixed;inset:0;background:rgba(0,0,0,.3);display:flex;justify-content:flex-end;z-index:50}
-.slidingPanel{background:#fff;width:400px;max-width:100%;height:100%;box-shadow:-2px 0 8px rgba(0,0,0,.2);padding:16px;overflow-y:auto;position:relative}
+.slidingPanelOverlay{position:fixed;inset:0;background:none;pointer-events:none}
+.slidingPanel{background:#fff;width:400px;max-width:100%;height:100%;box-shadow:-2px 0 8px rgba(0,0,0,.2);padding:16px;overflow-y:auto;position:fixed;left:0;top:0;transform:translateX(-100%);transition:transform .3s ease;z-index:50;pointer-events:auto}
+.slidingPanel.open{transform:translateX(0)}
 .slidingPanelClose{position:absolute;top:8px;right:12px;border:none;background:none;font-size:20px;cursor:pointer}

--- a/src/ui/MainTabs.tsx
+++ b/src/ui/MainTabs.tsx
@@ -89,7 +89,11 @@ export default function MainTabs({
         </button>
       </div>
 
-      <SlidingPanel isOpen={tab !== null} onClose={() => setTab(null)}>
+      <SlidingPanel
+        isOpen={tab !== null}
+        onClose={() => setTab(null)}
+        className={tab !== null ? 'open' : ''}
+      >
         {tab === 'cab' && (
           <>
             <div>

--- a/src/ui/components/SlidingPanel.tsx
+++ b/src/ui/components/SlidingPanel.tsx
@@ -1,21 +1,41 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 
 interface SlidingPanelProps {
   isOpen: boolean;
   onClose: () => void;
   children: React.ReactNode;
+  className?: string;
 }
 
-export default function SlidingPanel({ isOpen, onClose, children }: SlidingPanelProps) {
-  if (!isOpen) return null;
+export default function SlidingPanel({
+  isOpen,
+  onClose,
+  children,
+  className = '',
+}: SlidingPanelProps) {
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleMouseDown = (e: MouseEvent) => {
+      if (panelRef.current && !panelRef.current.contains(e.target as Node)) {
+        onClose();
+      }
+    };
+
+    document.addEventListener('mousedown', handleMouseDown);
+    return () => {
+      document.removeEventListener('mousedown', handleMouseDown);
+    };
+  }, [isOpen, onClose]);
+
   return (
-    <div className="slidingPanelOverlay" onClick={onClose}>
-      <div className="slidingPanel" onClick={(e) => e.stopPropagation()}>
-        <button className="slidingPanelClose" onClick={onClose}>
-          ×
-        </button>
-        {children}
-      </div>
+    <div ref={panelRef} className={`slidingPanel ${className}`}>
+      <button className="slidingPanelClose" onClick={onClose}>
+        ×
+      </button>
+      {children}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Refactor `SlidingPanel` to remove overlay, add outside click handling and allow sliding with a CSS `open` class
- Adjust styles to use transforms and pointer-event gating for the sliding panel
- Pass `open` class from `MainTabs` based on panel state

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b3483dcea08322901b9a4e1c266a55