### PR TITLE
feat: add sticky header for cabinet configurator

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -38,7 +38,7 @@
 .slidingPanel{background:#fff;width:400px;max-width:100%;height:100%;box-shadow:2px 0 8px rgba(0,0,0,.2);padding:16px;overflow-y:auto;position:fixed;left:0;right:auto;top:0;transform:translateX(-100%);transition:transform .3s ease;z-index:50;pointer-events:auto}
 .slidingPanel.open{transform:translateX(0)}
 .slidingPanelClose{position:absolute;top:8px;right:12px;border:none;background:none;font-size:20px;cursor:pointer}
-.stickyControls{position:sticky;top:0;background:var(--white);z-index:20;padding-bottom:8px}
+.configuratorHeader{position:sticky;top:0;z-index:10;background:var(--white)}
 details{border:1px solid var(--border);border-radius:8px;margin-top:8px}
 details>summary{cursor:pointer;padding:8px 0;font-weight:600}
 details>div{padding:8px 0;animation:fadeIn .2s ease}

--- a/src/ui/CabinetConfigurator.tsx
+++ b/src/ui/CabinetConfigurator.tsx
@@ -101,7 +101,7 @@ const CabinetConfigurator: React.FC<Props> = ({
         </div>
       </div>
       <div className="bd">
-        <div className="stickyControls">
+        <div className="configuratorHeader">
           <div className="preview">
             <Cabinet3D
               family={family}


### PR DESCRIPTION
## Summary
- add `.configuratorHeader` sticky header class
- apply sticky header to CabinetConfigurator controls

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b37a9a12d88322ad9b10077da7bdbf