### PR TITLE
feat: make form sections mutually exclusive

### DIFF
--- a/src/ui/forms/ApplianceCabinetForm.tsx
+++ b/src/ui/forms/ApplianceCabinetForm.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import SingleMMInput from '../components/SingleMMInput'
 import { CabinetFormValues, CabinetFormProps } from './CornerCabinetForm'
@@ -7,10 +7,11 @@ export default function ApplianceCabinetForm({ values, onChange }: CabinetFormPr
   const { t } = useTranslation()
   const { height, depth, hardware, legs } = values
   const update = (patch: Partial<CabinetFormValues>) => onChange({ ...values, ...patch })
+  const [openSection, setOpenSection] = useState<'korpus' | 'fronty' | 'okucie' | 'nozki'>('korpus')
   return (
     <div>
-      <details open>
-        <summary>{t('forms.sections.korpus')}</summary>
+      <details open={openSection === 'korpus'}>
+        <summary onClick={() => setOpenSection('korpus')}>{t('forms.sections.korpus')}</summary>
         <div>
           <div className="small">{t('forms.height')}</div>
           <SingleMMInput value={height} onChange={h=>update({ height:h })} />
@@ -18,16 +19,16 @@ export default function ApplianceCabinetForm({ values, onChange }: CabinetFormPr
           <SingleMMInput value={depth} onChange={d=>update({ depth:d })} />
         </div>
       </details>
-      <details>
-        <summary>{t('forms.sections.fronty')}</summary>
+      <details open={openSection === 'fronty'}>
+        <summary onClick={() => setOpenSection('fronty')}>{t('forms.sections.fronty')}</summary>
         <div />
       </details>
-      <details>
-        <summary>{t('forms.sections.okucie')}</summary>
+      <details open={openSection === 'okucie'}>
+        <summary onClick={() => setOpenSection('okucie')}>{t('forms.sections.okucie')}</summary>
         {hardware && <pre style={{ display:'none' }}>{JSON.stringify(hardware)}</pre>}
       </details>
-      <details>
-        <summary>{t('forms.sections.nozki')}</summary>
+      <details open={openSection === 'nozki'}>
+        <summary onClick={() => setOpenSection('nozki')}>{t('forms.sections.nozki')}</summary>
         {legs && <pre style={{ display:'none' }}>{JSON.stringify(legs)}</pre>}
       </details>
     </div>

--- a/src/ui/forms/CargoCabinetForm.tsx
+++ b/src/ui/forms/CargoCabinetForm.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import SingleMMInput from '../components/SingleMMInput'
 import { CabinetFormValues, CabinetFormProps } from './CornerCabinetForm'
@@ -7,10 +7,11 @@ export default function CargoCabinetForm({ values, onChange }: CabinetFormProps)
   const { t } = useTranslation()
   const { height, depth, hardware, legs } = values
   const update = (patch: Partial<CabinetFormValues>) => onChange({ ...values, ...patch })
+  const [openSection, setOpenSection] = useState<'korpus' | 'fronty' | 'okucie' | 'nozki'>('korpus')
   return (
     <div>
-      <details open>
-        <summary>{t('forms.sections.korpus')}</summary>
+      <details open={openSection === 'korpus'}>
+        <summary onClick={() => setOpenSection('korpus')}>{t('forms.sections.korpus')}</summary>
         <div>
           <div className="small">{t('forms.height')}</div>
           <SingleMMInput value={height} onChange={h=>update({ height:h })} />
@@ -18,16 +19,16 @@ export default function CargoCabinetForm({ values, onChange }: CabinetFormProps)
           <SingleMMInput value={depth} onChange={d=>update({ depth:d })} />
         </div>
       </details>
-      <details>
-        <summary>{t('forms.sections.fronty')}</summary>
+      <details open={openSection === 'fronty'}>
+        <summary onClick={() => setOpenSection('fronty')}>{t('forms.sections.fronty')}</summary>
         <div />
       </details>
-      <details>
-        <summary>{t('forms.sections.okucie')}</summary>
+      <details open={openSection === 'okucie'}>
+        <summary onClick={() => setOpenSection('okucie')}>{t('forms.sections.okucie')}</summary>
         {hardware && <pre style={{ display:'none' }}>{JSON.stringify(hardware)}</pre>}
       </details>
-      <details>
-        <summary>{t('forms.sections.nozki')}</summary>
+      <details open={openSection === 'nozki'}>
+        <summary onClick={() => setOpenSection('nozki')}>{t('forms.sections.nozki')}</summary>
         {legs && <pre style={{ display:'none' }}>{JSON.stringify(legs)}</pre>}
       </details>
     </div>

--- a/src/ui/forms/CornerCabinetForm.tsx
+++ b/src/ui/forms/CornerCabinetForm.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import SingleMMInput from '../components/SingleMMInput'
 
@@ -18,10 +18,11 @@ export default function CornerCabinetForm({ values, onChange }: CabinetFormProps
   const { t } = useTranslation()
   const { height, depth, hardware, legs } = values
   const update = (patch: Partial<CabinetFormValues>) => onChange({ ...values, ...patch })
+  const [openSection, setOpenSection] = useState<'korpus' | 'fronty' | 'okucie' | 'nozki'>('korpus')
   return (
     <div>
-      <details open>
-        <summary>{t('forms.sections.korpus')}</summary>
+      <details open={openSection === 'korpus'}>
+        <summary onClick={() => setOpenSection('korpus')}>{t('forms.sections.korpus')}</summary>
         <div>
           <div className="small">{t('forms.height')}</div>
           <SingleMMInput value={height} onChange={h=>update({ height:h })} />
@@ -29,16 +30,16 @@ export default function CornerCabinetForm({ values, onChange }: CabinetFormProps
           <SingleMMInput value={depth} onChange={d=>update({ depth:d })} />
         </div>
       </details>
-      <details>
-        <summary>{t('forms.sections.fronty')}</summary>
+      <details open={openSection === 'fronty'}>
+        <summary onClick={() => setOpenSection('fronty')}>{t('forms.sections.fronty')}</summary>
         <div />
       </details>
-      <details>
-        <summary>{t('forms.sections.okucie')}</summary>
+      <details open={openSection === 'okucie'}>
+        <summary onClick={() => setOpenSection('okucie')}>{t('forms.sections.okucie')}</summary>
         {hardware && <pre style={{ display:'none' }}>{JSON.stringify(hardware)}</pre>}
       </details>
-      <details>
-        <summary>{t('forms.sections.nozki')}</summary>
+      <details open={openSection === 'nozki'}>
+        <summary onClick={() => setOpenSection('nozki')}>{t('forms.sections.nozki')}</summary>
         {legs && <pre style={{ display:'none' }}>{JSON.stringify(legs)}</pre>}
       </details>
     </div>

--- a/src/ui/forms/SinkCabinetForm.tsx
+++ b/src/ui/forms/SinkCabinetForm.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import SingleMMInput from '../components/SingleMMInput'
 import { CabinetFormValues, CabinetFormProps } from './CornerCabinetForm'
@@ -7,10 +7,11 @@ export default function SinkCabinetForm({ values, onChange }: CabinetFormProps){
   const { t } = useTranslation()
   const { height, depth, hardware, legs } = values
   const update = (patch: Partial<CabinetFormValues>) => onChange({ ...values, ...patch })
+  const [openSection, setOpenSection] = useState<'korpus' | 'fronty' | 'okucie' | 'nozki'>('korpus')
   return (
     <div>
-      <details open>
-        <summary>{t('forms.sections.korpus')}</summary>
+      <details open={openSection === 'korpus'}>
+        <summary onClick={() => setOpenSection('korpus')}>{t('forms.sections.korpus')}</summary>
         <div>
           <div className="small">{t('forms.height')}</div>
           <SingleMMInput value={height} onChange={h=>update({ height:h })} />
@@ -18,17 +19,17 @@ export default function SinkCabinetForm({ values, onChange }: CabinetFormProps){
           <SingleMMInput value={depth} onChange={d=>update({ depth:d })} />
         </div>
       </details>
-      <details>
-        <summary>{t('forms.sections.fronty')}</summary>
+      <details open={openSection === 'fronty'}>
+        <summary onClick={() => setOpenSection('fronty')}>{t('forms.sections.fronty')}</summary>
         <div />
       </details>
-      <details>
-        <summary>{t('forms.sections.okucie')}</summary>
+      <details open={openSection === 'okucie'}>
+        <summary onClick={() => setOpenSection('okucie')}>{t('forms.sections.okucie')}</summary>
         {/* Sink specific advanced settings may include bowl size or position. */}
         {hardware && <pre style={{ display:'none' }}>{JSON.stringify(hardware)}</pre>}
       </details>
-      <details>
-        <summary>{t('forms.sections.nozki')}</summary>
+      <details open={openSection === 'nozki'}>
+        <summary onClick={() => setOpenSection('nozki')}>{t('forms.sections.nozki')}</summary>
         {legs && <pre style={{ display:'none' }}>{JSON.stringify(legs)}</pre>}
       </details>
     </div>


### PR DESCRIPTION
## Summary
- show only one cabinet form section at a time
- track expanded section with local state

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b3840d15f483228d02e25a94ef9525