### PR TITLE
Add door and drawer count selectors

### DIFF
--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -32,10 +32,6 @@ export default function App() {
     setAdv,
     onAdd,
     doAutoOnSelectedWall,
-    doorsCount,
-    setDoorsCount,
-    drawersCount,
-    setDrawersCount,
   } = useCabinetConfig(family, kind, variant, selWall, setVariant);
 
   const [tab, setTab] = useState<'cab' | 'room' | 'costs' | 'cut' | 'global' | null>(null);
@@ -81,10 +77,6 @@ export default function App() {
           gLocal={gLocal}
           setAdv={setAdv}
           onAdd={onAdd}
-          doorsCount={doorsCount}
-          setDoorsCount={setDoorsCount}
-          drawersCount={drawersCount}
-          setDrawersCount={setDrawersCount}
           threeRef={threeRef}
           boardL={boardL}
           setBoardL={setBoardL}

--- a/src/ui/CabinetConfigurator.tsx
+++ b/src/ui/CabinetConfigurator.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { FAMILY, Kind, Variant } from '../core/catalog'
 import { usePlannerStore } from '../state/store'
@@ -17,11 +17,12 @@ interface Props {
   setWidthMM: (n: number) => void
   gLocal: CabinetConfig
   setAdv: (v: CabinetConfig) => void
-  onAdd: (width: number, adv: CabinetConfig) => void
-  doorsCount: number
-  setDoorsCount: (n: number) => void
-  drawersCount: number
-  setDrawersCount: (n: number) => void
+  onAdd: (
+    width: number,
+    adv: CabinetConfig,
+    doorsCount: number,
+    drawersCount: number,
+  ) => void
 }
 
 const CabinetConfigurator: React.FC<Props> = ({
@@ -34,14 +35,25 @@ const CabinetConfigurator: React.FC<Props> = ({
   setWidthMM,
   gLocal,
   setAdv,
-  onAdd,
-  doorsCount,
-  setDoorsCount,
-  drawersCount,
-  setDrawersCount
+  onAdd
 }) => {
   const store = usePlannerStore()
   const { t } = useTranslation()
+  const [doorsCount, setDoorsCount] = useState(1)
+  const [drawersCount, setDrawersCount] = useState(0)
+
+  useEffect(() => {
+    if (kind?.key === 'doors') {
+      setDoorsCount(1)
+      setDrawersCount(0)
+    } else if (kind?.key === 'drawers') {
+      setDoorsCount(0)
+      setDrawersCount(1)
+    } else {
+      setDoorsCount(0)
+      setDrawersCount(0)
+    }
+  }, [kind])
   return (
     <div className="section">
       <div className="hd">
@@ -57,28 +69,44 @@ const CabinetConfigurator: React.FC<Props> = ({
             <div className="grid2">
               <div>
                 <div className="small">{t('configurator.width')}</div>
-                <input className="input" type="number" min={200} max={2400} step={1} value={widthMM} onChange={e=>setWidthMM(Number((e.target as HTMLInputElement).value)||0)} onKeyDown={(e)=>{ if (e.key==='Enter'){ const v = Number((e.target as HTMLInputElement).value)||0; if(v>0) onAdd(v, gLocal) } }} />
+                <input className="input" type="number" min={200} max={2400} step={1} value={widthMM} onChange={e=>setWidthMM(Number((e.target as HTMLInputElement).value)||0)} onKeyDown={(e)=>{ if (e.key==='Enter'){ const v = Number((e.target as HTMLInputElement).value)||0; if(v>0) onAdd(v, gLocal, doorsCount, drawersCount) } }} />
               </div>
               <div className="row" style={{alignItems:'flex-end'}}>
-                <button className="btn" onClick={()=>onAdd(widthMM, gLocal)}>{t('configurator.insertCabinet')}</button>
+                <button className="btn" onClick={()=>onAdd(widthMM, gLocal, doorsCount, drawersCount)}>{t('configurator.insertCabinet')}</button>
               </div>
             </div>
-            {variant.key==='doors' && (
-              <div className="grid2" style={{marginTop:8}}>
-                <div>
-                  <div className="small">{t('configurator.doorsCount')}</div>
-                  <input className="input" type="number" min={0} value={doorsCount} onChange={e=>setDoorsCount(Number((e.target as HTMLInputElement).value)||0)} />
-                </div>
-                <div>
-                  <div className="small">{t('configurator.drawersCount')}</div>
-                  <input className="input" type="number" min={0} value={drawersCount} onChange={e=>setDrawersCount(Number((e.target as HTMLInputElement).value)||0)} />
-                </div>
+            {kind?.key === 'doors' && (
+              <div style={{ marginTop: 8 }}>
+                <div className="small">{t('configurator.doorsCount')}</div>
+                <select
+                  className="input"
+                  value={doorsCount}
+                  onChange={(e) => setDoorsCount(Number((e.target as HTMLSelectElement).value))}
+                >
+                  {[1, 2, 3, 4].map((n) => (
+                    <option key={n} value={n}>
+                      {n}
+                    </option>
+                  ))}
+                </select>
               </div>
             )}
-            {variant.key==='drawers' && (
-              <div style={{marginTop:8}}>
+            {kind?.key === 'drawers' && (
+              <div style={{ marginTop: 8 }}>
                 <div className="small">{t('configurator.drawersCount')}</div>
-                <input className="input" type="number" min={0} value={drawersCount} onChange={e=>setDrawersCount(Number((e.target as HTMLInputElement).value)||0)} />
+                <select
+                  className="input"
+                  value={drawersCount}
+                  onChange={(e) =>
+                    setDrawersCount(Number((e.target as HTMLSelectElement).value))
+                  }
+                >
+                  {[1, 2, 3, 4].map((n) => (
+                    <option key={n} value={n}>
+                      {n}
+                    </option>
+                  ))}
+                </select>
               </div>
             )}
             <div style={{marginTop:8}}>
@@ -88,7 +116,8 @@ const CabinetConfigurator: React.FC<Props> = ({
                 heightMM={gLocal.height}
                 depthMM={gLocal.depth}
                 gaps={gLocal.gaps}
-                drawers={drawersCount}
+                doorsCount={doorsCount}
+                drawersCount={drawersCount}
                 drawerFronts={gLocal.drawerFronts}
               />
             </div>
@@ -98,7 +127,8 @@ const CabinetConfigurator: React.FC<Props> = ({
                 widthMM={widthMM}
                 heightMM={gLocal.height}
                 depthMM={gLocal.depth}
-                drawers={drawersCount}
+                doorsCount={doorsCount}
+                drawersCount={drawersCount}
                 gaps={{ top: gLocal.gaps.top, bottom: gLocal.gaps.bottom }}
                 drawerFronts={gLocal.drawerFronts}
                 shelves={gLocal.shelves}
@@ -134,7 +164,8 @@ const CabinetConfigurator: React.FC<Props> = ({
                 heightMM={gLocal.height}
                 depthMM={gLocal.depth}
                 gaps={gLocal.gaps}
-                drawers={drawersCount}
+                doorsCount={doorsCount}
+                drawersCount={drawersCount}
                 drawerFronts={gLocal.drawerFronts}
                 onChangeGaps={(gg: Gaps) => setAdv({ ...gLocal, gaps: gg })}
                 onChangeDrawerFronts={(arr: number[]) => setAdv({ ...gLocal, drawerFronts: arr })}
@@ -146,7 +177,8 @@ const CabinetConfigurator: React.FC<Props> = ({
                 widthMM={widthMM}
                 heightMM={gLocal.height}
                 depthMM={gLocal.depth}
-                drawers={drawersCount}
+                doorsCount={doorsCount}
+                drawersCount={drawersCount}
                 gaps={{ top: gLocal.gaps.top, bottom: gLocal.gaps.bottom }}
                 drawerFronts={gLocal.drawerFronts}
                 shelves={gLocal.shelves}
@@ -154,7 +186,7 @@ const CabinetConfigurator: React.FC<Props> = ({
               />
             </div>
             <div className="row" style={{marginTop:8}}>
-              <button className="btn" onClick={()=>onAdd(widthMM, gLocal)}>{t('configurator.insertCabinet')}</button>
+              <button className="btn" onClick={()=>onAdd(widthMM, gLocal, doorsCount, drawersCount)}>{t('configurator.insertCabinet')}</button>
               <button className="btnGhost" onClick={()=>setCfgTab('basic')}>{t('configurator.backToBasic')}</button>
             </div>
           </div>

--- a/src/ui/MainTabs.tsx
+++ b/src/ui/MainTabs.tsx
@@ -26,11 +26,12 @@ interface MainTabsProps {
   setWidthMM: (n: number) => void;
   gLocal: CabinetConfig;
   setAdv: (v: CabinetConfig) => void;
-  onAdd: (width: number, adv: CabinetConfig) => void;
-  doorsCount: number;
-  setDoorsCount: (n: number) => void;
-  drawersCount: number;
-  setDrawersCount: (n: number) => void;
+  onAdd: (
+    width: number,
+    adv: CabinetConfig,
+    doorsCount: number,
+    drawersCount: number,
+  ) => void;
   threeRef: React.MutableRefObject<any>;
   boardL: number;
   setBoardL: (v: number) => void;
@@ -59,10 +60,6 @@ export default function MainTabs({
   gLocal,
   setAdv,
   onAdd,
-  doorsCount,
-  setDoorsCount,
-  drawersCount,
-  setDrawersCount,
   threeRef,
   boardL,
   setBoardL,
@@ -159,10 +156,6 @@ export default function MainTabs({
                 gLocal={gLocal}
                 setAdv={setAdv}
                 onAdd={onAdd}
-                doorsCount={doorsCount}
-                setDoorsCount={setDoorsCount}
-                drawersCount={drawersCount}
-                setDrawersCount={setDrawersCount}
               />
             )}
           </>

--- a/src/ui/components/Cabinet3D.tsx
+++ b/src/ui/components/Cabinet3D.tsx
@@ -3,7 +3,7 @@ import * as THREE from 'three'
 import { FAMILY } from '../../core/catalog'
 import { buildCabinetMesh } from '../../scene/cabinetBuilder'
 
-export default function Cabinet3D({ widthMM, heightMM, depthMM, drawers, gaps, drawerFronts, family, shelves = 1, backPanel = 'full' }:{ widthMM:number;heightMM:number;depthMM:number;drawers:number;gaps:{top:number;bottom:number};drawerFronts?:number[];family:FAMILY; shelves?:number; backPanel?:'full'|'split'|'none' }){
+export default function Cabinet3D({ widthMM, heightMM, depthMM, doorsCount, drawersCount, gaps, drawerFronts, family, shelves = 1, backPanel = 'full' }:{ widthMM:number;heightMM:number;depthMM:number;doorsCount:number;drawersCount:number;gaps:{top:number;bottom:number};drawerFronts?:number[];family:FAMILY; shelves?:number; backPanel?:'full'|'split'|'none' }){
   const ref = useRef<HTMLDivElement>(null)
   useEffect(()=>{
     if (!ref.current) return
@@ -29,7 +29,8 @@ export default function Cabinet3D({ widthMM, heightMM, depthMM, drawers, gaps, d
       width: W,
       height: H,
       depth: D,
-      drawers,
+      drawers: drawersCount,
+      doorCount: doorsCount,
       gaps,
       drawerFronts,
       family,
@@ -40,6 +41,6 @@ export default function Cabinet3D({ widthMM, heightMM, depthMM, drawers, gaps, d
     scene.add(cabGroup)
     renderer.render(scene, camera)
     return () => { renderer.dispose() }
-  }, [widthMM, heightMM, depthMM, drawers, gaps, drawerFronts, family, shelves, backPanel])
+  }, [widthMM, heightMM, depthMM, doorsCount, drawersCount, gaps, drawerFronts, family, shelves, backPanel])
   return <div ref={ref} style={{ width: 260, height: 190, border: '1px solid #E5E7EB', borderRadius: 8, background: '#fff' }} />
 }

--- a/src/ui/components/TechDrawing.tsx
+++ b/src/ui/components/TechDrawing.tsx
@@ -14,7 +14,8 @@ type Props = {
   depthMM: number;
   boardType?: string;
   gaps: Gaps;
-  drawers: number;
+  doorsCount: number;
+  drawersCount: number;
   drawerFronts?: number[];
   onChangeGaps?: (g: Gaps) => void;
   onChangeDrawerFronts?: (arr: number[]) => void;
@@ -110,7 +111,8 @@ export default function TechDrawing({
   depthMM,
   boardType,
   gaps,
-  drawers,
+  doorsCount,
+  drawersCount,
   drawerFronts,
   onChangeGaps,
   onChangeDrawerFronts,
@@ -136,24 +138,34 @@ export default function TechDrawing({
   }, [gaps, widthMM, heightMM]);
 
   const drawerSplits = useMemo(() => {
-    if (drawers <= 1) return [];
+    if (drawersCount <= 1) return [];
     const availFrontH = heightMM - (gaps.top + gaps.bottom);
     const arr =
-      drawerFronts && drawerFronts.length === drawers
+      drawerFronts && drawerFronts.length === drawersCount
         ? drawerFronts
-        : Array.from({ length: drawers }, () =>
-            Math.floor(availFrontH / drawers),
+        : Array.from({ length: drawersCount }, () =>
+            Math.floor(availFrontH / drawersCount),
           );
     const sum = arr.reduce((a, b) => a + b, 0);
     const pxPerMM = front.h / Math.max(1, sum);
     let cum = 0;
     const ys: number[] = [];
-    for (let i = 0; i < drawers - 1; i++) {
+    for (let i = 0; i < drawersCount - 1; i++) {
       cum += arr[i];
       ys.push(front.y + cum * pxPerMM);
     }
     return ys;
-  }, [drawers, drawerFronts, gaps, heightMM, front.h, front.y]);
+  }, [drawersCount, drawerFronts, gaps, heightMM, front.h, front.y]);
+
+  const doorSplits = useMemo(() => {
+    if (doorsCount <= 1) return [];
+    const step = front.w / doorsCount;
+    const xs: number[] = [];
+    for (let i = 1; i < doorsCount; i++) {
+      xs.push(front.x + step * i);
+    }
+    return xs;
+  }, [doorsCount, front.w, front.x]);
 
   const onMouseDown = (e: React.MouseEvent<SVGSVGElement, MouseEvent>) => {
     if (mode !== 'edit') return;
@@ -180,10 +192,10 @@ export default function TechDrawing({
       const idx = Number(drag.tag.split('-')[1]);
       const availFrontH = heightMM - (gaps.top + gaps.bottom);
       const arr =
-        drawerFronts && drawerFronts.length === drawers
+        drawerFronts && drawerFronts.length === drawersCount
           ? drawerFronts.slice()
-          : Array.from({ length: drawers }, () =>
-              Math.floor(availFrontH / drawers),
+          : Array.from({ length: drawersCount }, () =>
+              Math.floor(availFrontH / drawersCount),
             );
       const sum = arr.reduce((a, b) => a + b, 0);
       const pxPerMM = front.h / Math.max(1, sum);
@@ -255,6 +267,18 @@ export default function TechDrawing({
           fill="#e5e7eb"
           stroke="#666"
         />
+        {/* podziały drzwi */}
+        {doorSplits.map((x, i) => (
+          <line
+            key={`door-${i}`}
+            x1={x}
+            y1={front.y}
+            x2={x}
+            y2={front.y + front.h}
+            stroke="#fff"
+            strokeWidth={2}
+          />
+        ))}
         {/* podziały szuflad */}
         {drawerSplits.map((y, i) => (
           <g key={i}>
@@ -380,7 +404,7 @@ export default function TechDrawing({
           stroke="#999"
         />
         {/* pomocnicze półki (symbolicznie) */}
-        {drawers > 0 && (
+        {drawersCount > 0 && (
           <>
             <rect
               x={pad + 12}

--- a/src/ui/useCabinetConfig.ts
+++ b/src/ui/useCabinetConfig.ts
@@ -19,8 +19,6 @@ export function useCabinetConfig(
   const [cfgTab, setCfgTab] = useState<'basic' | 'adv'>('basic');
   const [widthMM, setWidthMM] = useState(600);
   const [adv, setAdvState] = useState<CabinetConfig | null>(null);
-  const [doorsCount, setDoorsCount] = useState(1);
-  const [drawersCount, setDrawersCount] = useState(0);
   const { t } = useTranslation();
 
   useEffect(() => {
@@ -37,16 +35,7 @@ export function useCabinetConfig(
     });
   }, [family, store.globals]);
 
-  useEffect(() => {
-    if (!variant) return;
-    if (variant.key === 'drawers') {
-      setDoorsCount(0);
-      setDrawersCount(1);
-    } else {
-      setDoorsCount(1);
-      setDrawersCount(0);
-    }
-  }, [variant]);
+
 
   const snapToWalls = (
     mSize: { w: number; h: number; d: number },
@@ -121,7 +110,12 @@ export function useCabinetConfig(
     return rest as Module3D;
   };
 
-  const onAdd = (widthLocal: number, advLocal: CabinetConfig) => {
+  const onAdd = (
+    widthLocal: number,
+    advLocal: CabinetConfig,
+    doorsCount: number,
+    drawersCount: number,
+  ) => {
     if (!kind || !variant) return;
     const g: CabinetConfig = {
       ...store.globals[family],
@@ -266,10 +260,6 @@ export function useCabinetConfig(
     gLocal,
     onAdd,
     doAutoOnSelectedWall,
-    doorsCount,
-    setDoorsCount,
-    drawersCount,
-    setDrawersCount,
   };
 }
 


### PR DESCRIPTION
## Summary
- add dropdowns for door and drawer counts in cabinet configurator
- pass counts via onAdd and reflect in TechDrawing and Cabinet3D
- extend cabinet builder for multi-door rendering

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3612849b08322aae1edf6533a8b1d