### PR TITLE
Ensure top traverses match top board width

### DIFF
--- a/src/scene/cabinetBuilder.ts
+++ b/src/scene/cabinetBuilder.ts
@@ -223,7 +223,7 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
       }
     }
   }
-  const addTraverseTop = (tr: Traverse, zBase: number) => {
+  const addTraverseTop = (tr: Traverse, zBase: number, topWidth: number) => {
     const widthM = tr.width / 1000;
     if (tr.orientation === 'vertical') {
       const geo = new THREE.BoxGeometry(widthM, T, D);
@@ -233,13 +233,14 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
       addEdges(mesh);
       group.add(mesh);
     } else {
-      const geo = new THREE.BoxGeometry(W, T, widthM);
+      const geo = new THREE.BoxGeometry(topWidth, T, widthM);
       const mesh = new THREE.Mesh(geo, carcMat);
       const z =
         zBase === 0
           ? -(tr.offset + tr.width / 2) / 1000
           : -D + (tr.offset + tr.width / 2) / 1000;
-      mesh.position.set(W / 2, legHeight + H - T / 2, z);
+      const x = (W - topWidth) / 2 + topWidth / 2;
+      mesh.position.set(x, legHeight + H - T / 2, z);
       addEdges(mesh);
       group.add(mesh);
     }
@@ -279,12 +280,12 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
       }
     }
   } else if (topPanel.type === 'frontTraverse') {
-    addTraverseTop(topPanel.traverse, 0);
+    addTraverseTop(topPanel.traverse, 0, topWidth);
   } else if (topPanel.type === 'backTraverse') {
-    addTraverseTop(topPanel.traverse, D);
+    addTraverseTop(topPanel.traverse, D, topWidth);
   } else if (topPanel.type === 'twoTraverses') {
-    addTraverseTop(topPanel.front, 0);
-    addTraverseTop(topPanel.back, D);
+    addTraverseTop(topPanel.front, 0, topWidth);
+    addTraverseTop(topPanel.back, D, topWidth);
   }
 
   // Back panel styles

--- a/tests/cabinetBuilder.test.ts
+++ b/tests/cabinetBuilder.test.ts
@@ -140,10 +140,12 @@ describe('buildCabinetMesh', () => {
         traverse: { orientation: 'horizontal', offset, width: trWidth },
       },
     })
+    const boardThickness = 0.018
+    const expectedWidth = 1 - 2 * boardThickness
     const traverse = g.children.find(
       (c) =>
         c instanceof THREE.Mesh &&
-        Math.abs((c as any).geometry.parameters.width - 1) < 1e-6 &&
+        Math.abs((c as any).geometry.parameters.width - expectedWidth) < 1e-6 &&
         Math.abs((c as any).geometry.parameters.depth - trWidth / 1000) < 1e-6,
     ) as THREE.Mesh | undefined
     expect(traverse).toBeTruthy()


### PR DESCRIPTION
## Summary
- Pass top board width into `addTraverseTop`
- Size and position horizontal top traverses using the top board width
- Adjust tests for updated traverse width

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b45f9061848322a659b01093b30930