### PR TITLE
Support vertical traverse offset and alignment

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -121,6 +121,7 @@
     "offset": "Offset (mm)",
     "offsetWidth": "Offset (width mm)",
     "offsetDepth": "Offset (depth mm)",
+    "offsetHeight": "Offset (height mm)",
     "traverseWidth": "Traverse width (mm)"
   },
   "forms": {

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -121,6 +121,7 @@
     "offset": "Przesunięcie (mm)",
     "offsetWidth": "Przesunięcie (szerokość, mm)",
     "offsetDepth": "Przesunięcie (głębokość, mm)",
+    "offsetHeight": "Przesunięcie (wysokość, mm)",
     "traverseWidth": "Szerokość trawersu (mm)"
   },
   "forms": {

--- a/src/scene/cabinetBuilder.ts
+++ b/src/scene/cabinetBuilder.ts
@@ -227,10 +227,13 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
   const addTraverseTop = (tr: Traverse, zBase: number, topWidth: number) => {
     const widthM = tr.width / 1000;
     if (tr.orientation === 'vertical') {
-      const geo = new THREE.BoxGeometry(widthM, T, D);
+      const geo = new THREE.BoxGeometry(W - 2 * T, widthM, T);
       const mesh = new THREE.Mesh(geo, carcMat);
-      const x = sideInset + (tr.offset + tr.width / 2) / 1000;
-      mesh.position.set(x, legHeight + H - T / 2, -D / 2);
+      mesh.position.set(
+        W / 2,
+        legHeight + H - tr.width / 2000 - tr.offset / 1000,
+        -D + T / 2,
+      );
       addEdges(mesh);
       group.add(mesh);
     } else {

--- a/src/ui/CabinetConfigurator.tsx
+++ b/src/ui/CabinetConfigurator.tsx
@@ -410,7 +410,7 @@ const CabinetConfigurator: React.FC<Props> = ({
                     <div className="small" style={{ marginTop: 4 }}>
                       {t(
                         gLocal.topPanel.traverse.orientation === 'vertical'
-                          ? 'configurator.offsetWidth'
+                          ? 'configurator.offsetHeight'
                           : 'configurator.offsetDepth',
                       )}
                     </div>
@@ -420,7 +420,7 @@ const CabinetConfigurator: React.FC<Props> = ({
                       min={0}
                       max={
                         gLocal.topPanel.traverse.orientation === 'vertical'
-                          ? widthMM
+                          ? gLocal.height - gLocal.topPanel.traverse.width
                           : gLocal.depth
                       }
                       value={gLocal.topPanel.traverse.offset}
@@ -500,7 +500,7 @@ const CabinetConfigurator: React.FC<Props> = ({
                         <div className="small" style={{ marginTop: 4 }}>
                           {t(
                             gLocal.topPanel[pos].orientation === 'vertical'
-                              ? 'configurator.offsetWidth'
+                              ? 'configurator.offsetHeight'
                               : 'configurator.offsetDepth',
                           )}
                         </div>
@@ -510,7 +510,7 @@ const CabinetConfigurator: React.FC<Props> = ({
                           min={0}
                           max={
                             gLocal.topPanel[pos].orientation === 'vertical'
-                              ? widthMM
+                              ? gLocal.height - gLocal.topPanel[pos].width
                               : gLocal.depth
                           }
                           value={gLocal.topPanel[pos].offset}

--- a/tests/cabinetBuilder.test.ts
+++ b/tests/cabinetBuilder.test.ts
@@ -155,7 +155,7 @@ describe('buildCabinetMesh', () => {
     )
   })
 
-  it('positions vertical traverse by width offset', () => {
+  it('positions vertical traverse by vertical offset', () => {
     const offset = 100
     const trWidth = 100
     const g = buildCabinetMesh({
@@ -170,44 +170,20 @@ describe('buildCabinetMesh', () => {
         traverse: { orientation: 'vertical', offset, width: trWidth },
       },
     })
+    const boardThickness = 0.018
+    const expectedWidth = 1 - 2 * boardThickness
     const traverse = g.children.find(
       (c) =>
         c instanceof THREE.Mesh &&
-        Math.abs((c as any).geometry.parameters.depth - 0.5) < 1e-6 &&
-        Math.abs((c as any).geometry.parameters.width - trWidth / 1000) < 1e-6,
+        Math.abs((c as any).geometry.parameters.width - expectedWidth) < 1e-6 &&
+        Math.abs((c as any).geometry.parameters.height - trWidth / 1000) < 1e-6 &&
+        Math.abs((c as any).geometry.parameters.depth - boardThickness) < 1e-6,
     ) as THREE.Mesh | undefined
     expect(traverse).toBeTruthy()
-    expect(traverse!.position.x).toBeCloseTo(
-      0.018 + (offset + trWidth / 2) / 1000,
-      5,
-    )
-  })
-
-  it('positions vertical traverse flush for carcass type3', () => {
-    const offset = 100
-    const trWidth = 100
-    const g = buildCabinetMesh({
-      width: 1,
-      height: 0.9,
-      depth: 0.5,
-      drawers: 0,
-      gaps: { top: 0, bottom: 0 },
-      family: FAMILY.BASE,
-      carcassType: 'type3',
-      topPanel: {
-        type: 'frontTraverse',
-        traverse: { orientation: 'vertical', offset, width: trWidth },
-      },
-    })
-    const traverse = g.children.find(
-      (c) =>
-        c instanceof THREE.Mesh &&
-        Math.abs((c as any).geometry.parameters.depth - 0.5) < 1e-6 &&
-        Math.abs((c as any).geometry.parameters.width - trWidth / 1000) < 1e-6,
-    ) as THREE.Mesh | undefined
-    expect(traverse).toBeTruthy()
-    expect(traverse!.position.x).toBeCloseTo(
-      (offset + trWidth / 2) / 1000,
+    expect(traverse!.position.x).toBeCloseTo(0.5, 5)
+    expect(traverse!.position.z).toBeCloseTo(-0.5 + boardThickness / 2, 5)
+    expect(traverse!.position.y).toBeCloseTo(
+      0.9 - trWidth / 2000 - offset / 1000,
       5,
     )
   })


### PR DESCRIPTION
## Summary
- Align vertical top traverse with back panel, spanning inner width
- Allow vertical traverse offset from top in configurator
- Add offset height translations and adjust tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b468b1490c8322be8be0645149e993