### PR TITLE
Align vertical traverses with internal side surfaces

### DIFF
--- a/src/scene/cabinetBuilder.ts
+++ b/src/scene/cabinetBuilder.ts
@@ -185,6 +185,7 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
       : carcassType === 'type2'
         ? W - 2 * T
         : W - 2 * T;
+  const sideInset = carcassType === 'type3' ? 0 : T;
   if (bottomPanel !== 'none') {
     const bottom = new THREE.Mesh(
       new THREE.BoxGeometry(bottomWidth, T, D),
@@ -228,7 +229,7 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
     if (tr.orientation === 'vertical') {
       const geo = new THREE.BoxGeometry(widthM, T, D);
       const mesh = new THREE.Mesh(geo, carcMat);
-      const x = (tr.offset + tr.width / 2) / 1000;
+      const x = sideInset + (tr.offset + tr.width / 2) / 1000;
       mesh.position.set(x, legHeight + H - T / 2, -D / 2);
       addEdges(mesh);
       group.add(mesh);

--- a/tests/cabinetBuilder.test.ts
+++ b/tests/cabinetBuilder.test.ts
@@ -178,6 +178,35 @@ describe('buildCabinetMesh', () => {
     ) as THREE.Mesh | undefined
     expect(traverse).toBeTruthy()
     expect(traverse!.position.x).toBeCloseTo(
+      0.018 + (offset + trWidth / 2) / 1000,
+      5,
+    )
+  })
+
+  it('positions vertical traverse flush for carcass type3', () => {
+    const offset = 100
+    const trWidth = 100
+    const g = buildCabinetMesh({
+      width: 1,
+      height: 0.9,
+      depth: 0.5,
+      drawers: 0,
+      gaps: { top: 0, bottom: 0 },
+      family: FAMILY.BASE,
+      carcassType: 'type3',
+      topPanel: {
+        type: 'frontTraverse',
+        traverse: { orientation: 'vertical', offset, width: trWidth },
+      },
+    })
+    const traverse = g.children.find(
+      (c) =>
+        c instanceof THREE.Mesh &&
+        Math.abs((c as any).geometry.parameters.depth - 0.5) < 1e-6 &&
+        Math.abs((c as any).geometry.parameters.width - trWidth / 1000) < 1e-6,
+    ) as THREE.Mesh | undefined
+    expect(traverse).toBeTruthy()
+    expect(traverse!.position.x).toBeCloseTo(
       (offset + trWidth / 2) / 1000,
       5,
     )


### PR DESCRIPTION
## Summary
- add side inset based on carcass type
- offset vertical traverses by side inset for proper alignment
- update and extend tests for traverse positioning

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b460a47a688322b551d00eec6abb55