### PR TITLE
refactor: update showFronts sync

### DIFF
--- a/src/ui/CabinetConfigurator.tsx
+++ b/src/ui/CabinetConfigurator.tsx
@@ -48,7 +48,8 @@ const CabinetConfigurator: React.FC<Props> = ({
   setAdv,
   onAdd,
 }) => {
-  const store = usePlannerStore();
+  const setShowFronts = usePlannerStore((s) => s.setShowFronts);
+  const currentShowFronts = usePlannerStore((s) => s.showFronts);
   const { t } = useTranslation();
   const [doorsCount, setDoorsCount] = useState(1);
   const [drawersCount, setDrawersCount] = useState(0);
@@ -57,8 +58,8 @@ const CabinetConfigurator: React.FC<Props> = ({
   >(null);
   const showFronts = openSection !== 'korpus';
   useEffect(() => {
-    store.setShowFronts(showFronts);
-  }, [showFronts, store]);
+    if (currentShowFronts !== showFronts) setShowFronts(showFronts);
+  }, [currentShowFronts, showFronts, setShowFronts]);
   const FormComponent = kind ? FORM_COMPONENTS[kind.key] : null;
   const formValues: CabinetFormValues = {
     height: gLocal.height,


### PR DESCRIPTION
## Summary
- avoid redundant showFronts updates by selecting setters from store
- only update showFronts when value actually changes

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b43738bd848322981e2b6500e840df