### PR TITLE
Align traverse offset axes with orientation

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -119,6 +119,8 @@
       "vertical": "vertical"
     },
     "offset": "Offset (mm)",
+    "offsetWidth": "Offset (width mm)",
+    "offsetDepth": "Offset (depth mm)",
     "traverseWidth": "Traverse width (mm)"
   },
   "forms": {

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -119,6 +119,8 @@
       "vertical": "pionowa"
     },
     "offset": "Przesunięcie (mm)",
+    "offsetWidth": "Przesunięcie (szerokość, mm)",
+    "offsetDepth": "Przesunięcie (głębokość, mm)",
     "traverseWidth": "Szerokość trawersu (mm)"
   },
   "forms": {

--- a/src/scene/cabinetBuilder.ts
+++ b/src/scene/cabinetBuilder.ts
@@ -228,22 +228,18 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
     if (tr.orientation === 'vertical') {
       const geo = new THREE.BoxGeometry(widthM, T, D);
       const mesh = new THREE.Mesh(geo, carcMat);
-      const z =
-        zBase === 0
-          ? -(tr.offset + tr.width / 2) / 1000
-          : -D + (tr.offset + tr.width / 2) / 1000;
-      mesh.position.set(W / 2, legHeight + H - T / 2, z);
+      const x = (tr.offset + tr.width / 2) / 1000;
+      mesh.position.set(x, legHeight + H - T / 2, -D / 2);
       addEdges(mesh);
       group.add(mesh);
     } else {
       const geo = new THREE.BoxGeometry(W, T, widthM);
       const mesh = new THREE.Mesh(geo, carcMat);
-      const z = zBase === 0 ? -widthM / 2 : -D + widthM / 2;
-      mesh.position.set(
-        (tr.offset + tr.width / 2) / 1000,
-        legHeight + H - T / 2,
-        z,
-      );
+      const z =
+        zBase === 0
+          ? -(tr.offset + tr.width / 2) / 1000
+          : -D + (tr.offset + tr.width / 2) / 1000;
+      mesh.position.set(W / 2, legHeight + H - T / 2, z);
       addEdges(mesh);
       group.add(mesh);
     }

--- a/src/ui/CabinetConfigurator.tsx
+++ b/src/ui/CabinetConfigurator.tsx
@@ -406,7 +406,11 @@ const CabinetConfigurator: React.FC<Props> = ({
                       </option>
                     </select>
                     <div className="small" style={{ marginTop: 4 }}>
-                      {t('configurator.offset')}
+                      {t(
+                        gLocal.topPanel.traverse.orientation === 'vertical'
+                          ? 'configurator.offsetWidth'
+                          : 'configurator.offsetDepth',
+                      )}
                     </div>
                     <input
                       className="input"
@@ -414,8 +418,8 @@ const CabinetConfigurator: React.FC<Props> = ({
                       min={0}
                       max={
                         gLocal.topPanel.traverse.orientation === 'vertical'
-                          ? gLocal.depth
-                          : widthMM
+                          ? widthMM
+                          : gLocal.depth
                       }
                       value={gLocal.topPanel.traverse.offset}
                       onChange={(e) =>
@@ -492,7 +496,11 @@ const CabinetConfigurator: React.FC<Props> = ({
                           </option>
                         </select>
                         <div className="small" style={{ marginTop: 4 }}>
-                          {t('configurator.offset')}
+                          {t(
+                            gLocal.topPanel[pos].orientation === 'vertical'
+                              ? 'configurator.offsetWidth'
+                              : 'configurator.offsetDepth',
+                          )}
                         </div>
                         <input
                           className="input"
@@ -500,8 +508,8 @@ const CabinetConfigurator: React.FC<Props> = ({
                           min={0}
                           max={
                             gLocal.topPanel[pos].orientation === 'vertical'
-                              ? gLocal.depth
-                              : widthMM
+                              ? widthMM
+                              : gLocal.depth
                           }
                           value={gLocal.topPanel[pos].offset}
                           onChange={(e) =>

--- a/tests/cabinetBuilder.test.ts
+++ b/tests/cabinetBuilder.test.ts
@@ -125,6 +125,62 @@ describe('buildCabinetMesh', () => {
     expect(size.z).toBeCloseTo(depth + boardThickness + FRONT_OFFSET, 5)
   })
 
+  it('positions horizontal traverse by depth offset', () => {
+    const offset = 100
+    const trWidth = 100
+    const g = buildCabinetMesh({
+      width: 1,
+      height: 0.9,
+      depth: 0.5,
+      drawers: 0,
+      gaps: { top: 0, bottom: 0 },
+      family: FAMILY.BASE,
+      topPanel: {
+        type: 'frontTraverse',
+        traverse: { orientation: 'horizontal', offset, width: trWidth },
+      },
+    })
+    const traverse = g.children.find(
+      (c) =>
+        c instanceof THREE.Mesh &&
+        Math.abs((c as any).geometry.parameters.width - 1) < 1e-6 &&
+        Math.abs((c as any).geometry.parameters.depth - trWidth / 1000) < 1e-6,
+    ) as THREE.Mesh | undefined
+    expect(traverse).toBeTruthy()
+    expect(traverse!.position.z).toBeCloseTo(
+      -(offset + trWidth / 2) / 1000,
+      5,
+    )
+  })
+
+  it('positions vertical traverse by width offset', () => {
+    const offset = 100
+    const trWidth = 100
+    const g = buildCabinetMesh({
+      width: 1,
+      height: 0.9,
+      depth: 0.5,
+      drawers: 0,
+      gaps: { top: 0, bottom: 0 },
+      family: FAMILY.BASE,
+      topPanel: {
+        type: 'frontTraverse',
+        traverse: { orientation: 'vertical', offset, width: trWidth },
+      },
+    })
+    const traverse = g.children.find(
+      (c) =>
+        c instanceof THREE.Mesh &&
+        Math.abs((c as any).geometry.parameters.depth - 0.5) < 1e-6 &&
+        Math.abs((c as any).geometry.parameters.width - trWidth / 1000) < 1e-6,
+    ) as THREE.Mesh | undefined
+    expect(traverse).toBeTruthy()
+    expect(traverse!.position.x).toBeCloseTo(
+      (offset + trWidth / 2) / 1000,
+      5,
+    )
+  })
+
   it('adds edge outlines when showEdges is true', () => {
     const g = buildCabinetMesh({
       width: 1,


### PR DESCRIPTION
## Summary
- adjust traverse positioning: horizontal offsets now use cabinet depth, vertical offsets use side width
- update configurator offset sliders with proper ranges and axis-specific labels
- add tests verifying traverse placement along correct axes

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b45543cdac8322887bc16ea00a8496