### PR TITLE
Prevent double toggling in configurator forms

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -41,5 +41,6 @@
 .configuratorHeader{position:sticky;top:0;z-index:10;background:var(--white)}
 details{border:1px solid var(--border);border-radius:8px;margin-top:8px}
 details>summary{cursor:pointer;padding:8px 0;font-weight:600}
+details>summary.active{color:var(--accent);text-decoration:underline}
 details>div{padding:8px 0;animation:fadeIn .2s ease}
 @keyframes fadeIn{from{opacity:0}to{opacity:1}}

--- a/src/ui/CabinetConfigurator.tsx
+++ b/src/ui/CabinetConfigurator.tsx
@@ -209,9 +209,11 @@ const CabinetConfigurator: React.FC<Props> = ({
 
         <details open={openSection === 'korpus'}>
           <summary
-            onClick={() =>
-              setOpenSection(openSection === 'korpus' ? null : 'korpus')
-            }
+            onClick={(e) => {
+              e.preventDefault();
+              setOpenSection(openSection === 'korpus' ? null : 'korpus');
+            }}
+            className={openSection === 'korpus' ? 'active' : ''}
           >
             {t('configurator.sections.korpus')}
           </summary>
@@ -619,9 +621,11 @@ const CabinetConfigurator: React.FC<Props> = ({
 
         <details open={openSection === 'fronty'}>
           <summary
-            onClick={() =>
-              setOpenSection(openSection === 'fronty' ? null : 'fronty')
-            }
+            onClick={(e) => {
+              e.preventDefault();
+              setOpenSection(openSection === 'fronty' ? null : 'fronty');
+            }}
+            className={openSection === 'fronty' ? 'active' : ''}
           >
             {t('configurator.sections.fronty')}
           </summary>
@@ -683,9 +687,11 @@ const CabinetConfigurator: React.FC<Props> = ({
 
         <details open={openSection === 'okucie'}>
           <summary
-            onClick={() =>
-              setOpenSection(openSection === 'okucie' ? null : 'okucie')
-            }
+            onClick={(e) => {
+              e.preventDefault();
+              setOpenSection(openSection === 'okucie' ? null : 'okucie');
+            }}
+            className={openSection === 'okucie' ? 'active' : ''}
           >
             {t('configurator.sections.okucie')}
           </summary>
@@ -705,9 +711,11 @@ const CabinetConfigurator: React.FC<Props> = ({
 
         <details open={openSection === 'nozki'}>
           <summary
-            onClick={() =>
-              setOpenSection(openSection === 'nozki' ? null : 'nozki')
-            }
+            onClick={(e) => {
+              e.preventDefault();
+              setOpenSection(openSection === 'nozki' ? null : 'nozki');
+            }}
+            className={openSection === 'nozki' ? 'active' : ''}
           >
             {t('configurator.sections.nozki')}
           </summary>
@@ -726,9 +734,11 @@ const CabinetConfigurator: React.FC<Props> = ({
         </details>
         <details open={openSection === 'rysunki'}>
           <summary
-            onClick={() =>
-              setOpenSection(openSection === 'rysunki' ? null : 'rysunki')
-            }
+            onClick={(e) => {
+              e.preventDefault();
+              setOpenSection(openSection === 'rysunki' ? null : 'rysunki');
+            }}
+            className={openSection === 'rysunki' ? 'active' : ''}
           >
             {t('configurator.sections.rysunki')}
           </summary>

--- a/src/ui/forms/ApplianceCabinetForm.tsx
+++ b/src/ui/forms/ApplianceCabinetForm.tsx
@@ -13,9 +13,11 @@ export default function ApplianceCabinetForm({ values, onChange }: CabinetFormPr
     <div>
       <details open={openSection === 'korpus'}>
         <summary
-          onClick={() =>
-            setOpenSection(openSection === 'korpus' ? null : 'korpus')
-          }
+          onClick={(e) => {
+            e.preventDefault();
+            setOpenSection(openSection === 'korpus' ? null : 'korpus');
+          }}
+          className={openSection === 'korpus' ? 'active' : ''}
         >
           {t('forms.sections.korpus')}
         </summary>
@@ -28,9 +30,11 @@ export default function ApplianceCabinetForm({ values, onChange }: CabinetFormPr
       </details>
       <details open={openSection === 'fronty'}>
         <summary
-          onClick={() =>
-            setOpenSection(openSection === 'fronty' ? null : 'fronty')
-          }
+          onClick={(e) => {
+            e.preventDefault();
+            setOpenSection(openSection === 'fronty' ? null : 'fronty');
+          }}
+          className={openSection === 'fronty' ? 'active' : ''}
         >
           {t('forms.sections.fronty')}
         </summary>
@@ -38,9 +42,11 @@ export default function ApplianceCabinetForm({ values, onChange }: CabinetFormPr
       </details>
       <details open={openSection === 'okucie'}>
         <summary
-          onClick={() =>
-            setOpenSection(openSection === 'okucie' ? null : 'okucie')
-          }
+          onClick={(e) => {
+            e.preventDefault();
+            setOpenSection(openSection === 'okucie' ? null : 'okucie');
+          }}
+          className={openSection === 'okucie' ? 'active' : ''}
         >
           {t('forms.sections.okucie')}
         </summary>
@@ -48,9 +54,11 @@ export default function ApplianceCabinetForm({ values, onChange }: CabinetFormPr
       </details>
       <details open={openSection === 'nozki'}>
         <summary
-          onClick={() =>
-            setOpenSection(openSection === 'nozki' ? null : 'nozki')
-          }
+          onClick={(e) => {
+            e.preventDefault();
+            setOpenSection(openSection === 'nozki' ? null : 'nozki');
+          }}
+          className={openSection === 'nozki' ? 'active' : ''}
         >
           {t('forms.sections.nozki')}
         </summary>

--- a/src/ui/forms/CargoCabinetForm.tsx
+++ b/src/ui/forms/CargoCabinetForm.tsx
@@ -13,9 +13,11 @@ export default function CargoCabinetForm({ values, onChange }: CabinetFormProps)
     <div>
       <details open={openSection === 'korpus'}>
         <summary
-          onClick={() =>
-            setOpenSection(openSection === 'korpus' ? null : 'korpus')
-          }
+          onClick={(e) => {
+            e.preventDefault();
+            setOpenSection(openSection === 'korpus' ? null : 'korpus');
+          }}
+          className={openSection === 'korpus' ? 'active' : ''}
         >
           {t('forms.sections.korpus')}
         </summary>
@@ -28,9 +30,11 @@ export default function CargoCabinetForm({ values, onChange }: CabinetFormProps)
       </details>
       <details open={openSection === 'fronty'}>
         <summary
-          onClick={() =>
-            setOpenSection(openSection === 'fronty' ? null : 'fronty')
-          }
+          onClick={(e) => {
+            e.preventDefault();
+            setOpenSection(openSection === 'fronty' ? null : 'fronty');
+          }}
+          className={openSection === 'fronty' ? 'active' : ''}
         >
           {t('forms.sections.fronty')}
         </summary>
@@ -38,9 +42,11 @@ export default function CargoCabinetForm({ values, onChange }: CabinetFormProps)
       </details>
       <details open={openSection === 'okucie'}>
         <summary
-          onClick={() =>
-            setOpenSection(openSection === 'okucie' ? null : 'okucie')
-          }
+          onClick={(e) => {
+            e.preventDefault();
+            setOpenSection(openSection === 'okucie' ? null : 'okucie');
+          }}
+          className={openSection === 'okucie' ? 'active' : ''}
         >
           {t('forms.sections.okucie')}
         </summary>
@@ -48,9 +54,11 @@ export default function CargoCabinetForm({ values, onChange }: CabinetFormProps)
       </details>
       <details open={openSection === 'nozki'}>
         <summary
-          onClick={() =>
-            setOpenSection(openSection === 'nozki' ? null : 'nozki')
-          }
+          onClick={(e) => {
+            e.preventDefault();
+            setOpenSection(openSection === 'nozki' ? null : 'nozki');
+          }}
+          className={openSection === 'nozki' ? 'active' : ''}
         >
           {t('forms.sections.nozki')}
         </summary>

--- a/src/ui/forms/CornerCabinetForm.tsx
+++ b/src/ui/forms/CornerCabinetForm.tsx
@@ -24,9 +24,11 @@ export default function CornerCabinetForm({ values, onChange }: CabinetFormProps
     <div>
       <details open={openSection === 'korpus'}>
         <summary
-          onClick={() =>
-            setOpenSection(openSection === 'korpus' ? null : 'korpus')
-          }
+          onClick={(e) => {
+            e.preventDefault();
+            setOpenSection(openSection === 'korpus' ? null : 'korpus');
+          }}
+          className={openSection === 'korpus' ? 'active' : ''}
         >
           {t('forms.sections.korpus')}
         </summary>
@@ -39,9 +41,11 @@ export default function CornerCabinetForm({ values, onChange }: CabinetFormProps
       </details>
       <details open={openSection === 'fronty'}>
         <summary
-          onClick={() =>
-            setOpenSection(openSection === 'fronty' ? null : 'fronty')
-          }
+          onClick={(e) => {
+            e.preventDefault();
+            setOpenSection(openSection === 'fronty' ? null : 'fronty');
+          }}
+          className={openSection === 'fronty' ? 'active' : ''}
         >
           {t('forms.sections.fronty')}
         </summary>
@@ -49,9 +53,11 @@ export default function CornerCabinetForm({ values, onChange }: CabinetFormProps
       </details>
       <details open={openSection === 'okucie'}>
         <summary
-          onClick={() =>
-            setOpenSection(openSection === 'okucie' ? null : 'okucie')
-          }
+          onClick={(e) => {
+            e.preventDefault();
+            setOpenSection(openSection === 'okucie' ? null : 'okucie');
+          }}
+          className={openSection === 'okucie' ? 'active' : ''}
         >
           {t('forms.sections.okucie')}
         </summary>
@@ -59,9 +65,11 @@ export default function CornerCabinetForm({ values, onChange }: CabinetFormProps
       </details>
       <details open={openSection === 'nozki'}>
         <summary
-          onClick={() =>
-            setOpenSection(openSection === 'nozki' ? null : 'nozki')
-          }
+          onClick={(e) => {
+            e.preventDefault();
+            setOpenSection(openSection === 'nozki' ? null : 'nozki');
+          }}
+          className={openSection === 'nozki' ? 'active' : ''}
         >
           {t('forms.sections.nozki')}
         </summary>

--- a/src/ui/forms/SinkCabinetForm.tsx
+++ b/src/ui/forms/SinkCabinetForm.tsx
@@ -13,9 +13,11 @@ export default function SinkCabinetForm({ values, onChange }: CabinetFormProps){
     <div>
       <details open={openSection === 'korpus'}>
         <summary
-          onClick={() =>
-            setOpenSection(openSection === 'korpus' ? null : 'korpus')
-          }
+          onClick={(e) => {
+            e.preventDefault();
+            setOpenSection(openSection === 'korpus' ? null : 'korpus');
+          }}
+          className={openSection === 'korpus' ? 'active' : ''}
         >
           {t('forms.sections.korpus')}
         </summary>
@@ -28,9 +30,11 @@ export default function SinkCabinetForm({ values, onChange }: CabinetFormProps){
       </details>
       <details open={openSection === 'fronty'}>
         <summary
-          onClick={() =>
-            setOpenSection(openSection === 'fronty' ? null : 'fronty')
-          }
+          onClick={(e) => {
+            e.preventDefault();
+            setOpenSection(openSection === 'fronty' ? null : 'fronty');
+          }}
+          className={openSection === 'fronty' ? 'active' : ''}
         >
           {t('forms.sections.fronty')}
         </summary>
@@ -38,9 +42,11 @@ export default function SinkCabinetForm({ values, onChange }: CabinetFormProps){
       </details>
       <details open={openSection === 'okucie'}>
         <summary
-          onClick={() =>
-            setOpenSection(openSection === 'okucie' ? null : 'okucie')
-          }
+          onClick={(e) => {
+            e.preventDefault();
+            setOpenSection(openSection === 'okucie' ? null : 'okucie');
+          }}
+          className={openSection === 'okucie' ? 'active' : ''}
         >
           {t('forms.sections.okucie')}
         </summary>
@@ -49,9 +55,11 @@ export default function SinkCabinetForm({ values, onChange }: CabinetFormProps){
       </details>
       <details open={openSection === 'nozki'}>
         <summary
-          onClick={() =>
-            setOpenSection(openSection === 'nozki' ? null : 'nozki')
-          }
+          onClick={(e) => {
+            e.preventDefault();
+            setOpenSection(openSection === 'nozki' ? null : 'nozki');
+          }}
+          className={openSection === 'nozki' ? 'active' : ''}
         >
           {t('forms.sections.nozki')}
         </summary>


### PR DESCRIPTION
## Summary
- collapse all configurator and form sections by default
- prevent double toggling on section summaries and highlight active section
- add CSS for active summary tabs

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b462cad06c8322a18d0c14c4d5f583