### PR TITLE
Refactor base cabinet variants to dynamic counts

### DIFF
--- a/src/core/catalog.ts
+++ b/src/core/catalog.ts
@@ -13,20 +13,14 @@ export const KIND_SETS: Record<FAMILY, Kind[]> = {
       key:'doors',
       label:'Drzwiczki',
       variants:[
-        { key:'d1', label:'1 drzwiczki' },
-        { key:'d2', label:'2 drzwiczki' },
-        { key:'d1+drawer', label:'1 drzwiczki + szuflada' },
-        { key:'d2+drawer', label:'2 drzwiczki + szuflada' }
+        { key:'doors', label:'Drzwiczki' }
       ]
     },
     {
       key:'drawers',
       label:'Szuflady',
       variants:[
-        { key:'s1', label:'1 szuflada' },
-        { key:'s2', label:'2 szuflady' },
-        { key:'s3', label:'3 szuflady' },
-        { key:'s4', label:'4 szuflady' }
+        { key:'drawers', label:'Szuflady' }
       ]
     },
     {

--- a/src/core/pricing.ts
+++ b/src/core/pricing.ts
@@ -8,6 +8,8 @@ export function computeModuleCost(
   params: {
     family: FAMILY; kind:string; variant:string; width:number;
     adv: AdvParams;
+    doorsCount?: number;
+    drawersCount?: number;
   },
   data: PricingData
 ): Price {
@@ -35,6 +37,8 @@ export function computeModuleCost(
     aventosType = rule.aventos ?? null
     kits = (rule.kits || []).reduce((sum, k) => sum + (P[k] || 0), 0)
   }
+  if (typeof params.doorsCount === 'number') doors = params.doorsCount
+  if (typeof params.drawersCount === 'number') drawers = params.drawersCount
   const doorHeightMM = hMM - 100
   const hingesPerDoor = hingeCountPerDoor(doorHeightMM)
   const hingesCost = (P.hinges['Blum ClipTop']||0) * hingesPerDoor * doors

--- a/src/core/variantRules.ts
+++ b/src/core/variantRules.ts
@@ -15,19 +15,13 @@ export interface VariantRule {
 export const variantRules: Record<FAMILY, Record<string, VariantRule>> = {
   [FAMILY.BASE]: (() => {
     const rules: Record<string, VariantRule> = {
-      d1: { doors: 1 },
-      d2: { doors: 2 },
-      'd1+drawer': { doors: 1, drawers: 1 },
-      'd2+drawer': { doors: 2, drawers: 1 },
+      doors: {},
+      drawers: {},
       sink: { doors: 2, kits: ['sinkKit'] },
       hob: { doors: 2 },
       cargo150: { cargo: '150' },
       cargo200: { cargo: '200' },
       cargo300: { cargo: '300' },
-    }
-    // drawer variants like s1, s2 ... s5
-    for (let i = 1; i <= 5; i++) {
-      rules[`s${i}`] = { drawers: i }
     }
     return rules
   })(),

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -75,6 +75,8 @@
     "advanced": "Advanced",
     "width": "Width (mm)",
     "insertCabinet": "Insert cabinet",
+    "doorsCount": "Doors count",
+    "drawersCount": "Drawers count",
     "height": "Height (mm)",
     "depth": "Depth (mm)",
     "board": "Board",

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -75,6 +75,8 @@
     "advanced": "Zaawansowane",
     "width": "Szerokość (mm)",
     "insertCabinet": "Wstaw szafkę",
+    "doorsCount": "Liczba drzwi",
+    "drawersCount": "Liczba szuflad",
     "height": "Wysokość (mm)",
     "depth": "Głębokość (mm)",
     "board": "Płyta",

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -32,6 +32,10 @@ export default function App() {
     setAdv,
     onAdd,
     doAutoOnSelectedWall,
+    doorsCount,
+    setDoorsCount,
+    drawersCount,
+    setDrawersCount,
   } = useCabinetConfig(family, kind, variant, selWall, setVariant);
 
   const [tab, setTab] = useState<'cab' | 'room' | 'costs' | 'cut' | 'global' | null>(null);
@@ -77,6 +81,10 @@ export default function App() {
           gLocal={gLocal}
           setAdv={setAdv}
           onAdd={onAdd}
+          doorsCount={doorsCount}
+          setDoorsCount={setDoorsCount}
+          drawersCount={drawersCount}
+          setDrawersCount={setDrawersCount}
           threeRef={threeRef}
           boardL={boardL}
           setBoardL={setBoardL}

--- a/src/ui/CabinetConfigurator.tsx
+++ b/src/ui/CabinetConfigurator.tsx
@@ -18,6 +18,10 @@ interface Props {
   gLocal: CabinetConfig
   setAdv: (v: CabinetConfig) => void
   onAdd: (width: number, adv: CabinetConfig) => void
+  doorsCount: number
+  setDoorsCount: (n: number) => void
+  drawersCount: number
+  setDrawersCount: (n: number) => void
 }
 
 const CabinetConfigurator: React.FC<Props> = ({
@@ -30,7 +34,11 @@ const CabinetConfigurator: React.FC<Props> = ({
   setWidthMM,
   gLocal,
   setAdv,
-  onAdd
+  onAdd,
+  doorsCount,
+  setDoorsCount,
+  drawersCount,
+  setDrawersCount
 }) => {
   const store = usePlannerStore()
   const { t } = useTranslation()
@@ -55,17 +63,32 @@ const CabinetConfigurator: React.FC<Props> = ({
                 <button className="btn" onClick={()=>onAdd(widthMM, gLocal)}>{t('configurator.insertCabinet')}</button>
               </div>
             </div>
+            {variant.key==='doors' && (
+              <div className="grid2" style={{marginTop:8}}>
+                <div>
+                  <div className="small">{t('configurator.doorsCount')}</div>
+                  <input className="input" type="number" min={0} value={doorsCount} onChange={e=>setDoorsCount(Number((e.target as HTMLInputElement).value)||0)} />
+                </div>
+                <div>
+                  <div className="small">{t('configurator.drawersCount')}</div>
+                  <input className="input" type="number" min={0} value={drawersCount} onChange={e=>setDrawersCount(Number((e.target as HTMLInputElement).value)||0)} />
+                </div>
+              </div>
+            )}
+            {variant.key==='drawers' && (
+              <div style={{marginTop:8}}>
+                <div className="small">{t('configurator.drawersCount')}</div>
+                <input className="input" type="number" min={0} value={drawersCount} onChange={e=>setDrawersCount(Number((e.target as HTMLInputElement).value)||0)} />
+              </div>
+            )}
             <div style={{marginTop:8}}>
               <TechDrawing
                 mode="view"
-                family={family}
-                kindKey={kind?.key||'doors'}
-                variantKey={variant?.key||'d1'}
                 widthMM={widthMM}
                 heightMM={gLocal.height}
                 depthMM={gLocal.depth}
                 gaps={gLocal.gaps}
-                drawers={variant?.key?.startsWith('s') ? Number(variant.key.slice(1)) : (variant?.key?.includes('+drawer') ? 1 : 0)}
+                drawers={drawersCount}
                 drawerFronts={gLocal.drawerFronts}
               />
             </div>
@@ -75,7 +98,7 @@ const CabinetConfigurator: React.FC<Props> = ({
                 widthMM={widthMM}
                 heightMM={gLocal.height}
                 depthMM={gLocal.depth}
-                drawers={variant?.key?.startsWith('s') ? Number(variant.key.slice(1)) : (variant?.key?.includes('+drawer') ? 1 : 0)}
+                drawers={drawersCount}
                 gaps={{ top: gLocal.gaps.top, bottom: gLocal.gaps.bottom }}
                 drawerFronts={gLocal.drawerFronts}
                 shelves={gLocal.shelves}
@@ -97,7 +120,7 @@ const CabinetConfigurator: React.FC<Props> = ({
                 <option value="none">{t('configurator.backOptions.none')}</option>
               </select></div>
             </div>
-            {!(variant?.key?.startsWith('s')) && (
+            {drawersCount === 0 && (
               <div style={{marginTop:8}}>
                 <div className="small">{t('configurator.shelves')}</div>
                 <input className="input" type="number" min={0} value={gLocal.shelves||0} onChange={e=>setAdv({...gLocal, shelves:Number((e.target as HTMLInputElement).value)||0})} />
@@ -107,14 +130,11 @@ const CabinetConfigurator: React.FC<Props> = ({
               <div className="small">{t('configurator.gapsTitle')}</div>
               <TechDrawing
                 mode="edit"
-                family={family}
-                kindKey={kind?.key||'doors'}
-                variantKey={variant?.key||'d1'}
                 widthMM={widthMM}
                 heightMM={gLocal.height}
                 depthMM={gLocal.depth}
                 gaps={gLocal.gaps}
-                drawers={variant?.key?.startsWith('s') ? Number(variant.key.slice(1)) : (variant?.key?.includes('+drawer') ? 1 : 0)}
+                drawers={drawersCount}
                 drawerFronts={gLocal.drawerFronts}
                 onChangeGaps={(gg: Gaps) => setAdv({ ...gLocal, gaps: gg })}
                 onChangeDrawerFronts={(arr: number[]) => setAdv({ ...gLocal, drawerFronts: arr })}
@@ -126,7 +146,7 @@ const CabinetConfigurator: React.FC<Props> = ({
                 widthMM={widthMM}
                 heightMM={gLocal.height}
                 depthMM={gLocal.depth}
-                drawers={variant?.key?.startsWith('s') ? Number(variant.key.slice(1)) : (variant?.key?.includes('+drawer') ? 1 : 0)}
+                drawers={drawersCount}
                 gaps={{ top: gLocal.gaps.top, bottom: gLocal.gaps.bottom }}
                 drawerFronts={gLocal.drawerFronts}
                 shelves={gLocal.shelves}

--- a/src/ui/MainTabs.tsx
+++ b/src/ui/MainTabs.tsx
@@ -27,6 +27,10 @@ interface MainTabsProps {
   gLocal: CabinetConfig;
   setAdv: (v: CabinetConfig) => void;
   onAdd: (width: number, adv: CabinetConfig) => void;
+  doorsCount: number;
+  setDoorsCount: (n: number) => void;
+  drawersCount: number;
+  setDrawersCount: (n: number) => void;
   threeRef: React.MutableRefObject<any>;
   boardL: number;
   setBoardL: (v: number) => void;
@@ -55,6 +59,10 @@ export default function MainTabs({
   gLocal,
   setAdv,
   onAdd,
+  doorsCount,
+  setDoorsCount,
+  drawersCount,
+  setDrawersCount,
   threeRef,
   boardL,
   setBoardL,
@@ -151,6 +159,10 @@ export default function MainTabs({
                 gLocal={gLocal}
                 setAdv={setAdv}
                 onAdd={onAdd}
+                doorsCount={doorsCount}
+                setDoorsCount={setDoorsCount}
+                drawersCount={drawersCount}
+                setDrawersCount={setDrawersCount}
               />
             )}
           </>

--- a/tests/pricing.test.ts
+++ b/tests/pricing.test.ts
@@ -22,9 +22,10 @@ describe('computeModuleCost', () => {
       {
         family: FAMILY.BASE,
         kind: 'doors',
-        variant: 'd2',
+        variant: 'doors',
         width: 600,
         adv: advFor(FAMILY.BASE),
+        doorsCount: 2,
       },
       { prices: defaultPrices, globals: defaultGlobal }
     )
@@ -37,9 +38,10 @@ describe('computeModuleCost', () => {
       {
         family: FAMILY.BASE,
         kind: 'drawers',
-        variant: 's3',
+        variant: 'drawers',
         width: 600,
         adv: advFor(FAMILY.BASE),
+        drawersCount: 3,
       },
       { prices: defaultPrices, globals: defaultGlobal }
     )


### PR DESCRIPTION
## Summary
- simplify base cabinet catalog to only `doors` and `drawers` variants
- support dynamic `doorsCount`/`drawersCount` parameters across state, pricing and configurator
- add translations and tests for new variant handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b35e1bb0f4832293e0b47117713afe