### PR TITLE
Highlight active sections in configurator forms

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -40,7 +40,8 @@
 .slidingPanelClose{position:absolute;top:8px;right:12px;border:none;background:none;font-size:20px;cursor:pointer}
 .configuratorHeader{position:sticky;top:0;z-index:10;background:var(--white)}
 details{border:1px solid var(--border);border-radius:8px;margin-top:8px}
+details.active{border-color:var(--accent)}
 details>summary{cursor:pointer;padding:8px 0;font-weight:600}
-details>summary.active{color:var(--accent);text-decoration:underline}
+details.active>summary{color:var(--accent);text-decoration:underline;font-weight:700}
 details>div{padding:8px 0;animation:fadeIn .2s ease}
 @keyframes fadeIn{from{opacity:0}to{opacity:1}}

--- a/src/ui/CabinetConfigurator.tsx
+++ b/src/ui/CabinetConfigurator.tsx
@@ -207,13 +207,15 @@ const CabinetConfigurator: React.FC<Props> = ({
           )}
         </div>
 
-        <details open={openSection === 'korpus'}>
+        <details
+          open={openSection === 'korpus'}
+          className={openSection === 'korpus' ? 'active' : ''}
+        >
           <summary
             onClick={(e) => {
               e.preventDefault();
               setOpenSection(openSection === 'korpus' ? null : 'korpus');
             }}
-            className={openSection === 'korpus' ? 'active' : ''}
           >
             {t('configurator.sections.korpus')}
           </summary>
