### PR TITLE
feat: add accordion panels to cabinet configurator

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -89,7 +89,14 @@
       "split": "split",
       "none": "none"
     },
-    "backToBasic": "← Basic"
+    "backToBasic": "← Basic",
+    "corpus": "Carcass",
+    "fronts": "Fronts",
+    "fittings": "Fittings",
+    "legs": "Legs",
+    "hinge": "Hinge",
+    "drawerSlide": "Drawer slide",
+    "aventos": "Aventos"
   },
   "forms": {
     "width": "Width",

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -89,7 +89,14 @@
       "split": "split",
       "none": "none"
     },
-    "backToBasic": "← Podstawowe"
+    "backToBasic": "← Podstawowe",
+    "corpus": "Korpus",
+    "fronts": "Fronty",
+    "fittings": "Okucie",
+    "legs": "Nóżki",
+    "hinge": "Zawias",
+    "drawerSlide": "Prowadnice",
+    "aventos": "Aventos"
   },
   "forms": {
     "width": "Szerokość",

--- a/src/ui/CabinetConfigurator.tsx
+++ b/src/ui/CabinetConfigurator.tsx
@@ -4,6 +4,7 @@ import { FAMILY, Kind, Variant } from '../core/catalog'
 import { usePlannerStore } from '../state/store'
 import TechDrawing from './components/TechDrawing'
 import Cabinet3D from './components/Cabinet3D'
+import Accordion from './components/Accordion'
 import { CabinetConfig } from './types'
 import { Gaps } from '../types'
 
@@ -179,40 +180,61 @@ const CabinetConfigurator: React.FC<Props> = ({
           </div>
         )}
         {cfgTab==='adv' && (
-          <div>
-            <div className="grid4">
-              <div><div className="small">{t('configurator.height')}</div><input className="input" type="number" value={gLocal.height} onChange={e=>setAdv({...gLocal, height:Number((e.target as HTMLInputElement).value)||0})} /></div>
-              <div><div className="small">{t('configurator.depth')}</div><input className="input" type="number" value={gLocal.depth} onChange={e=>setAdv({...gLocal, depth:Number((e.target as HTMLInputElement).value)||0})} /></div>
-              <div><div className="small">{t('configurator.board')}</div><select className="input" value={gLocal.boardType} onChange={e=>setAdv({...gLocal, boardType:(e.target as HTMLSelectElement).value})}>{Object.keys(store.prices.board).map(k=><option key={k} value={k}>{k}</option>)}</select></div>
-              <div><div className="small">{t('configurator.front')}</div><select className="input" value={gLocal.frontType} onChange={e=>setAdv({...gLocal, frontType:(e.target as HTMLSelectElement).value})}>{Object.keys(store.prices.front).map(k=><option key={k} value={k}>{k}</option>)}</select></div>
-              <div><div className="small">{t('configurator.back')}</div><select className="input" value={gLocal.backPanel||'full'} onChange={e=>setAdv({...gLocal, backPanel:(e.target as HTMLSelectElement).value})}>
-                <option value="full">{t('configurator.backOptions.full')}</option>
-                <option value="split">{t('configurator.backOptions.split')}</option>
-                <option value="none">{t('configurator.backOptions.none')}</option>
-              </select></div>
-            </div>
-            {drawersCount === 0 && (
-              <div style={{marginTop:8}}>
-                <div className="small">{t('configurator.shelves')}</div>
-                <input className="input" type="number" min={0} value={gLocal.shelves||0} onChange={e=>setAdv({...gLocal, shelves:Number((e.target as HTMLInputElement).value)||0})} />
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+            <Accordion title={t('configurator.corpus')}>
+              <div className="grid4">
+                <div><div className="small">{t('configurator.height')}</div><input className="input" type="number" value={gLocal.height} onChange={e=>setAdv({...gLocal, height:Number((e.target as HTMLInputElement).value)||0})} /></div>
+                <div><div className="small">{t('configurator.depth')}</div><input className="input" type="number" value={gLocal.depth} onChange={e=>setAdv({...gLocal, depth:Number((e.target as HTMLInputElement).value)||0})} /></div>
+                <div><div className="small">{t('configurator.board')}</div><select className="input" value={gLocal.boardType} onChange={e=>setAdv({...gLocal, boardType:(e.target as HTMLSelectElement).value})}>{Object.keys(store.prices.board).map(k=><option key={k} value={k}>{k}</option>)}</select></div>
+                <div><div className="small">{t('configurator.back')}</div><select className="input" value={gLocal.backPanel||'full'} onChange={e=>setAdv({...gLocal, backPanel:(e.target as HTMLSelectElement).value})}>
+                  <option value="full">{t('configurator.backOptions.full')}</option>
+                  <option value="split">{t('configurator.backOptions.split')}</option>
+                  <option value="none">{t('configurator.backOptions.none')}</option>
+                </select></div>
               </div>
-            )}
-            <div style={{marginTop:8}}>
-              <div className="small">{t('configurator.gapsTitle')}</div>
-              <TechDrawing
-                mode="edit"
-                widthMM={widthMM}
-                heightMM={gLocal.height}
-                depthMM={gLocal.depth}
-                gaps={gLocal.gaps}
-                doorsCount={doorsCount}
-                drawersCount={drawersCount}
-                drawerFronts={gLocal.drawerFronts}
-                dividerPosition={gLocal.dividerPosition}
-                onChangeGaps={(gg: Gaps) => setAdv({ ...gLocal, gaps: gg })}
-                onChangeDrawerFronts={(arr: number[]) => setAdv({ ...gLocal, drawerFronts: arr })}
-              />
-            </div>
+              {drawersCount === 0 && (
+                <div style={{marginTop:8}}>
+                  <div className="small">{t('configurator.shelves')}</div>
+                  <input className="input" type="number" min={0} value={gLocal.shelves||0} onChange={e=>setAdv({...gLocal, shelves:Number((e.target as HTMLInputElement).value)||0})} />
+                </div>
+              )}
+            </Accordion>
+            <Accordion title={t('configurator.fronts')}>
+              <div className="grid4">
+                <div><div className="small">{t('configurator.front')}</div><select className="input" value={gLocal.frontType} onChange={e=>setAdv({...gLocal, frontType:(e.target as HTMLSelectElement).value})}>{Object.keys(store.prices.front).map(k=><option key={k} value={k}>{k}</option>)}</select></div>
+              </div>
+              <div style={{marginTop:8}}>
+                <div className="small">{t('configurator.gapsTitle')}</div>
+                <TechDrawing
+                  mode="edit"
+                  widthMM={widthMM}
+                  heightMM={gLocal.height}
+                  depthMM={gLocal.depth}
+                  gaps={gLocal.gaps}
+                  doorsCount={doorsCount}
+                  drawersCount={drawersCount}
+                  drawerFronts={gLocal.drawerFronts}
+                  dividerPosition={gLocal.dividerPosition}
+                  onChangeGaps={(gg: Gaps) => setAdv({ ...gLocal, gaps: gg })}
+                  onChangeDrawerFronts={(arr: number[]) => setAdv({ ...gLocal, drawerFronts: arr })}
+                />
+              </div>
+            </Accordion>
+            <Accordion title={t('configurator.fittings')}>
+              {kind?.key === 'doors' ? (
+                <div><div className="small">{t('configurator.hinge')}</div><select className="input" value={(gLocal as any).hinge || Object.keys(store.prices.hinges)[0]} onChange={e=>setAdv({ ...gLocal, hinge:(e.target as HTMLSelectElement).value } as any)}>{Object.keys(store.prices.hinges).map(k=><option key={k} value={k}>{k}</option>)}</select></div>
+              ) : kind?.key === 'drawers' ? (
+                <div><div className="small">{t('configurator.drawerSlide')}</div><select className="input" value={(gLocal as any).drawerSlide || Object.keys(store.prices.drawerSlide)[0]} onChange={e=>setAdv({ ...gLocal, drawerSlide:(e.target as HTMLSelectElement).value } as any)}>{Object.keys(store.prices.drawerSlide).map(k=><option key={k} value={k}>{k}</option>)}</select></div>
+              ) : (
+                <div><div className="small">{t('configurator.aventos')}</div><select className="input" value={(gLocal as any).aventos || Object.keys(store.prices.aventos)[0]} onChange={e=>setAdv({ ...gLocal, aventos:(e.target as HTMLSelectElement).value } as any)}>{Object.keys(store.prices.aventos).map(k=><option key={k} value={k}>{k}</option>)}</select></div>
+              )}
+            </Accordion>
+            <Accordion title={t('configurator.legs')}>
+              <div className="grid4">
+                <div><div className="small">{t('global.legs')}</div><select className="input" value={(gLocal as any).legsType || store.globals[family].legsType} onChange={e=>setAdv({ ...gLocal, legsType:(e.target as HTMLSelectElement).value } as any)}>{Object.keys(store.prices.legs).map(k=><option key={k} value={k}>{k}</option>)}</select></div>
+                <div><div className="small">{t('global.legsHeight')}</div><input className="input" type="number" value={(gLocal as any).legsHeight ?? store.globals[family].legsHeight || 0} onChange={e=>setAdv({ ...gLocal, legsHeight:Number((e.target as HTMLInputElement).value)||0 } as any)} /></div>
+              </div>
+            </Accordion>
             <div className="row" style={{marginTop:8}}>
               <Cabinet3D
                 family={family}

--- a/src/ui/components/Accordion.tsx
+++ b/src/ui/components/Accordion.tsx
@@ -1,0 +1,22 @@
+import React, { useState } from 'react';
+
+interface AccordionProps {
+  title: React.ReactNode;
+  children: React.ReactNode;
+  defaultOpen?: boolean;
+}
+
+const Accordion: React.FC<AccordionProps> = ({ title, children, defaultOpen = true }) => {
+  const [open, setOpen] = useState(defaultOpen);
+  return (
+    <div className="section">
+      <div className="hd" onClick={() => setOpen(!open)} style={{ cursor: 'pointer', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        <div>{title}</div>
+        <div>{open ? '-' : '+'}</div>
+      </div>
+      {open && <div className="bd">{children}</div>}
+    </div>
+  );
+};
+
+export default Accordion;


### PR DESCRIPTION
## Summary
- add reusable Accordion component
- reorganize cabinet configurator advanced tab into Carcass, Fronts, Fittings, and Legs panels
- support dynamic hinge/slide/aventos and leg configuration with translations

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3656ce8e08322855552d6c4ce674e