### PR TITLE
Correct vertical traverse placement and banding

### DIFF
--- a/src/scene/cabinetBuilder.ts
+++ b/src/scene/cabinetBuilder.ts
@@ -229,14 +229,16 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
     if (tr.orientation === 'vertical') {
       const geo = new THREE.BoxGeometry(widthM, T, D - 2 * T);
       const mesh = new THREE.Mesh(geo, carcMat);
-      const x = T + tr.offset / 1000 + widthM / 2;
-      const z = zBase === 0 ? -(D - 2 * T) / 2 : -D + (D - 2 * T) / 2;
+      const x = T + tr.offset / 1000;
+      const z = -D / 2;
       mesh.position.set(x, legHeight + H - T / 2, z);
       addEdges(mesh);
       group.add(mesh);
       if (edgeBanding !== 'none') {
-        const zEdge = zBase === 0 ? bandThickness / 2 : -D + bandThickness / 2;
-        addBand(x, legHeight + H - T / 2, zEdge, widthM, T, bandThickness);
+        const zFront = -T + bandThickness / 2;
+        const zBack = -D + T - bandThickness / 2;
+        addBand(x, legHeight + H - T / 2, zFront, widthM, T, bandThickness);
+        addBand(x, legHeight + H - T / 2, zBack, widthM, T, bandThickness);
         if (edgeBanding === 'full') {
           addBand(
             x - widthM / 2 + bandThickness / 2,

--- a/tests/cabinetBuilder.test.ts
+++ b/tests/cabinetBuilder.test.ts
@@ -163,12 +163,14 @@ describe('buildCabinetMesh', () => {
       drawers: 0,
       gaps: { top: 0, bottom: 0 },
       family: FAMILY.BASE,
+      edgeBanding: 'full',
       topPanel: {
         type: 'frontTraverse',
         traverse: { orientation: 'vertical', offset, width: trWidth },
       },
     });
     const boardThickness = 0.018;
+    const bandThickness = 0.002;
     const expectedDepth = depth - 2 * boardThickness;
     const widthM = trWidth / 1000;
     const traverse = g.children.find(
@@ -180,12 +182,31 @@ describe('buildCabinetMesh', () => {
         Math.abs((c as any).geometry.parameters.depth - expectedDepth) < 1e-6,
     ) as THREE.Mesh | undefined;
     expect(traverse).toBeTruthy();
-    expect(traverse!.position.x).toBeCloseTo(
-      boardThickness + offset / 1000 + widthM / 2,
-      5,
-    );
-    expect(traverse!.position.z).toBeCloseTo(-expectedDepth / 2, 5);
+    expect(traverse!.position.x).toBeCloseTo(boardThickness + offset / 1000, 5);
+    expect(traverse!.position.z).toBeCloseTo(-depth / 2, 5);
     expect(traverse!.position.y).toBeCloseTo(0.9 - boardThickness / 2, 5);
+
+    const frontBand = g.children.find(
+      (c) =>
+        c instanceof THREE.Mesh &&
+        Math.abs((c as any).geometry.parameters.width - widthM) < 1e-6 &&
+        Math.abs((c as any).geometry.parameters.height - boardThickness) <
+          1e-6 &&
+        Math.abs((c as any).geometry.parameters.depth - bandThickness) < 1e-6 &&
+        Math.abs(c.position.z - (-boardThickness + bandThickness / 2)) < 1e-6,
+    );
+    const backBand = g.children.find(
+      (c) =>
+        c instanceof THREE.Mesh &&
+        Math.abs((c as any).geometry.parameters.width - widthM) < 1e-6 &&
+        Math.abs((c as any).geometry.parameters.height - boardThickness) <
+          1e-6 &&
+        Math.abs((c as any).geometry.parameters.depth - bandThickness) < 1e-6 &&
+        Math.abs(c.position.z - (-depth + boardThickness - bandThickness / 2)) <
+          1e-6,
+    );
+    expect(frontBand).toBeTruthy();
+    expect(backBand).toBeTruthy();
   });
 
   it('adds edge outlines when showEdges is true', () => {


### PR DESCRIPTION
## Summary
- Align vertical top traverses using the offset as their center and always span the cabinet depth
- Apply edge banding at both the front and back of vertical top traverses
- Update cabinet builder tests for new positioning and banding checks

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b47d8639dc8322b2cff713a2d06700