### PR TITLE
Add door and drawer controls in cabinet forms

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -94,7 +94,15 @@
   "forms": {
     "width": "Width",
     "height": "Height",
-    "depth": "Depth"
+    "depth": "Depth",
+    "doorsCount": "Doors count",
+    "drawersCount": "Drawers count",
+    "sections": {
+      "dimensions": "Dimensions",
+      "fronts": "Fronts",
+      "advanced": "Advanced",
+      "hardware": "Hardware"
+    }
   },
   "costs": {
     "title": "Costs",

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -94,7 +94,15 @@
   "forms": {
     "width": "Szerokość",
     "height": "Wysokość",
-    "depth": "Głębokość"
+    "depth": "Głębokość",
+    "doorsCount": "Liczba drzwi",
+    "drawersCount": "Liczba szuflad",
+    "sections": {
+      "dimensions": "Wymiary",
+      "fronts": "Fronty",
+      "advanced": "Zaawansowane",
+      "hardware": "Okucia"
+    }
   },
   "costs": {
     "title": "Koszty",

--- a/src/ui/CabinetConfigurator.tsx
+++ b/src/ui/CabinetConfigurator.tsx
@@ -6,6 +6,14 @@ import TechDrawing from './components/TechDrawing'
 import Cabinet3D from './components/Cabinet3D'
 import { CabinetConfig } from './types'
 import { Gaps } from '../types'
+import {
+  CornerCabinetForm,
+  SinkCabinetForm,
+  CargoCabinetForm,
+  ApplianceCabinetForm,
+  CabinetFormValues,
+  CabinetFormProps,
+} from './forms'
 
 interface Props {
   family: FAMILY
@@ -25,6 +33,13 @@ interface Props {
   ) => void
 }
 
+const FORM_COMPONENTS: Record<string, React.ComponentType<CabinetFormProps>> = {
+  corner: CornerCabinetForm,
+  sink: SinkCabinetForm,
+  cargo: CargoCabinetForm,
+  appliance: ApplianceCabinetForm,
+}
+
 const CabinetConfigurator: React.FC<Props> = ({
   family,
   kind,
@@ -41,6 +56,21 @@ const CabinetConfigurator: React.FC<Props> = ({
   const { t } = useTranslation()
   const [doorsCount, setDoorsCount] = useState(1)
   const [drawersCount, setDrawersCount] = useState(0)
+  const FormComponent = kind ? FORM_COMPONENTS[kind.key] : null
+  const formValues: CabinetFormValues = {
+    width: widthMM,
+    height: gLocal.height,
+    depth: gLocal.depth,
+    doorsCount,
+    drawersCount,
+    adv: gLocal,
+  }
+  const handleFormChange = (vals: CabinetFormValues) => {
+    setWidthMM(vals.width)
+    setAdv({ ...gLocal, height: vals.height, depth: vals.depth })
+    if (typeof vals.doorsCount === 'number') setDoorsCount(vals.doorsCount)
+    if (typeof vals.drawersCount === 'number') setDrawersCount(vals.drawersCount)
+  }
 
   useEffect(() => {
     if (kind?.key === 'doors') {
@@ -180,6 +210,11 @@ const CabinetConfigurator: React.FC<Props> = ({
         )}
         {cfgTab==='adv' && (
           <div>
+            {FormComponent && (
+              <div style={{marginBottom:8}}>
+                <FormComponent values={formValues} onChange={handleFormChange} />
+              </div>
+            )}
             <div className="grid4">
               <div><div className="small">{t('configurator.height')}</div><input className="input" type="number" value={gLocal.height} onChange={e=>setAdv({...gLocal, height:Number((e.target as HTMLInputElement).value)||0})} /></div>
               <div><div className="small">{t('configurator.depth')}</div><input className="input" type="number" value={gLocal.depth} onChange={e=>setAdv({...gLocal, depth:Number((e.target as HTMLInputElement).value)||0})} /></div>

--- a/src/ui/forms/ApplianceCabinetForm.tsx
+++ b/src/ui/forms/ApplianceCabinetForm.tsx
@@ -5,16 +5,38 @@ import { CabinetFormValues, CabinetFormProps } from './CornerCabinetForm'
 
 export default function ApplianceCabinetForm({ values, onChange }: CabinetFormProps){
   const { t } = useTranslation()
-  const { width, height, depth, adv, hardware } = values
+  const { width, height, depth, doorsCount = 0, drawersCount = 0, adv, hardware } = values
   const update = (patch: Partial<CabinetFormValues>) => onChange({ ...values, ...patch })
   return (
     <div>
-      <SingleMMInput label={t('forms.width')} value={width} onChange={w=>update({ width:w })} />
-      <SingleMMInput label={t('forms.height')} value={height} onChange={h=>update({ height:h })} />
-      <SingleMMInput label={t('forms.depth')} value={depth} onChange={d=>update({ depth:d })} />
-      {/* Appliance specific options such as appliance type could be configured elsewhere. */}
-      {adv && <pre style={{ display:'none' }}>{JSON.stringify(adv)}</pre>}
-      {hardware && <pre style={{ display:'none' }}>{JSON.stringify(hardware)}</pre>}
+      <details open>
+        <summary>{t('forms.sections.dimensions')}</summary>
+        <div>
+          <div className="small">{t('forms.width')}</div>
+          <SingleMMInput value={width} onChange={w=>update({ width:w })} />
+          <div className="small">{t('forms.height')}</div>
+          <SingleMMInput value={height} onChange={h=>update({ height:h })} />
+          <div className="small">{t('forms.depth')}</div>
+          <SingleMMInput value={depth} onChange={d=>update({ depth:d })} />
+        </div>
+      </details>
+      <details>
+        <summary>{t('forms.sections.fronts')}</summary>
+        <div>
+          <div className="small">{t('forms.doorsCount')}</div>
+          <SingleMMInput min={0} step={1} value={doorsCount} onChange={n=>update({ doorsCount:n })} />
+          <div className="small">{t('forms.drawersCount')}</div>
+          <SingleMMInput min={0} step={1} value={drawersCount} onChange={n=>update({ drawersCount:n })} />
+        </div>
+      </details>
+      <details>
+        <summary>{t('forms.sections.advanced')}</summary>
+        {adv && <pre style={{ display:'none' }}>{JSON.stringify(adv)}</pre>}
+      </details>
+      <details>
+        <summary>{t('forms.sections.hardware')}</summary>
+        {hardware && <pre style={{ display:'none' }}>{JSON.stringify(hardware)}</pre>}
+      </details>
     </div>
   )
 }

--- a/src/ui/forms/CargoCabinetForm.tsx
+++ b/src/ui/forms/CargoCabinetForm.tsx
@@ -5,16 +5,38 @@ import { CabinetFormValues, CabinetFormProps } from './CornerCabinetForm'
 
 export default function CargoCabinetForm({ values, onChange }: CabinetFormProps){
   const { t } = useTranslation()
-  const { width, height, depth, adv, hardware } = values
+  const { width, height, depth, doorsCount = 0, drawersCount = 0, adv, hardware } = values
   const update = (patch: Partial<CabinetFormValues>) => onChange({ ...values, ...patch })
   return (
     <div>
-      <SingleMMInput label={t('forms.width')} value={width} onChange={w=>update({ width:w })} />
-      <SingleMMInput label={t('forms.height')} value={height} onChange={h=>update({ height:h })} />
-      <SingleMMInput label={t('forms.depth')} value={depth} onChange={d=>update({ depth:d })} />
-      {/* Cargo specific options such as basket count could be added here. */}
-      {adv && <pre style={{ display:'none' }}>{JSON.stringify(adv)}</pre>}
-      {hardware && <pre style={{ display:'none' }}>{JSON.stringify(hardware)}</pre>}
+      <details open>
+        <summary>{t('forms.sections.dimensions')}</summary>
+        <div>
+          <div className="small">{t('forms.width')}</div>
+          <SingleMMInput value={width} onChange={w=>update({ width:w })} />
+          <div className="small">{t('forms.height')}</div>
+          <SingleMMInput value={height} onChange={h=>update({ height:h })} />
+          <div className="small">{t('forms.depth')}</div>
+          <SingleMMInput value={depth} onChange={d=>update({ depth:d })} />
+        </div>
+      </details>
+      <details>
+        <summary>{t('forms.sections.fronts')}</summary>
+        <div>
+          <div className="small">{t('forms.doorsCount')}</div>
+          <SingleMMInput min={0} step={1} value={doorsCount} onChange={n=>update({ doorsCount:n })} />
+          <div className="small">{t('forms.drawersCount')}</div>
+          <SingleMMInput min={0} step={1} value={drawersCount} onChange={n=>update({ drawersCount:n })} />
+        </div>
+      </details>
+      <details>
+        <summary>{t('forms.sections.advanced')}</summary>
+        {adv && <pre style={{ display:'none' }}>{JSON.stringify(adv)}</pre>}
+      </details>
+      <details>
+        <summary>{t('forms.sections.hardware')}</summary>
+        {hardware && <pre style={{ display:'none' }}>{JSON.stringify(hardware)}</pre>}
+      </details>
     </div>
   )
 }

--- a/src/ui/forms/CornerCabinetForm.tsx
+++ b/src/ui/forms/CornerCabinetForm.tsx
@@ -6,6 +6,8 @@ export interface CabinetFormValues {
   width: number
   height: number
   depth: number
+  doorsCount?: number
+  drawersCount?: number
   adv?: any
   hardware?: any
 }
@@ -17,16 +19,38 @@ export interface CabinetFormProps {
 
 export default function CornerCabinetForm({ values, onChange }: CabinetFormProps){
   const { t } = useTranslation()
-  const { width, height, depth, adv, hardware } = values
+  const { width, height, depth, doorsCount = 0, drawersCount = 0, adv, hardware } = values
   const update = (patch: Partial<CabinetFormValues>) => onChange({ ...values, ...patch })
   return (
     <div>
-      <SingleMMInput label={t('forms.width')} value={width} onChange={w=>update({ width:w })} />
-      <SingleMMInput label={t('forms.height')} value={height} onChange={h=>update({ height:h })} />
-      <SingleMMInput label={t('forms.depth')} value={depth} onChange={d=>update({ depth:d })} />
-      {/* Advanced settings and hardware options are passed through unchanged */}
-      {adv && <pre style={{ display:'none' }}>{JSON.stringify(adv)}</pre>}
-      {hardware && <pre style={{ display:'none' }}>{JSON.stringify(hardware)}</pre>}
+      <details open>
+        <summary>{t('forms.sections.dimensions')}</summary>
+        <div>
+          <div className="small">{t('forms.width')}</div>
+          <SingleMMInput value={width} onChange={w=>update({ width:w })} />
+          <div className="small">{t('forms.height')}</div>
+          <SingleMMInput value={height} onChange={h=>update({ height:h })} />
+          <div className="small">{t('forms.depth')}</div>
+          <SingleMMInput value={depth} onChange={d=>update({ depth:d })} />
+        </div>
+      </details>
+      <details>
+        <summary>{t('forms.sections.fronts')}</summary>
+        <div>
+          <div className="small">{t('forms.doorsCount')}</div>
+          <SingleMMInput min={0} step={1} value={doorsCount} onChange={n=>update({ doorsCount:n })} />
+          <div className="small">{t('forms.drawersCount')}</div>
+          <SingleMMInput min={0} step={1} value={drawersCount} onChange={n=>update({ drawersCount:n })} />
+        </div>
+      </details>
+      <details>
+        <summary>{t('forms.sections.advanced')}</summary>
+        {adv && <pre style={{ display:'none' }}>{JSON.stringify(adv)}</pre>}
+      </details>
+      <details>
+        <summary>{t('forms.sections.hardware')}</summary>
+        {hardware && <pre style={{ display:'none' }}>{JSON.stringify(hardware)}</pre>}
+      </details>
     </div>
   )
 }

--- a/src/ui/forms/SinkCabinetForm.tsx
+++ b/src/ui/forms/SinkCabinetForm.tsx
@@ -5,16 +5,39 @@ import { CabinetFormValues, CabinetFormProps } from './CornerCabinetForm'
 
 export default function SinkCabinetForm({ values, onChange }: CabinetFormProps){
   const { t } = useTranslation()
-  const { width, height, depth, adv, hardware } = values
+  const { width, height, depth, doorsCount = 0, drawersCount = 0, adv, hardware } = values
   const update = (patch: Partial<CabinetFormValues>) => onChange({ ...values, ...patch })
   return (
     <div>
-      <SingleMMInput label={t('forms.width')} value={width} onChange={w=>update({ width:w })} />
-      <SingleMMInput label={t('forms.height')} value={height} onChange={h=>update({ height:h })} />
-      <SingleMMInput label={t('forms.depth')} value={depth} onChange={d=>update({ depth:d })} />
-      {/* Sink specific advanced settings may include bowl size or position. */}
-      {adv && <pre style={{ display:'none' }}>{JSON.stringify(adv)}</pre>}
-      {hardware && <pre style={{ display:'none' }}>{JSON.stringify(hardware)}</pre>}
+      <details open>
+        <summary>{t('forms.sections.dimensions')}</summary>
+        <div>
+          <div className="small">{t('forms.width')}</div>
+          <SingleMMInput value={width} onChange={w=>update({ width:w })} />
+          <div className="small">{t('forms.height')}</div>
+          <SingleMMInput value={height} onChange={h=>update({ height:h })} />
+          <div className="small">{t('forms.depth')}</div>
+          <SingleMMInput value={depth} onChange={d=>update({ depth:d })} />
+        </div>
+      </details>
+      <details>
+        <summary>{t('forms.sections.fronts')}</summary>
+        <div>
+          <div className="small">{t('forms.doorsCount')}</div>
+          <SingleMMInput min={0} step={1} value={doorsCount} onChange={n=>update({ doorsCount:n })} />
+          <div className="small">{t('forms.drawersCount')}</div>
+          <SingleMMInput min={0} step={1} value={drawersCount} onChange={n=>update({ drawersCount:n })} />
+        </div>
+      </details>
+      <details>
+        <summary>{t('forms.sections.advanced')}</summary>
+        {/* Sink specific advanced settings may include bowl size or position. */}
+        {adv && <pre style={{ display:'none' }}>{JSON.stringify(adv)}</pre>}
+      </details>
+      <details>
+        <summary>{t('forms.sections.hardware')}</summary>
+        {hardware && <pre style={{ display:'none' }}>{JSON.stringify(hardware)}</pre>}
+      </details>
     </div>
   )
 }

--- a/tests/cabinetBuilder.test.ts
+++ b/tests/cabinetBuilder.test.ts
@@ -19,6 +19,21 @@ describe('buildCabinetMesh', () => {
     expect(g.children.length).toBe(7)
   })
 
+  it('creates provided number of drawer groups', () => {
+    const g = buildCabinetMesh({
+      width: 1,
+      height: 0.9,
+      depth: 0.5,
+      drawers: 3,
+      gaps: { top: 0, bottom: 0 },
+      family: FAMILY.BASE,
+    })
+    const drawers = g.children.filter(
+      (c) => c instanceof THREE.Group && (c as any).userData.type === 'drawer'
+    )
+    expect(drawers.length).toBe(3)
+  })
+
   it('returns group with expected children for doors', () => {
     const g = buildCabinetMesh({
       width: 1,
@@ -29,6 +44,22 @@ describe('buildCabinetMesh', () => {
       family: FAMILY.BASE,
     })
     expect(g.children.length).toBe(7)
+  })
+
+  it('creates provided number of door groups', () => {
+    const g = buildCabinetMesh({
+      width: 1,
+      height: 0.9,
+      depth: 0.5,
+      drawers: 0,
+      doorCount: 2,
+      gaps: { top: 0, bottom: 0 },
+      family: FAMILY.BASE,
+    })
+    const doors = g.children.filter(
+      (c) => c instanceof THREE.Group && (c as any).userData.type === 'door'
+    )
+    expect(doors.length).toBe(2)
   })
 
   it('adds divider when dividerPosition provided', () => {


### PR DESCRIPTION
## Summary
- extend cabinet form interfaces with door and drawer counts and use accordions
- pass form values through CabinetConfigurator and update translations
- verify door and drawer counts in cabinet builder tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b369a2cd8083228e6da57b6795255e