### PR TITLE
Add option to hide cabinet fronts

### DIFF
--- a/src/scene/cabinetBuilder.ts
+++ b/src/scene/cabinetBuilder.ts
@@ -20,6 +20,7 @@ export interface CabinetOptions {
   dividerPosition?: 'left' | 'right' | 'center';
   showEdges?: boolean;
   edgeBanding?: 'none' | 'front' | 'full';
+  showFronts?: boolean;
 }
 
 /**
@@ -45,6 +46,7 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
     dividerPosition,
     showEdges = false,
     edgeBanding = 'none',
+    showFronts = true,
   } = opts;
 
   const FRONT_OFFSET = 0.002;
@@ -311,6 +313,7 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
       fg.userData.type = 'drawer';
       fg.userData.frontIndex = frontGroups.length;
       fg.userData.slideDist = -Math.min(0.45, D);
+      fg.visible = showFronts;
       frontGroups.push(fg);
       openStates.push(false);
       openProgress.push(0);
@@ -351,6 +354,7 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
       fg.userData.type = 'door';
       fg.userData.frontIndex = frontGroups.length;
       fg.userData.hingeSide = hingeSide;
+      fg.visible = showFronts;
       frontGroups.push(fg);
       openStates.push(false);
       openProgress.push(0);

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -93,6 +93,7 @@ type Store = {
   past: Module3D[][];
   future: Module3D[][];
   room: Room;
+  showFronts: boolean;
   setRole: (r: 'stolarz' | 'klient') => void;
   updateGlobals: (fam: FAMILY, patch: Partial<Globals[FAMILY]>) => void;
   updatePrices: (patch: Partial<Prices>) => void;
@@ -105,6 +106,7 @@ type Store = {
   setRoom: (patch: Partial<Room>) => void;
   addWall: (w: { length: number; angle: number }) => void;
   addOpening: (op: Opening) => void;
+  setShowFronts: (v: boolean) => void;
 };
 
 export const usePlannerStore = create<Store>((set, get) => ({
@@ -115,6 +117,7 @@ export const usePlannerStore = create<Store>((set, get) => ({
   past: [],
   future: [],
   room: persisted?.room || { walls: [], openings: [], height: 2700 },
+  showFronts: true,
   setRole: (r) => set({ role: r }),
   updateGlobals: (fam, patch) =>
     set((s) => {
@@ -193,6 +196,7 @@ export const usePlannerStore = create<Store>((set, get) => ({
     set((s) => ({ room: { ...s.room, walls: [...s.room.walls, w] } })),
   addOpening: (op) =>
     set((s) => ({ room: { ...s.room, openings: [...s.room.openings, op] } })),
+  setShowFronts: (v) => set({ showFronts: v }),
 }));
 
 usePlannerStore.subscribe((state) => {

--- a/src/ui/CabinetConfigurator.tsx
+++ b/src/ui/CabinetConfigurator.tsx
@@ -55,6 +55,10 @@ const CabinetConfigurator: React.FC<Props> = ({
   const [openSection, setOpenSection] = useState<
     'korpus' | 'fronty' | 'okucie' | 'nozki' | 'rysunki' | null
   >(null)
+  const showFronts = openSection !== 'korpus'
+  useEffect(() => {
+    store.setShowFronts(showFronts)
+  }, [showFronts, store])
   const FormComponent = kind ? FORM_COMPONENTS[kind.key] : null
   const formValues: CabinetFormValues = {
     height: gLocal.height,
@@ -123,6 +127,7 @@ const CabinetConfigurator: React.FC<Props> = ({
               backPanel={gLocal.backPanel}
               dividerPosition={gLocal.dividerPosition}
               edgeBanding={gLocal.edgeBanding}
+              showFronts={showFronts}
             />
           </div>
           <div className="grid2" style={{ marginTop: 8 }}>

--- a/src/ui/SceneViewer.tsx
+++ b/src/ui/SceneViewer.tsx
@@ -32,6 +32,7 @@ export const getLegHeight = (mod: Module3D, globals: Globals): number => {
     const containerRef = useRef<HTMLDivElement>(null)
     const store = usePlannerStore()
     const showEdges = store.role === 'stolarz'
+    const showFronts = store.showFronts
 
   useEffect(() => {
     if (!containerRef.current) return
@@ -70,12 +71,14 @@ export const getLegHeight = (mod: Module3D, globals: Globals): number => {
       dividerPosition,
       showEdges,
       edgeBanding: adv.edgeBanding,
+      showFronts,
     })
     group.userData.kind = 'cab'
     const fg = group.userData.frontGroups || []
     group.userData.openStates = mod.openStates?.slice(0, fg.length) || new Array(fg.length).fill(false)
     group.userData.openProgress = new Array(fg.length).fill(0)
     group.userData.animSpeed = (adv as any).animationSpeed ?? 0.15
+    fg.forEach((g: THREE.Object3D) => (g.visible = showFronts))
     return group
   }
 
@@ -96,6 +99,8 @@ export const getLegHeight = (mod: Module3D, globals: Globals): number => {
     })
     store.modules.forEach((m: Module3D) => {
       const cabMesh = createCabinetMesh(m)
+      const fgs: THREE.Object3D[] = cabMesh.userData.frontGroups || []
+      fgs.forEach((fg) => (fg.visible = showFronts))
       const legHeight = getLegHeight(m, store.globals)
       const baseY = m.family === FAMILY.BASE ? 0 : m.position[1]
       cabMesh.position.set(m.position[0], baseY, m.position[2])
@@ -115,7 +120,7 @@ export const getLegHeight = (mod: Module3D, globals: Globals): number => {
       }
     })
   }
-  useEffect(drawScene, [store.modules, addCountertop, showEdges])
+  useEffect(drawScene, [store.modules, addCountertop, showEdges, showFronts])
 
   useEffect(() => {
     const three = threeRef.current

--- a/src/ui/components/Cabinet3D.tsx
+++ b/src/ui/components/Cabinet3D.tsx
@@ -4,7 +4,7 @@ import { FAMILY } from '../../core/catalog'
 import { buildCabinetMesh } from '../../scene/cabinetBuilder'
 import { usePlannerStore } from '../../state/store'
 
-export default function Cabinet3D({ widthMM, heightMM, depthMM, doorsCount, drawersCount, gaps, drawerFronts, family, shelves = 1, backPanel = 'full', dividerPosition, edgeBanding = 'front' }:{ widthMM:number;heightMM:number;depthMM:number;doorsCount:number;drawersCount:number;gaps:{top:number;bottom:number};drawerFronts?:number[];family:FAMILY; shelves?:number; backPanel?:'full'|'split'|'none'; dividerPosition?:'left'|'right'|'center'; edgeBanding?:'none'|'front'|'full' }){
+ export default function Cabinet3D({ widthMM, heightMM, depthMM, doorsCount, drawersCount, gaps, drawerFronts, family, shelves = 1, backPanel = 'full', dividerPosition, edgeBanding = 'front', showFronts = true }:{ widthMM:number;heightMM:number;depthMM:number;doorsCount:number;drawersCount:number;gaps:{top:number;bottom:number};drawerFronts?:number[];family:FAMILY; shelves?:number; backPanel?:'full'|'split'|'none'; dividerPosition?:'left'|'right'|'center'; edgeBanding?:'none'|'front'|'full'; showFronts?:boolean }){
   const ref = useRef<HTMLDivElement>(null)
   const role = usePlannerStore(s=>s.role)
   const showEdges = role === 'stolarz'
@@ -28,25 +28,26 @@ export default function Cabinet3D({ widthMM, heightMM, depthMM, doorsCount, draw
     const H = heightMM / 1000
     const D = depthMM / 1000
     const legHeight = (family === FAMILY.BASE || family === FAMILY.TALL) ? 0.04 : 0
-    const cabGroup = buildCabinetMesh({
-      width: W,
-      height: H,
-      depth: D,
-      drawers: drawersCount,
-      doorCount: doorsCount,
-      gaps,
-      drawerFronts,
-      family,
-      shelves,
-      backPanel,
-      legHeight,
-      dividerPosition: drawersCount > 0 ? undefined : dividerPosition,
-      showEdges,
-      edgeBanding
-    })
+      const cabGroup = buildCabinetMesh({
+        width: W,
+        height: H,
+        depth: D,
+        drawers: drawersCount,
+        doorCount: doorsCount,
+        gaps,
+        drawerFronts,
+        family,
+        shelves,
+        backPanel,
+        legHeight,
+        dividerPosition: drawersCount > 0 ? undefined : dividerPosition,
+        showEdges,
+        edgeBanding,
+        showFronts
+      })
     scene.add(cabGroup)
     renderer.render(scene, camera)
     return () => { renderer.dispose() }
-    }, [widthMM, heightMM, depthMM, doorsCount, drawersCount, gaps, drawerFronts, family, shelves, backPanel, dividerPosition, showEdges, edgeBanding])
+      }, [widthMM, heightMM, depthMM, doorsCount, drawersCount, gaps, drawerFronts, family, shelves, backPanel, dividerPosition, showEdges, edgeBanding, showFronts])
   return <div ref={ref} style={{ width: 260, height: 190, border: '1px solid #E5E7EB', borderRadius: 8, background: '#fff' }} />
 }


### PR DESCRIPTION
## Summary
- add `showFronts` flag toggled by configurator to hide cabinet fronts
- thread `showFronts` into 3D builders and scene viewer
- allow cabinet builder to skip rendering front groups when hidden

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b42d22ca088322b308f9b4c6ef61f5