### PR TITLE
Allow closing configurator sections

### DIFF
--- a/src/ui/CabinetConfigurator.tsx
+++ b/src/ui/CabinetConfigurator.tsx
@@ -54,7 +54,7 @@ const CabinetConfigurator: React.FC<Props> = ({
   const [drawersCount, setDrawersCount] = useState(0)
   const [openSection, setOpenSection] = useState<
     'korpus' | 'fronty' | 'okucie' | 'nozki' | 'rysunki' | null
-  >('korpus')
+  >(null)
   const FormComponent = kind ? FORM_COMPONENTS[kind.key] : null
   const formValues: CabinetFormValues = {
     height: gLocal.height,
@@ -395,7 +395,11 @@ const CabinetConfigurator: React.FC<Props> = ({
           </div>
         </details>
         <details open={openSection === 'rysunki'}>
-          <summary onClick={() => setOpenSection('rysunki')}>
+          <summary
+            onClick={() =>
+              setOpenSection(openSection === 'rysunki' ? null : 'rysunki')
+            }
+          >
             {t('configurator.sections.rysunki')}
           </summary>
           <div>

--- a/src/ui/forms/ApplianceCabinetForm.tsx
+++ b/src/ui/forms/ApplianceCabinetForm.tsx
@@ -7,11 +7,18 @@ export default function ApplianceCabinetForm({ values, onChange }: CabinetFormPr
   const { t } = useTranslation()
   const { height, depth, hardware, legs } = values
   const update = (patch: Partial<CabinetFormValues>) => onChange({ ...values, ...patch })
-  const [openSection, setOpenSection] = useState<'korpus' | 'fronty' | 'okucie' | 'nozki'>('korpus')
+  const [openSection, setOpenSection] =
+    useState<'korpus' | 'fronty' | 'okucie' | 'nozki' | null>(null)
   return (
     <div>
       <details open={openSection === 'korpus'}>
-        <summary onClick={() => setOpenSection('korpus')}>{t('forms.sections.korpus')}</summary>
+        <summary
+          onClick={() =>
+            setOpenSection(openSection === 'korpus' ? null : 'korpus')
+          }
+        >
+          {t('forms.sections.korpus')}
+        </summary>
         <div>
           <div className="small">{t('forms.height')}</div>
           <SingleMMInput value={height} onChange={h=>update({ height:h })} />
@@ -20,15 +27,33 @@ export default function ApplianceCabinetForm({ values, onChange }: CabinetFormPr
         </div>
       </details>
       <details open={openSection === 'fronty'}>
-        <summary onClick={() => setOpenSection('fronty')}>{t('forms.sections.fronty')}</summary>
+        <summary
+          onClick={() =>
+            setOpenSection(openSection === 'fronty' ? null : 'fronty')
+          }
+        >
+          {t('forms.sections.fronty')}
+        </summary>
         <div />
       </details>
       <details open={openSection === 'okucie'}>
-        <summary onClick={() => setOpenSection('okucie')}>{t('forms.sections.okucie')}</summary>
+        <summary
+          onClick={() =>
+            setOpenSection(openSection === 'okucie' ? null : 'okucie')
+          }
+        >
+          {t('forms.sections.okucie')}
+        </summary>
         {hardware && <pre style={{ display:'none' }}>{JSON.stringify(hardware)}</pre>}
       </details>
       <details open={openSection === 'nozki'}>
-        <summary onClick={() => setOpenSection('nozki')}>{t('forms.sections.nozki')}</summary>
+        <summary
+          onClick={() =>
+            setOpenSection(openSection === 'nozki' ? null : 'nozki')
+          }
+        >
+          {t('forms.sections.nozki')}
+        </summary>
         {legs && <pre style={{ display:'none' }}>{JSON.stringify(legs)}</pre>}
       </details>
     </div>

--- a/src/ui/forms/CargoCabinetForm.tsx
+++ b/src/ui/forms/CargoCabinetForm.tsx
@@ -7,11 +7,18 @@ export default function CargoCabinetForm({ values, onChange }: CabinetFormProps)
   const { t } = useTranslation()
   const { height, depth, hardware, legs } = values
   const update = (patch: Partial<CabinetFormValues>) => onChange({ ...values, ...patch })
-  const [openSection, setOpenSection] = useState<'korpus' | 'fronty' | 'okucie' | 'nozki'>('korpus')
+  const [openSection, setOpenSection] =
+    useState<'korpus' | 'fronty' | 'okucie' | 'nozki' | null>(null)
   return (
     <div>
       <details open={openSection === 'korpus'}>
-        <summary onClick={() => setOpenSection('korpus')}>{t('forms.sections.korpus')}</summary>
+        <summary
+          onClick={() =>
+            setOpenSection(openSection === 'korpus' ? null : 'korpus')
+          }
+        >
+          {t('forms.sections.korpus')}
+        </summary>
         <div>
           <div className="small">{t('forms.height')}</div>
           <SingleMMInput value={height} onChange={h=>update({ height:h })} />
@@ -20,15 +27,33 @@ export default function CargoCabinetForm({ values, onChange }: CabinetFormProps)
         </div>
       </details>
       <details open={openSection === 'fronty'}>
-        <summary onClick={() => setOpenSection('fronty')}>{t('forms.sections.fronty')}</summary>
+        <summary
+          onClick={() =>
+            setOpenSection(openSection === 'fronty' ? null : 'fronty')
+          }
+        >
+          {t('forms.sections.fronty')}
+        </summary>
         <div />
       </details>
       <details open={openSection === 'okucie'}>
-        <summary onClick={() => setOpenSection('okucie')}>{t('forms.sections.okucie')}</summary>
+        <summary
+          onClick={() =>
+            setOpenSection(openSection === 'okucie' ? null : 'okucie')
+          }
+        >
+          {t('forms.sections.okucie')}
+        </summary>
         {hardware && <pre style={{ display:'none' }}>{JSON.stringify(hardware)}</pre>}
       </details>
       <details open={openSection === 'nozki'}>
-        <summary onClick={() => setOpenSection('nozki')}>{t('forms.sections.nozki')}</summary>
+        <summary
+          onClick={() =>
+            setOpenSection(openSection === 'nozki' ? null : 'nozki')
+          }
+        >
+          {t('forms.sections.nozki')}
+        </summary>
         {legs && <pre style={{ display:'none' }}>{JSON.stringify(legs)}</pre>}
       </details>
     </div>

--- a/src/ui/forms/CornerCabinetForm.tsx
+++ b/src/ui/forms/CornerCabinetForm.tsx
@@ -18,11 +18,18 @@ export default function CornerCabinetForm({ values, onChange }: CabinetFormProps
   const { t } = useTranslation()
   const { height, depth, hardware, legs } = values
   const update = (patch: Partial<CabinetFormValues>) => onChange({ ...values, ...patch })
-  const [openSection, setOpenSection] = useState<'korpus' | 'fronty' | 'okucie' | 'nozki'>('korpus')
+  const [openSection, setOpenSection] =
+    useState<'korpus' | 'fronty' | 'okucie' | 'nozki' | null>(null)
   return (
     <div>
       <details open={openSection === 'korpus'}>
-        <summary onClick={() => setOpenSection('korpus')}>{t('forms.sections.korpus')}</summary>
+        <summary
+          onClick={() =>
+            setOpenSection(openSection === 'korpus' ? null : 'korpus')
+          }
+        >
+          {t('forms.sections.korpus')}
+        </summary>
         <div>
           <div className="small">{t('forms.height')}</div>
           <SingleMMInput value={height} onChange={h=>update({ height:h })} />
@@ -31,15 +38,33 @@ export default function CornerCabinetForm({ values, onChange }: CabinetFormProps
         </div>
       </details>
       <details open={openSection === 'fronty'}>
-        <summary onClick={() => setOpenSection('fronty')}>{t('forms.sections.fronty')}</summary>
+        <summary
+          onClick={() =>
+            setOpenSection(openSection === 'fronty' ? null : 'fronty')
+          }
+        >
+          {t('forms.sections.fronty')}
+        </summary>
         <div />
       </details>
       <details open={openSection === 'okucie'}>
-        <summary onClick={() => setOpenSection('okucie')}>{t('forms.sections.okucie')}</summary>
+        <summary
+          onClick={() =>
+            setOpenSection(openSection === 'okucie' ? null : 'okucie')
+          }
+        >
+          {t('forms.sections.okucie')}
+        </summary>
         {hardware && <pre style={{ display:'none' }}>{JSON.stringify(hardware)}</pre>}
       </details>
       <details open={openSection === 'nozki'}>
-        <summary onClick={() => setOpenSection('nozki')}>{t('forms.sections.nozki')}</summary>
+        <summary
+          onClick={() =>
+            setOpenSection(openSection === 'nozki' ? null : 'nozki')
+          }
+        >
+          {t('forms.sections.nozki')}
+        </summary>
         {legs && <pre style={{ display:'none' }}>{JSON.stringify(legs)}</pre>}
       </details>
     </div>

--- a/src/ui/forms/SinkCabinetForm.tsx
+++ b/src/ui/forms/SinkCabinetForm.tsx
@@ -7,11 +7,18 @@ export default function SinkCabinetForm({ values, onChange }: CabinetFormProps){
   const { t } = useTranslation()
   const { height, depth, hardware, legs } = values
   const update = (patch: Partial<CabinetFormValues>) => onChange({ ...values, ...patch })
-  const [openSection, setOpenSection] = useState<'korpus' | 'fronty' | 'okucie' | 'nozki'>('korpus')
+  const [openSection, setOpenSection] =
+    useState<'korpus' | 'fronty' | 'okucie' | 'nozki' | null>(null)
   return (
     <div>
       <details open={openSection === 'korpus'}>
-        <summary onClick={() => setOpenSection('korpus')}>{t('forms.sections.korpus')}</summary>
+        <summary
+          onClick={() =>
+            setOpenSection(openSection === 'korpus' ? null : 'korpus')
+          }
+        >
+          {t('forms.sections.korpus')}
+        </summary>
         <div>
           <div className="small">{t('forms.height')}</div>
           <SingleMMInput value={height} onChange={h=>update({ height:h })} />
@@ -20,16 +27,34 @@ export default function SinkCabinetForm({ values, onChange }: CabinetFormProps){
         </div>
       </details>
       <details open={openSection === 'fronty'}>
-        <summary onClick={() => setOpenSection('fronty')}>{t('forms.sections.fronty')}</summary>
+        <summary
+          onClick={() =>
+            setOpenSection(openSection === 'fronty' ? null : 'fronty')
+          }
+        >
+          {t('forms.sections.fronty')}
+        </summary>
         <div />
       </details>
       <details open={openSection === 'okucie'}>
-        <summary onClick={() => setOpenSection('okucie')}>{t('forms.sections.okucie')}</summary>
+        <summary
+          onClick={() =>
+            setOpenSection(openSection === 'okucie' ? null : 'okucie')
+          }
+        >
+          {t('forms.sections.okucie')}
+        </summary>
         {/* Sink specific advanced settings may include bowl size or position. */}
         {hardware && <pre style={{ display:'none' }}>{JSON.stringify(hardware)}</pre>}
       </details>
       <details open={openSection === 'nozki'}>
-        <summary onClick={() => setOpenSection('nozki')}>{t('forms.sections.nozki')}</summary>
+        <summary
+          onClick={() =>
+            setOpenSection(openSection === 'nozki' ? null : 'nozki')
+          }
+        >
+          {t('forms.sections.nozki')}
+        </summary>
         {legs && <pre style={{ display:'none' }}>{JSON.stringify(legs)}</pre>}
       </details>
     </div>


### PR DESCRIPTION
## Summary
- allow all configurator sections and forms to start closed
- toggle details sections based on openSection state

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b42bd6c0648322b6f902aa91674a1a