### PR TITLE
Use prices from planner store in cabinet configurator

### DIFF
--- a/src/ui/CabinetConfigurator.tsx
+++ b/src/ui/CabinetConfigurator.tsx
@@ -50,6 +50,7 @@ const CabinetConfigurator: React.FC<Props> = ({
 }) => {
   const setShowFronts = usePlannerStore((s) => s.setShowFronts);
   const currentShowFronts = usePlannerStore((s) => s.showFronts);
+  const prices = usePlannerStore((s) => s.prices);
   const { t } = useTranslation();
   const [doorsCount, setDoorsCount] = useState(1);
   const [drawersCount, setDrawersCount] = useState(0);
@@ -288,7 +289,7 @@ const CabinetConfigurator: React.FC<Props> = ({
                     })
                   }
                 >
-                  {Object.keys(store.prices.board).map((k) => (
+                  {Object.keys(prices.board).map((k) => (
                     <option key={k} value={k}>
                       {k}
                     </option>
@@ -571,7 +572,7 @@ const CabinetConfigurator: React.FC<Props> = ({
                     })
                   }
                 >
-                  {Object.keys(store.prices.front).map((k) => (
+                  {Object.keys(prices.front).map((k) => (
                     <option key={k} value={k}>
                       {k}
                     </option>


### PR DESCRIPTION
## Summary
- fetch prices via `usePlannerStore` in `CabinetConfigurator`
- reference `prices.board` and `prices.front` when rendering material options

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b43cb04e5883228d5f1d2cb3ff841a