### PR TITLE
feat: allow configurable traverse width

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -118,7 +118,8 @@
       "horizontal": "horizontal",
       "vertical": "vertical"
     },
-    "offset": "Offset (mm)"
+    "offset": "Offset (mm)",
+    "traverseWidth": "Traverse width (mm)"
   },
   "forms": {
     "width": "Width",

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -118,7 +118,8 @@
       "horizontal": "pozioma",
       "vertical": "pionowa"
     },
-    "offset": "Przesunięcie (mm)"
+    "offset": "Przesunięcie (mm)",
+    "traverseWidth": "Szerokość trawersu (mm)"
   },
   "forms": {
     "width": "Szerokość",

--- a/src/scene/cabinetBuilder.ts
+++ b/src/scene/cabinetBuilder.ts
@@ -224,21 +224,25 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
     }
   }
   const addTraverseTop = (tr: Traverse, zBase: number) => {
+    const widthM = tr.width / 1000;
     if (tr.orientation === 'vertical') {
-      const geo = new THREE.BoxGeometry(T, T, D);
+      const geo = new THREE.BoxGeometry(widthM, T, D);
       const mesh = new THREE.Mesh(geo, carcMat);
       const z =
-        zBase === 0 ? -tr.offset / 1000 - T / 2 : -D + tr.offset / 1000 + T / 2;
+        zBase === 0
+          ? -(tr.offset + tr.width / 2) / 1000
+          : -D + (tr.offset + tr.width / 2) / 1000;
       mesh.position.set(W / 2, legHeight + H - T / 2, z);
       addEdges(mesh);
       group.add(mesh);
     } else {
-      const geo = new THREE.BoxGeometry(W, T, T);
+      const geo = new THREE.BoxGeometry(W, T, widthM);
       const mesh = new THREE.Mesh(geo, carcMat);
+      const z = zBase === 0 ? -widthM / 2 : -D + widthM / 2;
       mesh.position.set(
-        tr.offset / 1000 + T / 2,
+        (tr.offset + tr.width / 2) / 1000,
         legHeight + H - T / 2,
-        -D / 2,
+        z,
       );
       addEdges(mesh);
       group.add(mesh);

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,6 +13,8 @@ export interface Traverse {
   orientation: TraverseOrientation;
   /** offset in millimetres */
   offset: number;
+  /** width in millimetres */
+  width: number;
 }
 
 export type TopPanel =

--- a/src/ui/CabinetConfigurator.tsx
+++ b/src/ui/CabinetConfigurator.tsx
@@ -332,8 +332,16 @@ const CabinetConfigurator: React.FC<Props> = ({
                         ...gLocal,
                         topPanel: {
                           type: 'twoTraverses',
-                          front: { orientation: 'horizontal', offset: 0 },
-                          back: { orientation: 'horizontal', offset: 0 },
+                          front: {
+                            orientation: 'horizontal',
+                            offset: 0,
+                            width: 100,
+                          },
+                          back: {
+                            orientation: 'horizontal',
+                            offset: 0,
+                            width: 100,
+                          },
                         },
                       });
                     else if (v === 'frontTraverse' || v === 'backTraverse')
@@ -341,7 +349,11 @@ const CabinetConfigurator: React.FC<Props> = ({
                         ...gLocal,
                         topPanel: {
                           type: v,
-                          traverse: { orientation: 'horizontal', offset: 0 },
+                          traverse: {
+                            orientation: 'horizontal',
+                            offset: 0,
+                            width: 100,
+                          },
                         },
                       });
                     else setAdv({ ...gLocal, topPanel: { type: v } });
@@ -421,6 +433,29 @@ const CabinetConfigurator: React.FC<Props> = ({
                         })
                       }
                     />
+                    <div className="small" style={{ marginTop: 4 }}>
+                      {t('configurator.traverseWidth')}
+                    </div>
+                    <input
+                      className="input"
+                      type="number"
+                      min={0}
+                      value={gLocal.topPanel.traverse.width}
+                      onChange={(e) =>
+                        setAdv({
+                          ...gLocal,
+                          topPanel: {
+                            ...gLocal.topPanel,
+                            traverse: {
+                              ...gLocal.topPanel.traverse,
+                              width:
+                                Number((e.target as HTMLInputElement).value) ||
+                                0,
+                            },
+                          } as any,
+                        })
+                      }
+                    />
                   </div>
                 ) : gLocal.topPanel?.type === 'twoTraverses' ? (
                   <div style={{ marginTop: 4 }}>
@@ -477,6 +512,30 @@ const CabinetConfigurator: React.FC<Props> = ({
                                 [pos]: {
                                   ...gLocal.topPanel[pos],
                                   offset:
+                                    Number(
+                                      (e.target as HTMLInputElement).value,
+                                    ) || 0,
+                                },
+                              } as any,
+                            })
+                          }
+                        />
+                        <div className="small" style={{ marginTop: 4 }}>
+                          {t('configurator.traverseWidth')}
+                        </div>
+                        <input
+                          className="input"
+                          type="number"
+                          min={0}
+                          value={gLocal.topPanel[pos].width}
+                          onChange={(e) =>
+                            setAdv({
+                              ...gLocal,
+                              topPanel: {
+                                ...gLocal.topPanel,
+                                [pos]: {
+                                  ...gLocal.topPanel[pos],
+                                  width:
                                     Number(
                                       (e.target as HTMLInputElement).value,
                                     ) || 0,


### PR DESCRIPTION
## Summary
- add width property to traverse type
- allow editing traverse width in configurator
- build traverses using width dimension

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b44a80f2e48322a4dc14823e0be92d