### PR TITLE
Swap traverse orientation semantics

### DIFF
--- a/src/scene/cabinetBuilder.ts
+++ b/src/scene/cabinetBuilder.ts
@@ -224,22 +224,22 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
     }
   }
   const addTraverseTop = (tr: Traverse, zBase: number) => {
-    if (tr.orientation === 'horizontal') {
+    if (tr.orientation === 'vertical') {
       const geo = new THREE.BoxGeometry(T, T, D);
+      const mesh = new THREE.Mesh(geo, carcMat);
+      const z =
+        zBase === 0 ? -tr.offset / 1000 - T / 2 : -D + tr.offset / 1000 + T / 2;
+      mesh.position.set(W / 2, legHeight + H - T / 2, z);
+      addEdges(mesh);
+      group.add(mesh);
+    } else {
+      const geo = new THREE.BoxGeometry(W, T, T);
       const mesh = new THREE.Mesh(geo, carcMat);
       mesh.position.set(
         tr.offset / 1000 + T / 2,
         legHeight + H - T / 2,
         -D / 2,
       );
-      addEdges(mesh);
-      group.add(mesh);
-    } else {
-      const geo = new THREE.BoxGeometry(W, T, T);
-      const mesh = new THREE.Mesh(geo, carcMat);
-      const z =
-        zBase === 0 ? -tr.offset / 1000 - T / 2 : -D + tr.offset / 1000 + T / 2;
-      mesh.position.set(W / 2, legHeight + H - T / 2, z);
       addEdges(mesh);
       group.add(mesh);
     }

--- a/src/ui/CabinetConfigurator.tsx
+++ b/src/ui/CabinetConfigurator.tsx
@@ -401,9 +401,9 @@ const CabinetConfigurator: React.FC<Props> = ({
                       type="number"
                       min={0}
                       max={
-                        gLocal.topPanel.traverse.orientation === 'horizontal'
-                          ? widthMM
-                          : gLocal.depth
+                        gLocal.topPanel.traverse.orientation === 'vertical'
+                          ? gLocal.depth
+                          : widthMM
                       }
                       value={gLocal.topPanel.traverse.offset}
                       onChange={(e) =>
@@ -464,9 +464,9 @@ const CabinetConfigurator: React.FC<Props> = ({
                           type="number"
                           min={0}
                           max={
-                            gLocal.topPanel[pos].orientation === 'horizontal'
-                              ? widthMM
-                              : gLocal.depth
+                            gLocal.topPanel[pos].orientation === 'vertical'
+                              ? gLocal.depth
+                              : widthMM
                           }
                           value={gLocal.topPanel[pos].offset}
                           onChange={(e) =>


### PR DESCRIPTION
## Summary
- flip traverse orientation logic so `vertical` runs front-to-back and `horizontal` spans the width
- update configurator offset limits to respect new orientation mapping

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b44891b9ec8322bfcd90fb9248645a