### PR TITLE
Fix front vertical traverse positioning

### DIFF
--- a/src/scene/cabinetBuilder.ts
+++ b/src/scene/cabinetBuilder.ts
@@ -229,10 +229,11 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
     if (tr.orientation === 'vertical') {
       const geo = new THREE.BoxGeometry(W - 2 * T, widthM, T);
       const mesh = new THREE.Mesh(geo, carcMat);
+      const z = zBase === 0 ? -T / 2 : -D + T / 2;
       mesh.position.set(
         W / 2,
         legHeight + H - tr.width / 2000 - tr.offset / 1000,
-        -D + T / 2,
+        z,
       );
       addEdges(mesh);
       group.add(mesh);

--- a/tests/cabinetBuilder.test.ts
+++ b/tests/cabinetBuilder.test.ts
@@ -181,7 +181,7 @@ describe('buildCabinetMesh', () => {
     ) as THREE.Mesh | undefined
     expect(traverse).toBeTruthy()
     expect(traverse!.position.x).toBeCloseTo(0.5, 5)
-    expect(traverse!.position.z).toBeCloseTo(-0.5 + boardThickness / 2, 5)
+    expect(traverse!.position.z).toBeCloseTo(-boardThickness / 2, 5)
     expect(traverse!.position.y).toBeCloseTo(
       0.9 - trWidth / 2000 - offset / 1000,
       5,


### PR DESCRIPTION
## Summary
- Place vertical top traverse at cabinet front when requested
- Update unit test for vertical traverse positioning

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b42aeedb38832284da52418ace50fd