@@ -619,13 +621,15 @@ const CabinetConfigurator: React.FC<Props> = ({
           </div>
         </details>
 
-        <details open={openSection === 'fronty'}>
+        <details
+          open={openSection === 'fronty'}
+          className={openSection === 'fronty' ? 'active' : ''}
+        >
           <summary
             onClick={(e) => {
               e.preventDefault();
               setOpenSection(openSection === 'fronty' ? null : 'fronty');
             }}
-            className={openSection === 'fronty' ? 'active' : ''}
           >
             {t('configurator.sections.fronty')}
           </summary>
@@ -685,13 +689,15 @@ const CabinetConfigurator: React.FC<Props> = ({
           </div>
         </details>
 
-        <details open={openSection === 'okucie'}>
+        <details
+          open={openSection === 'okucie'}
+          className={openSection === 'okucie' ? 'active' : ''}
+        >
           <summary
             onClick={(e) => {
               e.preventDefault();
               setOpenSection(openSection === 'okucie' ? null : 'okucie');
             }}
-            className={openSection === 'okucie' ? 'active' : ''}
           >
             {t('configurator.sections.okucie')}
           </summary>
@@ -709,13 +715,15 @@ const CabinetConfigurator: React.FC<Props> = ({
           </div>
         </details>
 
-        <details open={openSection === 'nozki'}>
+        <details
+          open={openSection === 'nozki'}
+          className={openSection === 'nozki' ? 'active' : ''}
+        >
           <summary
             onClick={(e) => {
               e.preventDefault();
               setOpenSection(openSection === 'nozki' ? null : 'nozki');
             }}
-            className={openSection === 'nozki' ? 'active' : ''}
           >
             {t('configurator.sections.nozki')}
           </summary>
@@ -732,13 +740,15 @@ const CabinetConfigurator: React.FC<Props> = ({
             </div>
           </div>
         </details>
-        <details open={openSection === 'rysunki'}>
+        <details
+          open={openSection === 'rysunki'}
+          className={openSection === 'rysunki' ? 'active' : ''}
+        >
           <summary
             onClick={(e) => {
               e.preventDefault();
               setOpenSection(openSection === 'rysunki' ? null : 'rysunki');
             }}
-            className={openSection === 'rysunki' ? 'active' : ''}
           >
             {t('configurator.sections.rysunki')}
           </summary>

--- a/src/ui/forms/ApplianceCabinetForm.tsx
+++ b/src/ui/forms/ApplianceCabinetForm.tsx
@@ -11,13 +11,15 @@ export default function ApplianceCabinetForm({ values, onChange }: CabinetFormPr
     useState<'korpus' | 'fronty' | 'okucie' | 'nozki' | null>(null)
   return (
     <div>
-      <details open={openSection === 'korpus'}>
+      <details
+        open={openSection === 'korpus'}
+        className={openSection === 'korpus' ? 'active' : ''}
+      >
         <summary
           onClick={(e) => {
             e.preventDefault();
             setOpenSection(openSection === 'korpus' ? null : 'korpus');
           }}
-          className={openSection === 'korpus' ? 'active' : ''}
         >
           {t('forms.sections.korpus')}
         </summary>
@@ -28,37 +30,43 @@ export default function ApplianceCabinetForm({ values, onChange }: CabinetFormPr
           <SingleMMInput value={depth} onChange={d=>update({ depth:d })} />
         </div>
       </details>
-      <details open={openSection === 'fronty'}>
+      <details
+        open={openSection === 'fronty'}
+        className={openSection === 'fronty' ? 'active' : ''}
+      >
         <summary
           onClick={(e) => {
             e.preventDefault();
             setOpenSection(openSection === 'fronty' ? null : 'fronty');
           }}
-          className={openSection === 'fronty' ? 'active' : ''}
         >
           {t('forms.sections.fronty')}
         </summary>
         <div />
       </details>
-      <details open={openSection === 'okucie'}>
+      <details
+        open={openSection === 'okucie'}
+        className={openSection === 'okucie' ? 'active' : ''}
+      >
         <summary
           onClick={(e) => {
             e.preventDefault();
             setOpenSection(openSection === 'okucie' ? null : 'okucie');
           }}
-          className={openSection === 'okucie' ? 'active' : ''}
         >
           {t('forms.sections.okucie')}
         </summary>
         {hardware && <pre style={{ display:'none' }}>{JSON.stringify(hardware)}</pre>}
       </details>
-      <details open={openSection === 'nozki'}>
+      <details
+        open={openSection === 'nozki'}
+        className={openSection === 'nozki' ? 'active' : ''}
+      >
         <summary
           onClick={(e) => {
             e.preventDefault();
             setOpenSection(openSection === 'nozki' ? null : 'nozki');
           }}
-          className={openSection === 'nozki' ? 'active' : ''}
         >
           {t('forms.sections.nozki')}
         </summary>

--- a/src/ui/forms/CargoCabinetForm.tsx
+++ b/src/ui/forms/CargoCabinetForm.tsx
@@ -11,13 +11,15 @@ export default function CargoCabinetForm({ values, onChange }: CabinetFormProps)
     useState<'korpus' | 'fronty' | 'okucie' | 'nozki' | null>(null)
   return (
     <div>
-      <details open={openSection === 'korpus'}>
+      <details
+        open={openSection === 'korpus'}
+        className={openSection === 'korpus' ? 'active' : ''}
+      >
         <summary
           onClick={(e) => {
             e.preventDefault();
             setOpenSection(openSection === 'korpus' ? null : 'korpus');
           }}
-          className={openSection === 'korpus' ? 'active' : ''}
         >
           {t('forms.sections.korpus')}
         </summary>
@@ -28,37 +30,43 @@ export default function CargoCabinetForm({ values, onChange }: CabinetFormProps)
           <SingleMMInput value={depth} onChange={d=>update({ depth:d })} />
         </div>
       </details>
-      <details open={openSection === 'fronty'}>
+      <details
+        open={openSection === 'fronty'}
+        className={openSection === 'fronty' ? 'active' : ''}
+      >
         <summary
           onClick={(e) => {
             e.preventDefault();
             setOpenSection(openSection === 'fronty' ? null : 'fronty');
           }}
-          className={openSection === 'fronty' ? 'active' : ''}
         >
           {t('forms.sections.fronty')}
         </summary>
         <div />
       </details>
-      <details open={openSection === 'okucie'}>
+      <details
+        open={openSection === 'okucie'}
+        className={openSection === 'okucie' ? 'active' : ''}
+      >
         <summary
           onClick={(e) => {
             e.preventDefault();
             setOpenSection(openSection === 'okucie' ? null : 'okucie');
           }}
-          className={openSection === 'okucie' ? 'active' : ''}
         >
           {t('forms.sections.okucie')}
         </summary>
         {hardware && <pre style={{ display:'none' }}>{JSON.stringify(hardware)}</pre>}
       </details>
-      <details open={openSection === 'nozki'}>
+      <details
+        open={openSection === 'nozki'}
+        className={openSection === 'nozki' ? 'active' : ''}
+      >
         <summary
           onClick={(e) => {
             e.preventDefault();
             setOpenSection(openSection === 'nozki' ? null : 'nozki');
           }}
-          className={openSection === 'nozki' ? 'active' : ''}
         >
           {t('forms.sections.nozki')}
         </summary>

--- a/src/ui/forms/CornerCabinetForm.tsx
+++ b/src/ui/forms/CornerCabinetForm.tsx
@@ -22,13 +22,15 @@ export default function CornerCabinetForm({ values, onChange }: CabinetFormProps
     useState<'korpus' | 'fronty' | 'okucie' | 'nozki' | null>(null)
   return (
     <div>
-      <details open={openSection === 'korpus'}>
+      <details
+        open={openSection === 'korpus'}
+        className={openSection === 'korpus' ? 'active' : ''}
+      >
         <summary
           onClick={(e) => {
             e.preventDefault();
             setOpenSection(openSection === 'korpus' ? null : 'korpus');
           }}
-          className={openSection === 'korpus' ? 'active' : ''}
         >
           {t('forms.sections.korpus')}
         </summary>
@@ -39,37 +41,43 @@ export default function CornerCabinetForm({ values, onChange }: CabinetFormProps
           <SingleMMInput value={depth} onChange={d=>update({ depth:d })} />
         </div>
       </details>
-      <details open={openSection === 'fronty'}>
+      <details
+        open={openSection === 'fronty'}
+        className={openSection === 'fronty' ? 'active' : ''}
+      >
         <summary
           onClick={(e) => {
             e.preventDefault();
             setOpenSection(openSection === 'fronty' ? null : 'fronty');
           }}
-          className={openSection === 'fronty' ? 'active' : ''}
         >
           {t('forms.sections.fronty')}
         </summary>
         <div />
       </details>
-      <details open={openSection === 'okucie'}>
+      <details
+        open={openSection === 'okucie'}
+        className={openSection === 'okucie' ? 'active' : ''}
+      >
         <summary
           onClick={(e) => {
             e.preventDefault();
             setOpenSection(openSection === 'okucie' ? null : 'okucie');
           }}
-          className={openSection === 'okucie' ? 'active' : ''}
         >
           {t('forms.sections.okucie')}
         </summary>
         {hardware && <pre style={{ display:'none' }}>{JSON.stringify(hardware)}</pre>}
       </details>
-      <details open={openSection === 'nozki'}>
+      <details
+        open={openSection === 'nozki'}
+        className={openSection === 'nozki' ? 'active' : ''}
+      >
         <summary
           onClick={(e) => {
             e.preventDefault();
             setOpenSection(openSection === 'nozki' ? null : 'nozki');
           }}
-          className={openSection === 'nozki' ? 'active' : ''}
         >
           {t('forms.sections.nozki')}
         </summary>

--- a/src/ui/forms/SinkCabinetForm.tsx
+++ b/src/ui/forms/SinkCabinetForm.tsx
@@ -11,13 +11,15 @@ export default function SinkCabinetForm({ values, onChange }: CabinetFormProps){
     useState<'korpus' | 'fronty' | 'okucie' | 'nozki' | null>(null)
   return (
     <div>
-      <details open={openSection === 'korpus'}>
+      <details
+        open={openSection === 'korpus'}
+        className={openSection === 'korpus' ? 'active' : ''}
+      >
         <summary
           onClick={(e) => {
             e.preventDefault();
             setOpenSection(openSection === 'korpus' ? null : 'korpus');
           }}
-          className={openSection === 'korpus' ? 'active' : ''}
         >
           {t('forms.sections.korpus')}
         </summary>
@@ -28,38 +30,44 @@ export default function SinkCabinetForm({ values, onChange }: CabinetFormProps){
           <SingleMMInput value={depth} onChange={d=>update({ depth:d })} />
         </div>
       </details>
-      <details open={openSection === 'fronty'}>
+      <details
+        open={openSection === 'fronty'}
+        className={openSection === 'fronty' ? 'active' : ''}
+      >
         <summary
           onClick={(e) => {
             e.preventDefault();
             setOpenSection(openSection === 'fronty' ? null : 'fronty');
           }}
-          className={openSection === 'fronty' ? 'active' : ''}
         >
           {t('forms.sections.fronty')}
         </summary>
         <div />
       </details>
-      <details open={openSection === 'okucie'}>
+      <details
+        open={openSection === 'okucie'}
+        className={openSection === 'okucie' ? 'active' : ''}
+      >
         <summary
           onClick={(e) => {
             e.preventDefault();
             setOpenSection(openSection === 'okucie' ? null : 'okucie');
           }}
-          className={openSection === 'okucie' ? 'active' : ''}
         >
           {t('forms.sections.okucie')}
         </summary>
         {/* Sink specific advanced settings may include bowl size or position. */}
         {hardware && <pre style={{ display:'none' }}>{JSON.stringify(hardware)}</pre>}
       </details>
-      <details open={openSection === 'nozki'}>
+      <details
+        open={openSection === 'nozki'}
+        className={openSection === 'nozki' ? 'active' : ''}
+      >
         <summary
           onClick={(e) => {
             e.preventDefault();
             setOpenSection(openSection === 'nozki' ? null : 'nozki');
           }}
-          className={openSection === 'nozki' ? 'active' : ''}
         >
           {t('forms.sections.nozki')}
         </summary>


### PR DESCRIPTION
## Summary
- ensure configurator and form sections start collapsed and toggle a single open panel
- add `.active` class to open `<details>` blocks and style them for visibility

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b494e3ae6c8322abc2d5de5caea8c3