### PR TITLE
Avoid divider for drawer cabinets

### DIFF
--- a/src/scene/cabinetBuilder.ts
+++ b/src/scene/cabinetBuilder.ts
@@ -130,7 +130,7 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
     }
   }
 
-  if (dividerPosition) {
+  if (dividerPosition && drawers === 0) {
     const divGeo = new THREE.BoxGeometry(T, H, D);
     const divider = new THREE.Mesh(divGeo, carcMat);
     let x = W / 2;

--- a/src/ui/CabinetConfigurator.tsx
+++ b/src/ui/CabinetConfigurator.tsx
@@ -86,7 +86,11 @@ const CabinetConfigurator: React.FC<Props> = ({
   }, [kind])
 
   useEffect(() => {
-    const fronts = Math.max(doorsCount, drawersCount)
+    if (drawersCount > 0) {
+      if (gLocal.dividerPosition) setAdv({ ...gLocal, dividerPosition: undefined })
+      return
+    }
+    const fronts = doorsCount
     if (fronts < 3) {
       if (gLocal.dividerPosition) setAdv({ ...gLocal, dividerPosition: undefined })
     } else if (fronts === 4) {
@@ -299,10 +303,10 @@ const CabinetConfigurator: React.FC<Props> = ({
                 </select>
               </div>
             </div>
-            {Math.max(doorsCount, drawersCount) >= 3 && (
+            {doorsCount >= 3 && (
               <div style={{ marginTop: 8 }}>
                 <div className="small">Przegroda</div>
-                {Math.max(doorsCount, drawersCount) === 3 ? (
+                {doorsCount === 3 ? (
                   <div className="row" style={{ gap: 8 }}>
                     <label>
                       <input

--- a/src/ui/SceneViewer.tsx
+++ b/src/ui/SceneViewer.tsx
@@ -45,11 +45,14 @@ const SceneViewer: React.FC<Props> = ({ threeRef, addCountertop }) => {
     const legHeight = getLegHeight(mod, store.globals)
     const drawers = Array.isArray(adv.drawerFronts) ? adv.drawerFronts.length : 0
     const hinge = (adv as any).hinge as 'left' | 'right' | undefined
-    const dividerPosition = (adv as any).dividerPosition as
-      | 'left'
-      | 'right'
-      | 'center'
-      | undefined
+    const dividerPosition =
+      drawers > 0
+        ? undefined
+        : ((adv as any).dividerPosition as
+            | 'left'
+            | 'right'
+            | 'center'
+            | undefined)
     const group = buildCabinetMesh({
       width: W,
       height: H,

--- a/src/ui/components/Cabinet3D.tsx
+++ b/src/ui/components/Cabinet3D.tsx
@@ -37,7 +37,7 @@ export default function Cabinet3D({ widthMM, heightMM, depthMM, doorsCount, draw
       shelves,
       backPanel,
       legHeight,
-      dividerPosition
+      dividerPosition: drawersCount > 0 ? undefined : dividerPosition
     })
     scene.add(cabGroup)
     renderer.render(scene, camera)

--- a/src/ui/components/TechDrawing.tsx
+++ b/src/ui/components/TechDrawing.tsx
@@ -170,24 +170,22 @@ export default function TechDrawing({
   }, [doorsCount, front.w, front.x]);
 
   const dividerX = useMemo(() => {
-    const fronts = doorsCount > 0 ? doorsCount : drawersCount;
-    if (!dividerPosition || fronts < 3) return null;
-    if (dividerPosition === 'center') return front.x + front.w / 2;
-    const step = front.w / fronts;
+    if (!dividerPosition || doorsCount < 3) return null
+    if (dividerPosition === 'center') return front.x + front.w / 2
+    const step = front.w / doorsCount
     return dividerPosition === 'left'
       ? front.x + step
-      : front.x + front.w - step;
-  }, [dividerPosition, doorsCount, drawersCount, front.x, front.w]);
+      : front.x + front.w - step
+  }, [dividerPosition, doorsCount, front.x, front.w])
 
   const dividerSectionX = useMemo(() => {
-    const fronts = doorsCount > 0 ? doorsCount : drawersCount;
-    if (!dividerPosition || fronts < 3) return null;
-    const avail = innerW - 20;
-    let ratio = 0.5;
-    if (dividerPosition === 'left') ratio = 1 / fronts;
-    else if (dividerPosition === 'right') ratio = (fronts - 1) / fronts;
-    return pad + 10 + avail * ratio - 4;
-  }, [dividerPosition, doorsCount, drawersCount, innerW]);
+    if (!dividerPosition || doorsCount < 3) return null
+    const avail = innerW - 20
+    let ratio = 0.5
+    if (dividerPosition === 'left') ratio = 1 / doorsCount
+    else if (dividerPosition === 'right') ratio = (doorsCount - 1) / doorsCount
+    return pad + 10 + avail * ratio - 4
+  }, [dividerPosition, doorsCount, innerW])
 
   const onMouseDown = (e: React.MouseEvent<SVGSVGElement, MouseEvent>) => {
     if (mode !== 'edit') return;

--- a/tests/cabinetBuilder.test.ts
+++ b/tests/cabinetBuilder.test.ts
@@ -83,6 +83,26 @@ describe('buildCabinetMesh', () => {
     expect(div).toBeTruthy()
   })
 
+  it('does not add divider when drawers present', () => {
+    const g = buildCabinetMesh({
+      width: 1,
+      height: 0.9,
+      depth: 0.5,
+      drawers: 2,
+      gaps: { top: 0, bottom: 0 },
+      family: FAMILY.BASE,
+      dividerPosition: 'left',
+    })
+    const div = g.children.find(
+      (c) =>
+        c instanceof THREE.Mesh &&
+        Math.abs(c.position.x - 1 / 3) < 0.001 &&
+        (c as THREE.Mesh).geometry instanceof THREE.BoxGeometry &&
+        (c as any).geometry.parameters.width === 0.018
+    )
+    expect(div).toBeUndefined()
+  })
+
   it('matches provided dimensions', () => {
     const width = 0.8
     const height = 0.7


### PR DESCRIPTION
## Summary
- ignore divider settings whenever drawers are present
- draw and display cabinet divider only for hinged doors
- cover divider behavior with tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b37ebe5be0832284b427b2897f1505