### PR TITLE
feat: add configurator sections

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -71,8 +71,12 @@
   },
   "configurator": {
     "title": "Configuration — {{variant}}",
-    "basic": "Basic",
-    "advanced": "Advanced",
+    "sections": {
+      "korpus": "Carcass",
+      "fronty": "Fronts",
+      "okucie": "Hardware",
+      "nozki": "Legs"
+    },
     "width": "Width (mm)",
     "insertCabinet": "Insert cabinet",
     "doorsCount": "Doors count",
@@ -88,8 +92,7 @@
       "full": "full",
       "split": "split",
       "none": "none"
-    },
-    "backToBasic": "← Basic"
+    }
   },
   "forms": {
     "width": "Width",

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -71,8 +71,12 @@
   },
   "configurator": {
     "title": "Konfiguracja — {{variant}}",
-    "basic": "Podstawowe",
-    "advanced": "Zaawansowane",
+    "sections": {
+      "korpus": "Korpus",
+      "fronty": "Fronty",
+      "okucie": "Okucie",
+      "nozki": "Nóżki"
+    },
     "width": "Szerokość (mm)",
     "insertCabinet": "Wstaw szafkę",
     "doorsCount": "Liczba drzwi",
@@ -88,8 +92,7 @@
       "full": "full",
       "split": "split",
       "none": "none"
-    },
-    "backToBasic": "← Podstawowe"
+    }
   },
   "forms": {
     "width": "Szerokość",

--- a/src/ui/CabinetConfigurator.tsx
+++ b/src/ui/CabinetConfigurator.tsx
@@ -181,7 +181,7 @@ const CabinetConfigurator: React.FC<Props> = ({
         </div>
 
         <details>
-          <summary>Korpus</summary>
+          <summary>{t('configurator.sections.korpus')}</summary>
           <div>
             {FormComponent && (
               <div style={{ marginBottom: 8 }}>
@@ -279,7 +279,7 @@ const CabinetConfigurator: React.FC<Props> = ({
         </details>
 
         <details>
-          <summary>Fronty</summary>
+          <summary>{t('configurator.sections.fronty')}</summary>
           <div>
             <div className="grid4">
               <div>
@@ -330,7 +330,7 @@ const CabinetConfigurator: React.FC<Props> = ({
         </details>
 
         <details>
-          <summary>Okucie</summary>
+          <summary>{t('configurator.sections.okucie')}</summary>
           <div>
             <div className="grid2">
               <div>
@@ -346,7 +346,7 @@ const CabinetConfigurator: React.FC<Props> = ({
         </details>
 
         <details>
-          <summary>Nóżki</summary>
+          <summary>{t('configurator.sections.nozki')}</summary>
           <div>
             <div className="grid2">
               <div>

--- a/src/ui/forms/ApplianceCabinetForm.tsx
+++ b/src/ui/forms/ApplianceCabinetForm.tsx
@@ -10,7 +10,7 @@ export default function ApplianceCabinetForm({ values, onChange }: CabinetFormPr
   return (
     <div>
       <details open>
-        <summary>{t('forms.sections.dimensions')}</summary>
+        <summary>{t('configurator.sections.korpus')}</summary>
         <div>
           <div className="small">{t('forms.width')}</div>
           <SingleMMInput value={width} onChange={w=>update({ width:w })} />
@@ -21,7 +21,7 @@ export default function ApplianceCabinetForm({ values, onChange }: CabinetFormPr
         </div>
       </details>
       <details>
-        <summary>{t('forms.sections.fronts')}</summary>
+        <summary>{t('configurator.sections.fronty')}</summary>
         <div>
           <div className="small">{t('forms.doorsCount')}</div>
           <SingleMMInput min={0} step={1} value={doorsCount} onChange={n=>update({ doorsCount:n })} />
@@ -30,11 +30,11 @@ export default function ApplianceCabinetForm({ values, onChange }: CabinetFormPr
         </div>
       </details>
       <details>
-        <summary>{t('forms.sections.advanced')}</summary>
+        <summary>{t('configurator.sections.okucie')}</summary>
         {adv && <pre style={{ display:'none' }}>{JSON.stringify(adv)}</pre>}
       </details>
       <details>
-        <summary>{t('forms.sections.hardware')}</summary>
+        <summary>{t('configurator.sections.nozki')}</summary>
         {hardware && <pre style={{ display:'none' }}>{JSON.stringify(hardware)}</pre>}
       </details>
     </div>

--- a/src/ui/forms/CargoCabinetForm.tsx
+++ b/src/ui/forms/CargoCabinetForm.tsx
@@ -10,7 +10,7 @@ export default function CargoCabinetForm({ values, onChange }: CabinetFormProps)
   return (
     <div>
       <details open>
-        <summary>{t('forms.sections.dimensions')}</summary>
+        <summary>{t('configurator.sections.korpus')}</summary>
         <div>
           <div className="small">{t('forms.width')}</div>
           <SingleMMInput value={width} onChange={w=>update({ width:w })} />
@@ -21,7 +21,7 @@ export default function CargoCabinetForm({ values, onChange }: CabinetFormProps)
         </div>
       </details>
       <details>
-        <summary>{t('forms.sections.fronts')}</summary>
+        <summary>{t('configurator.sections.fronty')}</summary>
         <div>
           <div className="small">{t('forms.doorsCount')}</div>
           <SingleMMInput min={0} step={1} value={doorsCount} onChange={n=>update({ doorsCount:n })} />
@@ -30,11 +30,11 @@ export default function CargoCabinetForm({ values, onChange }: CabinetFormProps)
         </div>
       </details>
       <details>
-        <summary>{t('forms.sections.advanced')}</summary>
+        <summary>{t('configurator.sections.okucie')}</summary>
         {adv && <pre style={{ display:'none' }}>{JSON.stringify(adv)}</pre>}
       </details>
       <details>
-        <summary>{t('forms.sections.hardware')}</summary>
+        <summary>{t('configurator.sections.nozki')}</summary>
         {hardware && <pre style={{ display:'none' }}>{JSON.stringify(hardware)}</pre>}
       </details>
     </div>

--- a/src/ui/forms/CornerCabinetForm.tsx
+++ b/src/ui/forms/CornerCabinetForm.tsx
@@ -24,7 +24,7 @@ export default function CornerCabinetForm({ values, onChange }: CabinetFormProps
   return (
     <div>
       <details open>
-        <summary>{t('forms.sections.dimensions')}</summary>
+        <summary>{t('configurator.sections.korpus')}</summary>
         <div>
           <div className="small">{t('forms.width')}</div>
           <SingleMMInput value={width} onChange={w=>update({ width:w })} />
@@ -35,7 +35,7 @@ export default function CornerCabinetForm({ values, onChange }: CabinetFormProps
         </div>
       </details>
       <details>
-        <summary>{t('forms.sections.fronts')}</summary>
+        <summary>{t('configurator.sections.fronty')}</summary>
         <div>
           <div className="small">{t('forms.doorsCount')}</div>
           <SingleMMInput min={0} step={1} value={doorsCount} onChange={n=>update({ doorsCount:n })} />
@@ -44,11 +44,11 @@ export default function CornerCabinetForm({ values, onChange }: CabinetFormProps
         </div>
       </details>
       <details>
-        <summary>{t('forms.sections.advanced')}</summary>
+        <summary>{t('configurator.sections.okucie')}</summary>
         {adv && <pre style={{ display:'none' }}>{JSON.stringify(adv)}</pre>}
       </details>
       <details>
-        <summary>{t('forms.sections.hardware')}</summary>
+        <summary>{t('configurator.sections.nozki')}</summary>
         {hardware && <pre style={{ display:'none' }}>{JSON.stringify(hardware)}</pre>}
       </details>
     </div>

--- a/src/ui/forms/SinkCabinetForm.tsx
+++ b/src/ui/forms/SinkCabinetForm.tsx
@@ -10,7 +10,7 @@ export default function SinkCabinetForm({ values, onChange }: CabinetFormProps){
   return (
     <div>
       <details open>
-        <summary>{t('forms.sections.dimensions')}</summary>
+        <summary>{t('configurator.sections.korpus')}</summary>
         <div>
           <div className="small">{t('forms.width')}</div>
           <SingleMMInput value={width} onChange={w=>update({ width:w })} />
@@ -21,7 +21,7 @@ export default function SinkCabinetForm({ values, onChange }: CabinetFormProps){
         </div>
       </details>
       <details>
-        <summary>{t('forms.sections.fronts')}</summary>
+        <summary>{t('configurator.sections.fronty')}</summary>
         <div>
           <div className="small">{t('forms.doorsCount')}</div>
           <SingleMMInput min={0} step={1} value={doorsCount} onChange={n=>update({ doorsCount:n })} />
@@ -30,12 +30,12 @@ export default function SinkCabinetForm({ values, onChange }: CabinetFormProps){
         </div>
       </details>
       <details>
-        <summary>{t('forms.sections.advanced')}</summary>
+        <summary>{t('configurator.sections.okucie')}</summary>
         {/* Sink specific advanced settings may include bowl size or position. */}
         {adv && <pre style={{ display:'none' }}>{JSON.stringify(adv)}</pre>}
       </details>
       <details>
-        <summary>{t('forms.sections.hardware')}</summary>
+        <summary>{t('configurator.sections.nozki')}</summary>
         {hardware && <pre style={{ display:'none' }}>{JSON.stringify(hardware)}</pre>}
       </details>
     </div>


### PR DESCRIPTION
## Summary
- add `configurator.sections` translations for corpus, fronts, hardware and legs
- remove unused basic/advanced/backToBasic strings
- switch forms and configurator UI to new section keys

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b37749d7048322a7091a97817f3280