### PR TITLE
feat: add drawings section

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -75,7 +75,8 @@
       "korpus": "Carcass",
       "fronty": "Fronts",
       "okucie": "Hardware",
-      "nozki": "Legs"
+      "nozki": "Legs",
+      "rysunki": "Drawings"
     },
     "width": "Width (mm)",
     "insertCabinet": "Insert cabinet",

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -75,7 +75,8 @@
       "korpus": "Korpus",
       "fronty": "Fronty",
       "okucie": "Okucie",
-      "nozki": "Nóżki"
+      "nozki": "Nóżki",
+      "rysunki": "Rysunki"
     },
     "width": "Szerokość (mm)",
     "insertCabinet": "Wstaw szafkę",

--- a/src/ui/CabinetConfigurator.tsx
+++ b/src/ui/CabinetConfigurator.tsx
@@ -269,22 +269,6 @@ const CabinetConfigurator: React.FC<Props> = ({
                 />
               </div>
             )}
-            <div style={{ marginTop: 8 }}>
-              <div className="small">{t('configurator.gapsTitle')}</div>
-              <TechDrawing
-                mode="edit"
-                widthMM={widthMM}
-                heightMM={gLocal.height}
-                depthMM={gLocal.depth}
-                gaps={gLocal.gaps}
-                doorsCount={doorsCount}
-                drawersCount={drawersCount}
-                drawerFronts={gLocal.drawerFronts}
-                dividerPosition={gLocal.dividerPosition}
-                onChangeGaps={(gg: Gaps) => setAdv({ ...gLocal, gaps: gg })}
-                onChangeDrawerFronts={(arr: number[]) => setAdv({ ...gLocal, drawerFronts: arr })}
-              />
-            </div>
           </div>
         </details>
 
@@ -386,6 +370,29 @@ const CabinetConfigurator: React.FC<Props> = ({
                 <input className="input" placeholder="-" />
               </div>
             </div>
+          </div>
+        </details>
+        <details open={openSection === 'rysunki'}>
+          <summary onClick={() => setOpenSection('rysunki')}>
+            {t('configurator.sections.rysunki')}
+          </summary>
+          <div>
+            <div className="small">{t('configurator.gapsTitle')}</div>
+            <TechDrawing
+              mode="edit"
+              widthMM={widthMM}
+              heightMM={gLocal.height}
+              depthMM={gLocal.depth}
+              gaps={gLocal.gaps}
+              doorsCount={doorsCount}
+              drawersCount={drawersCount}
+              drawerFronts={gLocal.drawerFronts}
+              dividerPosition={gLocal.dividerPosition}
+              onChangeGaps={(gg: Gaps) => setAdv({ ...gLocal, gaps: gg })}
+              onChangeDrawerFronts={(arr: number[]) =>
+                setAdv({ ...gLocal, drawerFronts: arr })
+              }
+            />
           </div>
         </details>
       </div>


### PR DESCRIPTION
## Summary
- move gap editing to new "rysunki" section with TechDrawing
- add translation entries for the new section

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b3817a28b083228ccad2f96d2e3e50