### PR TITLE
Add optional edge outlines to cabinet meshes

### DIFF
--- a/src/scene/cabinetBuilder.ts
+++ b/src/scene/cabinetBuilder.ts
@@ -18,6 +18,7 @@ export interface CabinetOptions {
   backThickness?: number;
   hinge?: 'left' | 'right';
   dividerPosition?: 'left' | 'right' | 'center';
+  showEdges?: boolean;
 }
 
 /**
@@ -41,6 +42,7 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
     boardThickness: T = 0.018,
     backThickness: backT = 0.003,
     dividerPosition,
+    showEdges = false,
   } = opts;
 
   const FRONT_OFFSET = 0.002;
@@ -82,22 +84,33 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
   const openStates: boolean[] = [];
   const openProgress: number[] = [];
 
+  const edgeMat = new THREE.LineBasicMaterial({ color: 0x000000 });
+  const addEdges = (mesh: THREE.Mesh) => {
+    if (!showEdges) return;
+    const e = new THREE.LineSegments(new THREE.EdgesGeometry(mesh.geometry), edgeMat);
+    mesh.add(e);
+  };
+
   // Sides
   const sideGeo = new THREE.BoxGeometry(T, H, D);
   const leftSide = new THREE.Mesh(sideGeo, carcMat);
   leftSide.position.set(T / 2, legHeight + H / 2, -D / 2);
+  addEdges(leftSide);
   group.add(leftSide);
   const rightSide = new THREE.Mesh(sideGeo.clone(), carcMat);
   rightSide.position.set(W - T / 2, legHeight + H / 2, -D / 2);
+  addEdges(rightSide);
   group.add(rightSide);
 
   // Top and bottom
   const horizGeo = new THREE.BoxGeometry(W, T, D);
   const bottom = new THREE.Mesh(horizGeo, carcMat);
   bottom.position.set(W / 2, legHeight + T / 2, -D / 2);
+  addEdges(bottom);
   group.add(bottom);
   const top = new THREE.Mesh(horizGeo.clone(), carcMat);
   top.position.set(W / 2, legHeight + H - T / 2, -D / 2);
+  addEdges(top);
   group.add(top);
 
   // Back panel styles
@@ -105,6 +118,7 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
     const backGeo = new THREE.BoxGeometry(W, H, backT);
     const back = new THREE.Mesh(backGeo, backMat);
     back.position.set(W / 2, legHeight + H / 2, -D + backT / 2);
+    addEdges(back);
     group.add(back);
   } else if (backPanel === 'split') {
     const gap = 0.002;
@@ -112,9 +126,11 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
     const backGeo = new THREE.BoxGeometry(W, halfH, backT);
     const bottomBack = new THREE.Mesh(backGeo, backMat);
     bottomBack.position.set(W / 2, legHeight + halfH / 2, -D + backT / 2);
+    addEdges(bottomBack);
     group.add(bottomBack);
     const topBack = new THREE.Mesh(backGeo.clone(), backMat);
     topBack.position.set(W / 2, legHeight + H - halfH / 2, -D + backT / 2);
+    addEdges(topBack);
     group.add(topBack);
   }
 
@@ -126,6 +142,7 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
       const shelf = new THREE.Mesh(shelfGeo, carcMat);
       const y = legHeight + (H * (i + 1)) / (count + 1);
       shelf.position.set(W / 2, y, -D / 2);
+      addEdges(shelf);
       group.add(shelf);
     }
   }
@@ -137,6 +154,7 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
     if (dividerPosition === 'left') x = W / 3;
     else if (dividerPosition === 'right') x = (2 * W) / 3;
     divider.position.set(x, legHeight + H / 2, -D / 2);
+    addEdges(divider);
     group.add(divider);
   }
 
@@ -162,6 +180,7 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
       fg.position.set(W / 2, currentY + h / 2, FRONT_OFFSET + T / 2);
       fg.userData.closedZ = FRONT_OFFSET + T / 2;
       frontMesh.position.set(0, 0, 0);
+      addEdges(frontMesh);
       fg.add(frontMesh);
       fg.userData.type = 'drawer';
       fg.userData.frontIndex = frontGroups.length;
@@ -201,6 +220,7 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
         0,
         T / 2,
       );
+      addEdges(doorMesh);
       fg.add(doorMesh);
       fg.userData.type = 'door';
       fg.userData.frontIndex = frontGroups.length;

--- a/src/ui/SceneViewer.tsx
+++ b/src/ui/SceneViewer.tsx
@@ -28,9 +28,10 @@ export const getLegHeight = (mod: Module3D, globals: Globals): number => {
   return 0.1
 }
 
-const SceneViewer: React.FC<Props> = ({ threeRef, addCountertop }) => {
-  const containerRef = useRef<HTMLDivElement>(null)
-  const store = usePlannerStore()
+  const SceneViewer: React.FC<Props> = ({ threeRef, addCountertop }) => {
+    const containerRef = useRef<HTMLDivElement>(null)
+    const store = usePlannerStore()
+    const showEdges = store.role === 'stolarz'
 
   useEffect(() => {
     if (!containerRef.current) return
@@ -66,7 +67,8 @@ const SceneViewer: React.FC<Props> = ({ threeRef, addCountertop }) => {
       legHeight,
       showHandles: true,
       hinge,
-      dividerPosition
+      dividerPosition,
+      showEdges,
     })
     group.userData.kind = 'cab'
     const fg = group.userData.frontGroups || []
@@ -112,7 +114,7 @@ const SceneViewer: React.FC<Props> = ({ threeRef, addCountertop }) => {
       }
     })
   }
-  useEffect(drawScene, [store.modules, addCountertop])
+  useEffect(drawScene, [store.modules, addCountertop, showEdges])
 
   useEffect(() => {
     const three = threeRef.current

--- a/src/ui/components/Cabinet3D.tsx
+++ b/src/ui/components/Cabinet3D.tsx
@@ -2,9 +2,12 @@ import React, { useEffect, useRef } from 'react'
 import * as THREE from 'three'
 import { FAMILY } from '../../core/catalog'
 import { buildCabinetMesh } from '../../scene/cabinetBuilder'
+import { usePlannerStore } from '../../state/store'
 
 export default function Cabinet3D({ widthMM, heightMM, depthMM, doorsCount, drawersCount, gaps, drawerFronts, family, shelves = 1, backPanel = 'full', dividerPosition }:{ widthMM:number;heightMM:number;depthMM:number;doorsCount:number;drawersCount:number;gaps:{top:number;bottom:number};drawerFronts?:number[];family:FAMILY; shelves?:number; backPanel?:'full'|'split'|'none'; dividerPosition?:'left'|'right'|'center' }){
   const ref = useRef<HTMLDivElement>(null)
+  const role = usePlannerStore(s=>s.role)
+  const showEdges = role === 'stolarz'
   useEffect(()=>{
     if (!ref.current) return
     const w = 260, h = 190
@@ -37,11 +40,12 @@ export default function Cabinet3D({ widthMM, heightMM, depthMM, doorsCount, draw
       shelves,
       backPanel,
       legHeight,
-      dividerPosition: drawersCount > 0 ? undefined : dividerPosition
+      dividerPosition: drawersCount > 0 ? undefined : dividerPosition,
+      showEdges
     })
     scene.add(cabGroup)
     renderer.render(scene, camera)
     return () => { renderer.dispose() }
-  }, [widthMM, heightMM, depthMM, doorsCount, drawersCount, gaps, drawerFronts, family, shelves, backPanel, dividerPosition])
+  }, [widthMM, heightMM, depthMM, doorsCount, drawersCount, gaps, drawerFronts, family, shelves, backPanel, dividerPosition, showEdges])
   return <div ref={ref} style={{ width: 260, height: 190, border: '1px solid #E5E7EB', borderRadius: 8, background: '#fff' }} />
 }

--- a/tests/cabinetBuilder.test.ts
+++ b/tests/cabinetBuilder.test.ts
@@ -124,4 +124,21 @@ describe('buildCabinetMesh', () => {
     const boardThickness = 0.018
     expect(size.z).toBeCloseTo(depth + boardThickness + FRONT_OFFSET, 5)
   })
+
+  it('adds edge outlines when showEdges is true', () => {
+    const g = buildCabinetMesh({
+      width: 1,
+      height: 0.9,
+      depth: 0.5,
+      drawers: 1,
+      gaps: { top: 0, bottom: 0 },
+      family: FAMILY.BASE,
+      showEdges: true,
+    })
+    let edgesCount = 0
+    g.traverse((obj) => {
+      if (obj instanceof THREE.LineSegments) edgesCount++
+    })
+    expect(edgesCount).toBeGreaterThan(0)
+  })
 })


### PR DESCRIPTION
## Summary
- add `showEdges` option to cabinet builder to render outlines on all parts
- pass edge setting from UI viewers based on user role
- test edge creation on cabinet mesh

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b38ccebf4c8322a02e01dcf217f691