### PR TITLE
Add cabinet divider configuration and rendering

### DIFF
--- a/src/scene/cabinetBuilder.ts
+++ b/src/scene/cabinetBuilder.ts
@@ -17,6 +17,7 @@ export interface CabinetOptions {
   boardThickness?: number;
   backThickness?: number;
   hinge?: 'left' | 'right';
+  dividerPosition?: 'left' | 'right' | 'center';
 }
 
 /**
@@ -39,6 +40,7 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
     showHandles = true,
     boardThickness: T = 0.018,
     backThickness: backT = 0.003,
+    dividerPosition,
   } = opts;
 
   const FRONT_OFFSET = 0.002;
@@ -126,6 +128,16 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
       shelf.position.set(W / 2, y, -D / 2);
       group.add(shelf);
     }
+  }
+
+  if (dividerPosition) {
+    const divGeo = new THREE.BoxGeometry(T, H, D);
+    const divider = new THREE.Mesh(divGeo, carcMat);
+    let x = W / 2;
+    if (dividerPosition === 'left') x = W / 3;
+    else if (dividerPosition === 'right') x = (2 * W) / 3;
+    divider.position.set(x, legHeight + H / 2, -D / 2);
+    group.add(divider);
   }
 
   // Fronts

--- a/src/types.ts
+++ b/src/types.ts
@@ -77,6 +77,7 @@ export interface ModuleAdv {
   drawerFronts?: number[]
   shelves?:number
   backPanel?:'full'|'split'|'none'
+  dividerPosition?: 'left' | 'right' | 'center'
 }
 
 export interface Module3D {

--- a/src/ui/CabinetConfigurator.tsx
+++ b/src/ui/CabinetConfigurator.tsx
@@ -54,6 +54,18 @@ const CabinetConfigurator: React.FC<Props> = ({
       setDrawersCount(0)
     }
   }, [kind])
+
+  useEffect(() => {
+    const fronts = Math.max(doorsCount, drawersCount)
+    if (fronts < 3) {
+      if (gLocal.dividerPosition) setAdv({ ...gLocal, dividerPosition: undefined })
+    } else if (fronts === 4) {
+      if (gLocal.dividerPosition !== 'center')
+        setAdv({ ...gLocal, dividerPosition: 'center' })
+    } else if (fronts === 3 && !gLocal.dividerPosition) {
+      setAdv({ ...gLocal, dividerPosition: 'left' })
+    }
+  }, [doorsCount, drawersCount, gLocal])
   return (
     <div className="section">
       <div className="hd">
@@ -109,6 +121,33 @@ const CabinetConfigurator: React.FC<Props> = ({
                 </select>
               </div>
             )}
+            {Math.max(doorsCount, drawersCount) >= 3 && (
+              <div style={{ marginTop: 8 }}>
+                <div className="small">Przegroda</div>
+                {Math.max(doorsCount, drawersCount) === 3 ? (
+                  <div className="row" style={{ gap: 8 }}>
+                    <label>
+                      <input
+                        type="radio"
+                        checked={gLocal.dividerPosition === 'left'}
+                        onChange={() => setAdv({ ...gLocal, dividerPosition: 'left' })}
+                      />
+                      L
+                    </label>
+                    <label>
+                      <input
+                        type="radio"
+                        checked={gLocal.dividerPosition === 'right'}
+                        onChange={() => setAdv({ ...gLocal, dividerPosition: 'right' })}
+                      />
+                      P
+                    </label>
+                  </div>
+                ) : (
+                  <div className="small">Centralna</div>
+                )}
+              </div>
+            )}
             <div style={{marginTop:8}}>
               <TechDrawing
                 mode="view"
@@ -119,6 +158,7 @@ const CabinetConfigurator: React.FC<Props> = ({
                 doorsCount={doorsCount}
                 drawersCount={drawersCount}
                 drawerFronts={gLocal.drawerFronts}
+                dividerPosition={gLocal.dividerPosition}
               />
             </div>
             <div className="row" style={{marginTop:8}}>
@@ -133,6 +173,7 @@ const CabinetConfigurator: React.FC<Props> = ({
                 drawerFronts={gLocal.drawerFronts}
                 shelves={gLocal.shelves}
                 backPanel={gLocal.backPanel}
+                dividerPosition={gLocal.dividerPosition}
               />
             </div>
           </div>
@@ -167,6 +208,7 @@ const CabinetConfigurator: React.FC<Props> = ({
                 doorsCount={doorsCount}
                 drawersCount={drawersCount}
                 drawerFronts={gLocal.drawerFronts}
+                dividerPosition={gLocal.dividerPosition}
                 onChangeGaps={(gg: Gaps) => setAdv({ ...gLocal, gaps: gg })}
                 onChangeDrawerFronts={(arr: number[]) => setAdv({ ...gLocal, drawerFronts: arr })}
               />
@@ -183,6 +225,7 @@ const CabinetConfigurator: React.FC<Props> = ({
                 drawerFronts={gLocal.drawerFronts}
                 shelves={gLocal.shelves}
                 backPanel={gLocal.backPanel}
+                dividerPosition={gLocal.dividerPosition}
               />
             </div>
             <div className="row" style={{marginTop:8}}>

--- a/src/ui/SceneViewer.tsx
+++ b/src/ui/SceneViewer.tsx
@@ -45,6 +45,11 @@ const SceneViewer: React.FC<Props> = ({ threeRef, addCountertop }) => {
     const legHeight = getLegHeight(mod, store.globals)
     const drawers = Array.isArray(adv.drawerFronts) ? adv.drawerFronts.length : 0
     const hinge = (adv as any).hinge as 'left' | 'right' | undefined
+    const dividerPosition = (adv as any).dividerPosition as
+      | 'left'
+      | 'right'
+      | 'center'
+      | undefined
     const group = buildCabinetMesh({
       width: W,
       height: H,
@@ -57,7 +62,8 @@ const SceneViewer: React.FC<Props> = ({ threeRef, addCountertop }) => {
       backPanel: adv.backPanel,
       legHeight,
       showHandles: true,
-      hinge
+      hinge,
+      dividerPosition
     })
     group.userData.kind = 'cab'
     const fg = group.userData.frontGroups || []

--- a/src/ui/components/Cabinet3D.tsx
+++ b/src/ui/components/Cabinet3D.tsx
@@ -3,7 +3,7 @@ import * as THREE from 'three'
 import { FAMILY } from '../../core/catalog'
 import { buildCabinetMesh } from '../../scene/cabinetBuilder'
 
-export default function Cabinet3D({ widthMM, heightMM, depthMM, doorsCount, drawersCount, gaps, drawerFronts, family, shelves = 1, backPanel = 'full' }:{ widthMM:number;heightMM:number;depthMM:number;doorsCount:number;drawersCount:number;gaps:{top:number;bottom:number};drawerFronts?:number[];family:FAMILY; shelves?:number; backPanel?:'full'|'split'|'none' }){
+export default function Cabinet3D({ widthMM, heightMM, depthMM, doorsCount, drawersCount, gaps, drawerFronts, family, shelves = 1, backPanel = 'full', dividerPosition }:{ widthMM:number;heightMM:number;depthMM:number;doorsCount:number;drawersCount:number;gaps:{top:number;bottom:number};drawerFronts?:number[];family:FAMILY; shelves?:number; backPanel?:'full'|'split'|'none'; dividerPosition?:'left'|'right'|'center' }){
   const ref = useRef<HTMLDivElement>(null)
   useEffect(()=>{
     if (!ref.current) return
@@ -36,11 +36,12 @@ export default function Cabinet3D({ widthMM, heightMM, depthMM, doorsCount, draw
       family,
       shelves,
       backPanel,
-      legHeight
+      legHeight,
+      dividerPosition
     })
     scene.add(cabGroup)
     renderer.render(scene, camera)
     return () => { renderer.dispose() }
-  }, [widthMM, heightMM, depthMM, doorsCount, drawersCount, gaps, drawerFronts, family, shelves, backPanel])
+  }, [widthMM, heightMM, depthMM, doorsCount, drawersCount, gaps, drawerFronts, family, shelves, backPanel, dividerPosition])
   return <div ref={ref} style={{ width: 260, height: 190, border: '1px solid #E5E7EB', borderRadius: 8, background: '#fff' }} />
 }

--- a/src/ui/components/TechDrawing.tsx
+++ b/src/ui/components/TechDrawing.tsx
@@ -17,6 +17,7 @@ type Props = {
   doorsCount: number;
   drawersCount: number;
   drawerFronts?: number[];
+  dividerPosition?: 'left' | 'right' | 'center';
   onChangeGaps?: (g: Gaps) => void;
   onChangeDrawerFronts?: (arr: number[]) => void;
 };
@@ -114,6 +115,7 @@ export default function TechDrawing({
   doorsCount,
   drawersCount,
   drawerFronts,
+  dividerPosition,
   onChangeGaps,
   onChangeDrawerFronts,
 }: Props) {
@@ -166,6 +168,26 @@ export default function TechDrawing({
     }
     return xs;
   }, [doorsCount, front.w, front.x]);
+
+  const dividerX = useMemo(() => {
+    const fronts = doorsCount > 0 ? doorsCount : drawersCount;
+    if (!dividerPosition || fronts < 3) return null;
+    if (dividerPosition === 'center') return front.x + front.w / 2;
+    const step = front.w / fronts;
+    return dividerPosition === 'left'
+      ? front.x + step
+      : front.x + front.w - step;
+  }, [dividerPosition, doorsCount, drawersCount, front.x, front.w]);
+
+  const dividerSectionX = useMemo(() => {
+    const fronts = doorsCount > 0 ? doorsCount : drawersCount;
+    if (!dividerPosition || fronts < 3) return null;
+    const avail = innerW - 20;
+    let ratio = 0.5;
+    if (dividerPosition === 'left') ratio = 1 / fronts;
+    else if (dividerPosition === 'right') ratio = (fronts - 1) / fronts;
+    return pad + 10 + avail * ratio - 4;
+  }, [dividerPosition, doorsCount, drawersCount, innerW]);
 
   const onMouseDown = (e: React.MouseEvent<SVGSVGElement, MouseEvent>) => {
     if (mode !== 'edit') return;
@@ -279,6 +301,16 @@ export default function TechDrawing({
             strokeWidth={2}
           />
         ))}
+        {dividerX !== null && (
+          <line
+            x1={dividerX}
+            y1={front.y}
+            x2={dividerX}
+            y2={front.y + front.h}
+            stroke="#999"
+            strokeWidth={1}
+          />
+        )}
         {/* podziały szuflad */}
         {drawerSplits.map((y, i) => (
           <g key={i}>
@@ -377,6 +409,16 @@ export default function TechDrawing({
           fill="url(#hatch2)"
           stroke="#999"
         />
+        {dividerSectionX !== null && (
+          <rect
+            x={dividerSectionX}
+            y={pad}
+            width={8}
+            height={innerH}
+            fill="url(#hatch2)"
+            stroke="#999"
+          />
+        )}
         {/* plecy */}
         <rect
           x={pad + 8}

--- a/src/ui/types.ts
+++ b/src/ui/types.ts
@@ -9,5 +9,6 @@ export interface CabinetConfig {
   shelves?: number
   backPanel?: 'full' | 'split' | 'none'
   drawerFronts?: number[]
+  dividerPosition?: 'left' | 'right' | 'center'
 }
 

--- a/tests/cabinetBuilder.test.ts
+++ b/tests/cabinetBuilder.test.ts
@@ -31,6 +31,27 @@ describe('buildCabinetMesh', () => {
     expect(g.children.length).toBe(7)
   })
 
+  it('adds divider when dividerPosition provided', () => {
+    const g = buildCabinetMesh({
+      width: 1,
+      height: 0.9,
+      depth: 0.5,
+      drawers: 0,
+      doorCount: 3,
+      gaps: { top: 0, bottom: 0 },
+      family: FAMILY.BASE,
+      dividerPosition: 'left',
+    })
+    const div = g.children.find(
+      (c) =>
+        c instanceof THREE.Mesh &&
+        Math.abs(c.position.x - 1 / 3) < 0.001 &&
+        (c as THREE.Mesh).geometry instanceof THREE.BoxGeometry &&
+        (c as any).geometry.parameters.width === 0.018
+    )
+    expect(div).toBeTruthy()
+  })
+
   it('matches provided dimensions', () => {
     const width = 0.8
     const height = 0.7


### PR DESCRIPTION
## Summary
- allow selecting divider position for cabinets with ≥3 doors or drawers
- include divider position in cabinet configuration and 3D/2D rendering
- add tests for divider placement in cabinet builder

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3640960a083229ebfbf0277394cef