### PR TITLE
feat: add edge banding options

### DIFF
--- a/src/scene/cabinetBuilder.ts
+++ b/src/scene/cabinetBuilder.ts
@@ -19,6 +19,7 @@ export interface CabinetOptions {
   hinge?: 'left' | 'right';
   dividerPosition?: 'left' | 'right' | 'center';
   showEdges?: boolean;
+  edgeBanding?: 'none' | 'front' | 'full';
 }
 
 /**
@@ -43,6 +44,7 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
     backThickness: backT = 0.003,
     dividerPosition,
     showEdges = false,
+    edgeBanding = 'none',
   } = opts;
 
   const FRONT_OFFSET = 0.002;
@@ -78,6 +80,26 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
     metalness: 0.3,
     roughness: 0.7,
   });
+  const bandThickness = edgeBanding === 'full' ? 0.002 : 0.001;
+  const bandMat = new THREE.MeshStandardMaterial({
+    color: edgeBanding === 'full' ? 0xffaa00 : 0xffdd99,
+    metalness: 0.2,
+    roughness: 0.6,
+  });
+
+  const addBand = (
+    x: number,
+    y: number,
+    z: number,
+    w: number,
+    h: number,
+    d: number,
+  ) => {
+    const geo = new THREE.BoxGeometry(w, h, d);
+    const mesh = new THREE.Mesh(geo, bandMat);
+    mesh.position.set(x, y, z);
+    group.add(mesh);
+  };
 
   const group = new THREE.Group();
   const frontGroups: THREE.Group[] = [];
@@ -101,6 +123,44 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
   rightSide.position.set(W - T / 2, legHeight + H / 2, -D / 2);
   addEdges(rightSide);
   group.add(rightSide);
+  if (edgeBanding !== 'none') {
+    addBand(T / 2, legHeight + H / 2, bandThickness / 2, T, H, bandThickness);
+    addBand(
+      W - T / 2,
+      legHeight + H / 2,
+      bandThickness / 2,
+      T,
+      H,
+      bandThickness,
+    );
+    if (edgeBanding === 'full') {
+      addBand(T / 2, legHeight + bandThickness / 2, -D / 2, T, bandThickness, D);
+      addBand(
+        T / 2,
+        legHeight + H - bandThickness / 2,
+        -D / 2,
+        T,
+        bandThickness,
+        D,
+      );
+      addBand(
+        W - T / 2,
+        legHeight + bandThickness / 2,
+        -D / 2,
+        T,
+        bandThickness,
+        D,
+      );
+      addBand(
+        W - T / 2,
+        legHeight + H - bandThickness / 2,
+        -D / 2,
+        T,
+        bandThickness,
+        D,
+      );
+    }
+  }
 
   // Top and bottom
   const horizGeo = new THREE.BoxGeometry(W, T, D);
@@ -112,6 +172,37 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
   top.position.set(W / 2, legHeight + H - T / 2, -D / 2);
   addEdges(top);
   group.add(top);
+  if (edgeBanding !== 'none') {
+    addBand(W / 2, legHeight + T / 2, bandThickness / 2, W, T, bandThickness);
+    addBand(W / 2, legHeight + H - T / 2, bandThickness / 2, W, T, bandThickness);
+    if (edgeBanding === 'full') {
+      addBand(bandThickness / 2, legHeight + T / 2, -D / 2, bandThickness, T, D);
+      addBand(
+        W - bandThickness / 2,
+        legHeight + T / 2,
+        -D / 2,
+        bandThickness,
+        T,
+        D,
+      );
+      addBand(
+        bandThickness / 2,
+        legHeight + H - T / 2,
+        -D / 2,
+        bandThickness,
+        T,
+        D,
+      );
+      addBand(
+        W - bandThickness / 2,
+        legHeight + H - T / 2,
+        -D / 2,
+        bandThickness,
+        T,
+        D,
+      );
+    }
+  }
 
   // Back panel styles
   if (backPanel === 'full') {
@@ -144,6 +235,27 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
       shelf.position.set(W / 2, y, -D / 2);
       addEdges(shelf);
       group.add(shelf);
+      if (edgeBanding !== 'none') {
+        addBand(W / 2, y, bandThickness / 2, W - 2 * T, T, bandThickness);
+        if (edgeBanding === 'full') {
+          addBand(
+            T + bandThickness / 2,
+            y,
+            -D / 2,
+            bandThickness,
+            T,
+            D,
+          );
+          addBand(
+            W - T - bandThickness / 2,
+            y,
+            -D / 2,
+            bandThickness,
+            T,
+            D,
+          );
+        }
+      }
     }
   }
 
@@ -156,6 +268,20 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
     divider.position.set(x, legHeight + H / 2, -D / 2);
     addEdges(divider);
     group.add(divider);
+    if (edgeBanding !== 'none') {
+      addBand(x, legHeight + H / 2, bandThickness / 2, T, H, bandThickness);
+      if (edgeBanding === 'full') {
+        addBand(x, legHeight + bandThickness / 2, -D / 2, T, bandThickness, D);
+        addBand(
+          x,
+          legHeight + H - bandThickness / 2,
+          -D / 2,
+          T,
+          bandThickness,
+          D,
+        );
+      }
+    }
   }
 
   // Fronts

--- a/src/types.ts
+++ b/src/types.ts
@@ -78,6 +78,7 @@ export interface ModuleAdv {
   shelves?:number
   backPanel?:'full'|'split'|'none'
   dividerPosition?: 'left' | 'right' | 'center'
+  edgeBanding?: 'none' | 'front' | 'full'
 }
 
 export interface Module3D {

--- a/src/ui/CabinetConfigurator.tsx
+++ b/src/ui/CabinetConfigurator.tsx
@@ -122,6 +122,7 @@ const CabinetConfigurator: React.FC<Props> = ({
               shelves={gLocal.shelves}
               backPanel={gLocal.backPanel}
               dividerPosition={gLocal.dividerPosition}
+              edgeBanding={gLocal.edgeBanding}
             />
           </div>
           <div className="grid2" style={{ marginTop: 8 }}>
@@ -256,6 +257,23 @@ const CabinetConfigurator: React.FC<Props> = ({
                   <option value="full">{t('configurator.backOptions.full')}</option>
                   <option value="split">{t('configurator.backOptions.split')}</option>
                   <option value="none">{t('configurator.backOptions.none')}</option>
+                </select>
+              </div>
+              <div>
+                <div className="small">Edge banding</div>
+                <select
+                  className="input"
+                  value={gLocal.edgeBanding || 'front'}
+                  onChange={(e) =>
+                    setAdv({
+                      ...gLocal,
+                      edgeBanding: (e.target as HTMLSelectElement).value as CabinetConfig['edgeBanding'],
+                    })
+                  }
+                >
+                  <option value="none">none</option>
+                  <option value="front">front</option>
+                  <option value="full">full</option>
                 </select>
               </div>
             </div>

--- a/src/ui/SceneViewer.tsx
+++ b/src/ui/SceneViewer.tsx
@@ -69,6 +69,7 @@ export const getLegHeight = (mod: Module3D, globals: Globals): number => {
       hinge,
       dividerPosition,
       showEdges,
+      edgeBanding: adv.edgeBanding,
     })
     group.userData.kind = 'cab'
     const fg = group.userData.frontGroups || []

--- a/src/ui/components/Cabinet3D.tsx
+++ b/src/ui/components/Cabinet3D.tsx
@@ -4,7 +4,7 @@ import { FAMILY } from '../../core/catalog'
 import { buildCabinetMesh } from '../../scene/cabinetBuilder'
 import { usePlannerStore } from '../../state/store'
 
-export default function Cabinet3D({ widthMM, heightMM, depthMM, doorsCount, drawersCount, gaps, drawerFronts, family, shelves = 1, backPanel = 'full', dividerPosition }:{ widthMM:number;heightMM:number;depthMM:number;doorsCount:number;drawersCount:number;gaps:{top:number;bottom:number};drawerFronts?:number[];family:FAMILY; shelves?:number; backPanel?:'full'|'split'|'none'; dividerPosition?:'left'|'right'|'center' }){
+export default function Cabinet3D({ widthMM, heightMM, depthMM, doorsCount, drawersCount, gaps, drawerFronts, family, shelves = 1, backPanel = 'full', dividerPosition, edgeBanding = 'front' }:{ widthMM:number;heightMM:number;depthMM:number;doorsCount:number;drawersCount:number;gaps:{top:number;bottom:number};drawerFronts?:number[];family:FAMILY; shelves?:number; backPanel?:'full'|'split'|'none'; dividerPosition?:'left'|'right'|'center'; edgeBanding?:'none'|'front'|'full' }){
   const ref = useRef<HTMLDivElement>(null)
   const role = usePlannerStore(s=>s.role)
   const showEdges = role === 'stolarz'
@@ -41,11 +41,12 @@ export default function Cabinet3D({ widthMM, heightMM, depthMM, doorsCount, draw
       backPanel,
       legHeight,
       dividerPosition: drawersCount > 0 ? undefined : dividerPosition,
-      showEdges
+      showEdges,
+      edgeBanding
     })
     scene.add(cabGroup)
     renderer.render(scene, camera)
     return () => { renderer.dispose() }
-  }, [widthMM, heightMM, depthMM, doorsCount, drawersCount, gaps, drawerFronts, family, shelves, backPanel, dividerPosition, showEdges])
+    }, [widthMM, heightMM, depthMM, doorsCount, drawersCount, gaps, drawerFronts, family, shelves, backPanel, dividerPosition, showEdges, edgeBanding])
   return <div ref={ref} style={{ width: 260, height: 190, border: '1px solid #E5E7EB', borderRadius: 8, background: '#fff' }} />
 }

--- a/src/ui/types.ts
+++ b/src/ui/types.ts
@@ -10,6 +10,7 @@ export interface CabinetConfig {
   backPanel?: 'full' | 'split' | 'none'
   drawerFronts?: number[]
   dividerPosition?: 'left' | 'right' | 'center'
+  edgeBanding?: 'none' | 'front' | 'full'
   hardware?: any
   legs?: any
 }

--- a/src/ui/useCabinetConfig.ts
+++ b/src/ui/useCabinetConfig.ts
@@ -31,6 +31,7 @@ export function useCabinetConfig(
       gaps: { ...g.gaps },
       shelves: g.shelves ?? defaultShelves,
       backPanel: g.backPanel,
+      edgeBanding: 'front',
     });
   }, [family, store.globals]);
 
@@ -138,6 +139,7 @@ export function useCabinetConfig(
           frontType: g.frontType,
           gaps: g.gaps,
           backPanel: g.backPanel,
+          edgeBanding: g.edgeBanding,
         },
         doorsCount,
         drawersCount,
@@ -224,6 +226,7 @@ export function useCabinetConfig(
             frontType: g.frontType,
             gaps: g.gaps,
             backPanel: g.backPanel,
+            edgeBanding: 'front',
           },
           doorsCount: 1,
           drawersCount: 0,
@@ -240,7 +243,7 @@ export function useCabinetConfig(
         rotationY: pl.rot,
         segIndex: selWall,
         price,
-        adv: { ...g, doorCount: 1 } as ModuleAdv,
+        adv: { ...g, doorCount: 1, edgeBanding: 'front' } as ModuleAdv,
       };
       mod = resolveCollisions(mod);
       store.addModule(mod);


### PR DESCRIPTION
## Summary
- add edgeBanding field to module types and configuration
- render edge banding strips in cabinet meshes
- expose edge banding controls and pass through UI

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b38e3d9d2883228708ebcbb13ac775