### PR TITLE
Refine cabinet form sections and rely on configurator inputs

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -101,10 +101,11 @@
     "doorsCount": "Doors count",
     "drawersCount": "Drawers count",
     "sections": {
-      "dimensions": "Dimensions",
-      "fronts": "Fronts",
+      "korpus": "Carcass",
+      "fronty": "Fronts",
       "advanced": "Advanced",
-      "hardware": "Hardware"
+      "okucie": "Hardware",
+      "nozki": "Legs"
     }
   },
   "costs": {

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -101,10 +101,11 @@
     "doorsCount": "Liczba drzwi",
     "drawersCount": "Liczba szuflad",
     "sections": {
-      "dimensions": "Wymiary",
-      "fronts": "Fronty",
+      "korpus": "Korpus",
+      "fronty": "Fronty",
       "advanced": "Zaawansowane",
-      "hardware": "Okucia"
+      "okucie": "Okucie",
+      "nozki": "Nóżki"
     }
   },
   "costs": {

--- a/src/ui/CabinetConfigurator.tsx
+++ b/src/ui/CabinetConfigurator.tsx
@@ -54,18 +54,19 @@ const CabinetConfigurator: React.FC<Props> = ({
   const [drawersCount, setDrawersCount] = useState(0)
   const FormComponent = kind ? FORM_COMPONENTS[kind.key] : null
   const formValues: CabinetFormValues = {
-    width: widthMM,
     height: gLocal.height,
     depth: gLocal.depth,
-    doorsCount,
-    drawersCount,
-    adv: gLocal,
+    hardware: gLocal.hardware,
+    legs: gLocal.legs,
   }
   const handleFormChange = (vals: CabinetFormValues) => {
-    setWidthMM(vals.width)
-    setAdv({ ...gLocal, height: vals.height, depth: vals.depth })
-    if (typeof vals.doorsCount === 'number') setDoorsCount(vals.doorsCount)
-    if (typeof vals.drawersCount === 'number') setDrawersCount(vals.drawersCount)
+    setAdv({
+      ...gLocal,
+      height: vals.height,
+      depth: vals.depth,
+      hardware: vals.hardware,
+      legs: vals.legs,
+    })
   }
 
   useEffect(() => {

--- a/src/ui/forms/ApplianceCabinetForm.tsx
+++ b/src/ui/forms/ApplianceCabinetForm.tsx
@@ -5,15 +5,13 @@ import { CabinetFormValues, CabinetFormProps } from './CornerCabinetForm'
 
 export default function ApplianceCabinetForm({ values, onChange }: CabinetFormProps){
   const { t } = useTranslation()
-  const { width, height, depth, doorsCount = 0, drawersCount = 0, adv, hardware } = values
+  const { height, depth, hardware, legs } = values
   const update = (patch: Partial<CabinetFormValues>) => onChange({ ...values, ...patch })
   return (
     <div>
       <details open>
-        <summary>{t('configurator.sections.korpus')}</summary>
+        <summary>{t('forms.sections.korpus')}</summary>
         <div>
-          <div className="small">{t('forms.width')}</div>
-          <SingleMMInput value={width} onChange={w=>update({ width:w })} />
           <div className="small">{t('forms.height')}</div>
           <SingleMMInput value={height} onChange={h=>update({ height:h })} />
           <div className="small">{t('forms.depth')}</div>
@@ -21,21 +19,16 @@ export default function ApplianceCabinetForm({ values, onChange }: CabinetFormPr
         </div>
       </details>
       <details>
-        <summary>{t('configurator.sections.fronty')}</summary>
-        <div>
-          <div className="small">{t('forms.doorsCount')}</div>
-          <SingleMMInput min={0} step={1} value={doorsCount} onChange={n=>update({ doorsCount:n })} />
-          <div className="small">{t('forms.drawersCount')}</div>
-          <SingleMMInput min={0} step={1} value={drawersCount} onChange={n=>update({ drawersCount:n })} />
-        </div>
+        <summary>{t('forms.sections.fronty')}</summary>
+        <div />
       </details>
       <details>
-        <summary>{t('configurator.sections.okucie')}</summary>
-        {adv && <pre style={{ display:'none' }}>{JSON.stringify(adv)}</pre>}
-      </details>
-      <details>
-        <summary>{t('configurator.sections.nozki')}</summary>
+        <summary>{t('forms.sections.okucie')}</summary>
         {hardware && <pre style={{ display:'none' }}>{JSON.stringify(hardware)}</pre>}
+      </details>
+      <details>
+        <summary>{t('forms.sections.nozki')}</summary>
+        {legs && <pre style={{ display:'none' }}>{JSON.stringify(legs)}</pre>}
       </details>
     </div>
   )

--- a/src/ui/forms/CargoCabinetForm.tsx
+++ b/src/ui/forms/CargoCabinetForm.tsx
@@ -5,15 +5,13 @@ import { CabinetFormValues, CabinetFormProps } from './CornerCabinetForm'
 
 export default function CargoCabinetForm({ values, onChange }: CabinetFormProps){
   const { t } = useTranslation()
-  const { width, height, depth, doorsCount = 0, drawersCount = 0, adv, hardware } = values
+  const { height, depth, hardware, legs } = values
   const update = (patch: Partial<CabinetFormValues>) => onChange({ ...values, ...patch })
   return (
     <div>
       <details open>
-        <summary>{t('configurator.sections.korpus')}</summary>
+        <summary>{t('forms.sections.korpus')}</summary>
         <div>
-          <div className="small">{t('forms.width')}</div>
-          <SingleMMInput value={width} onChange={w=>update({ width:w })} />
           <div className="small">{t('forms.height')}</div>
           <SingleMMInput value={height} onChange={h=>update({ height:h })} />
           <div className="small">{t('forms.depth')}</div>
@@ -21,21 +19,16 @@ export default function CargoCabinetForm({ values, onChange }: CabinetFormProps)
         </div>
       </details>
       <details>
-        <summary>{t('configurator.sections.fronty')}</summary>
-        <div>
-          <div className="small">{t('forms.doorsCount')}</div>
-          <SingleMMInput min={0} step={1} value={doorsCount} onChange={n=>update({ doorsCount:n })} />
-          <div className="small">{t('forms.drawersCount')}</div>
-          <SingleMMInput min={0} step={1} value={drawersCount} onChange={n=>update({ drawersCount:n })} />
-        </div>
+        <summary>{t('forms.sections.fronty')}</summary>
+        <div />
       </details>
       <details>
-        <summary>{t('configurator.sections.okucie')}</summary>
-        {adv && <pre style={{ display:'none' }}>{JSON.stringify(adv)}</pre>}
-      </details>
-      <details>
-        <summary>{t('configurator.sections.nozki')}</summary>
+        <summary>{t('forms.sections.okucie')}</summary>
         {hardware && <pre style={{ display:'none' }}>{JSON.stringify(hardware)}</pre>}
+      </details>
+      <details>
+        <summary>{t('forms.sections.nozki')}</summary>
+        {legs && <pre style={{ display:'none' }}>{JSON.stringify(legs)}</pre>}
       </details>
     </div>
   )

--- a/src/ui/forms/CornerCabinetForm.tsx
+++ b/src/ui/forms/CornerCabinetForm.tsx
@@ -3,13 +3,10 @@ import { useTranslation } from 'react-i18next'
 import SingleMMInput from '../components/SingleMMInput'
 
 export interface CabinetFormValues {
-  width: number
   height: number
   depth: number
-  doorsCount?: number
-  drawersCount?: number
-  adv?: any
   hardware?: any
+  legs?: any
 }
 
 export interface CabinetFormProps {
@@ -19,15 +16,13 @@ export interface CabinetFormProps {
 
 export default function CornerCabinetForm({ values, onChange }: CabinetFormProps){
   const { t } = useTranslation()
-  const { width, height, depth, doorsCount = 0, drawersCount = 0, adv, hardware } = values
+  const { height, depth, hardware, legs } = values
   const update = (patch: Partial<CabinetFormValues>) => onChange({ ...values, ...patch })
   return (
     <div>
       <details open>
-        <summary>{t('configurator.sections.korpus')}</summary>
+        <summary>{t('forms.sections.korpus')}</summary>
         <div>
-          <div className="small">{t('forms.width')}</div>
-          <SingleMMInput value={width} onChange={w=>update({ width:w })} />
           <div className="small">{t('forms.height')}</div>
           <SingleMMInput value={height} onChange={h=>update({ height:h })} />
           <div className="small">{t('forms.depth')}</div>
@@ -35,21 +30,16 @@ export default function CornerCabinetForm({ values, onChange }: CabinetFormProps
         </div>
       </details>
       <details>
-        <summary>{t('configurator.sections.fronty')}</summary>
-        <div>
-          <div className="small">{t('forms.doorsCount')}</div>
-          <SingleMMInput min={0} step={1} value={doorsCount} onChange={n=>update({ doorsCount:n })} />
-          <div className="small">{t('forms.drawersCount')}</div>
-          <SingleMMInput min={0} step={1} value={drawersCount} onChange={n=>update({ drawersCount:n })} />
-        </div>
+        <summary>{t('forms.sections.fronty')}</summary>
+        <div />
       </details>
       <details>
-        <summary>{t('configurator.sections.okucie')}</summary>
-        {adv && <pre style={{ display:'none' }}>{JSON.stringify(adv)}</pre>}
-      </details>
-      <details>
-        <summary>{t('configurator.sections.nozki')}</summary>
+        <summary>{t('forms.sections.okucie')}</summary>
         {hardware && <pre style={{ display:'none' }}>{JSON.stringify(hardware)}</pre>}
+      </details>
+      <details>
+        <summary>{t('forms.sections.nozki')}</summary>
+        {legs && <pre style={{ display:'none' }}>{JSON.stringify(legs)}</pre>}
       </details>
     </div>
   )

--- a/src/ui/forms/SinkCabinetForm.tsx
+++ b/src/ui/forms/SinkCabinetForm.tsx
@@ -5,15 +5,13 @@ import { CabinetFormValues, CabinetFormProps } from './CornerCabinetForm'
 
 export default function SinkCabinetForm({ values, onChange }: CabinetFormProps){
   const { t } = useTranslation()
-  const { width, height, depth, doorsCount = 0, drawersCount = 0, adv, hardware } = values
+  const { height, depth, hardware, legs } = values
   const update = (patch: Partial<CabinetFormValues>) => onChange({ ...values, ...patch })
   return (
     <div>
       <details open>
-        <summary>{t('configurator.sections.korpus')}</summary>
+        <summary>{t('forms.sections.korpus')}</summary>
         <div>
-          <div className="small">{t('forms.width')}</div>
-          <SingleMMInput value={width} onChange={w=>update({ width:w })} />
           <div className="small">{t('forms.height')}</div>
           <SingleMMInput value={height} onChange={h=>update({ height:h })} />
           <div className="small">{t('forms.depth')}</div>
@@ -21,22 +19,17 @@ export default function SinkCabinetForm({ values, onChange }: CabinetFormProps){
         </div>
       </details>
       <details>
-        <summary>{t('configurator.sections.fronty')}</summary>
-        <div>
-          <div className="small">{t('forms.doorsCount')}</div>
-          <SingleMMInput min={0} step={1} value={doorsCount} onChange={n=>update({ doorsCount:n })} />
-          <div className="small">{t('forms.drawersCount')}</div>
-          <SingleMMInput min={0} step={1} value={drawersCount} onChange={n=>update({ drawersCount:n })} />
-        </div>
+        <summary>{t('forms.sections.fronty')}</summary>
+        <div />
       </details>
       <details>
-        <summary>{t('configurator.sections.okucie')}</summary>
+        <summary>{t('forms.sections.okucie')}</summary>
         {/* Sink specific advanced settings may include bowl size or position. */}
-        {adv && <pre style={{ display:'none' }}>{JSON.stringify(adv)}</pre>}
+        {hardware && <pre style={{ display:'none' }}>{JSON.stringify(hardware)}</pre>}
       </details>
       <details>
-        <summary>{t('configurator.sections.nozki')}</summary>
-        {hardware && <pre style={{ display:'none' }}>{JSON.stringify(hardware)}</pre>}
+        <summary>{t('forms.sections.nozki')}</summary>
+        {legs && <pre style={{ display:'none' }}>{JSON.stringify(legs)}</pre>}
       </details>
     </div>
   )

--- a/src/ui/types.ts
+++ b/src/ui/types.ts
@@ -10,5 +10,7 @@ export interface CabinetConfig {
   backPanel?: 'full' | 'split' | 'none'
   drawerFronts?: number[]
   dividerPosition?: 'left' | 'right' | 'center'
+  hardware?: any
+  legs?: any
 }
 


### PR DESCRIPTION
## Summary
- use new `forms.sections.*` keys in cabinet forms and translations
- drop width and front count fields from forms, relying on configurator inputs
- support hardware and leg fields in forms and `CabinetConfig`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b3788482248322ad474f34e55cfa9c