### PR TITLE
Show configurator after variant selection

### DIFF
--- a/src/ui/MainTabs.tsx
+++ b/src/ui/MainTabs.tsx
@@ -127,7 +127,7 @@ export default function MainTabs({
               </div>
             </div>
 
-            {kind && (
+            {kind && !variant && (
               <div className="section">
                 <div className="hd">
                   <div>


### PR DESCRIPTION
## Summary
- display CabinetConfigurator immediately when a variant is chosen

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3763065688322bff8cd3e0069db77