### PR TITLE
feat: toggle cabinet fronts visibility

### DIFF
--- a/src/scene/cabinetBuilder.ts
+++ b/src/scene/cabinetBuilder.ts
@@ -381,95 +381,95 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
   }
 
   // Fronts
-  if (drawers > 0) {
-    const totalFrontHeight = Math.max(
-      50,
-      Math.round(H * 1000 - (gaps.top + gaps.bottom)),
-    );
-    const arr =
-      drawerFronts && drawerFronts.length === drawers
-        ? drawerFronts
-        : Array.from({ length: drawers }, () =>
-            Math.floor(totalFrontHeight / drawers),
-          );
-    let currentY = legHeight + gaps.bottom / 1000;
-    for (let i = 0; i < drawers; i++) {
-      const h = arr[i] / 1000;
-      const frontGeo = new THREE.BoxGeometry(W, h, T);
-      const frontMesh = new THREE.Mesh(frontGeo, frontMat);
-      const fg = new THREE.Group();
-      // Start each drawer front completely in front of the carcass with a 2 mm gap
-      fg.position.set(W / 2, currentY + h / 2, FRONT_OFFSET + T / 2);
-      fg.userData.closedZ = FRONT_OFFSET + T / 2;
-      frontMesh.position.set(0, 0, 0);
-      addEdges(frontMesh);
-      fg.add(frontMesh);
-      fg.userData.type = 'drawer';
-      fg.userData.frontIndex = frontGroups.length;
-      fg.userData.slideDist = -Math.min(0.45, D);
-      fg.visible = showFronts;
-      frontGroups.push(fg);
-      openStates.push(false);
-      openProgress.push(0);
-      if (showHandles) {
-        const handleWidth = Math.min(0.4, W * 0.5);
-        const handleHeight = 0.02;
-        const handleDepth = 0.03;
-        const handleGeo = new THREE.BoxGeometry(
-          handleWidth,
-          handleHeight,
-          handleDepth,
-        );
-        const handle = new THREE.Mesh(handleGeo, handleMat);
-        handle.position.set(0, h / 2 - handleHeight * 1.5, T / 2 + 0.01);
-        frontMesh.add(handle);
-      }
-      group.add(fg);
-      currentY += h;
-    }
-  } else {
-    const doors = Math.max(1, doorCount);
-    const doorW = W / doors;
-    for (let i = 0; i < doors; i++) {
-      const hingeSide = i < doors / 2 ? 'left' : 'right';
-      const doorGeo = new THREE.BoxGeometry(doorW, H, T);
-      const doorMesh = new THREE.Mesh(doorGeo, frontMat);
-      const fg = new THREE.Group();
-      const pivotX = hingeSide === 'left' ? i * doorW : (i + 1) * doorW;
-      // Hinge pivot sits 2 mm in front of the carcass, door hangs entirely in front
-      fg.position.set(pivotX, legHeight + H / 2, FRONT_OFFSET);
-      doorMesh.position.set(
-        hingeSide === 'left' ? doorW / 2 : -doorW / 2,
-        0,
-        T / 2,
+  if (showFronts) {
+    if (drawers > 0) {
+      const totalFrontHeight = Math.max(
+        50,
+        Math.round(H * 1000 - (gaps.top + gaps.bottom)),
       );
-      addEdges(doorMesh);
-      fg.add(doorMesh);
-      fg.userData.type = 'door';
-      fg.userData.frontIndex = frontGroups.length;
-      fg.userData.hingeSide = hingeSide;
-      fg.visible = showFronts;
-      frontGroups.push(fg);
-      openStates.push(false);
-      openProgress.push(0);
-      if (showHandles) {
-        const handleWidth = Math.min(0.4, doorW * 0.5);
-        const handleHeight = 0.02;
-        const handleDepth = 0.03;
-        const handleGeo = new THREE.BoxGeometry(
-          handleWidth,
-          handleHeight,
-          handleDepth,
-        );
-        const handle = new THREE.Mesh(handleGeo, handleMat);
-        const xPos =
-          hingeSide === 'left'
-            ? doorW / 2 - handleWidth / 2
-            : -doorW / 2 + handleWidth / 2;
-        handle.position.set(xPos, H * 0.2, T / 2 + 0.01);
-        doorMesh.add(handle);
+      const arr =
+        drawerFronts && drawerFronts.length === drawers
+          ? drawerFronts
+          : Array.from({ length: drawers }, () =>
+              Math.floor(totalFrontHeight / drawers),
+            );
+      let currentY = legHeight + gaps.bottom / 1000;
+      for (let i = 0; i < drawers; i++) {
+        const h = arr[i] / 1000;
+        const frontGeo = new THREE.BoxGeometry(W, h, T);
+        const frontMesh = new THREE.Mesh(frontGeo, frontMat);
+        const fg = new THREE.Group();
+        // Start each drawer front completely in front of the carcass with a 2 mm gap
+        fg.position.set(W / 2, currentY + h / 2, FRONT_OFFSET + T / 2);
+        fg.userData.closedZ = FRONT_OFFSET + T / 2;
+        frontMesh.position.set(0, 0, 0);
+        addEdges(frontMesh);
+        fg.add(frontMesh);
+        fg.userData.type = 'drawer';
+        fg.userData.frontIndex = frontGroups.length;
+        fg.userData.slideDist = -Math.min(0.45, D);
+        frontGroups.push(fg);
+        openStates.push(false);
+        openProgress.push(0);
+        if (showHandles) {
+          const handleWidth = Math.min(0.4, W * 0.5);
+          const handleHeight = 0.02;
+          const handleDepth = 0.03;
+          const handleGeo = new THREE.BoxGeometry(
+            handleWidth,
+            handleHeight,
+            handleDepth,
+          );
+          const handle = new THREE.Mesh(handleGeo, handleMat);
+          handle.position.set(0, h / 2 - handleHeight * 1.5, T / 2 + 0.01);
+          frontMesh.add(handle);
+        }
+        group.add(fg);
+        currentY += h;
       }
-      group.add(fg);
+    } else {
+      const doors = Math.max(1, doorCount);
+      const doorW = W / doors;
+      for (let i = 0; i < doors; i++) {
+        const hingeSide = i < doors / 2 ? 'left' : 'right';
+        const doorGeo = new THREE.BoxGeometry(doorW, H, T);
+        const doorMesh = new THREE.Mesh(doorGeo, frontMat);
+        const fg = new THREE.Group();
+        const pivotX = hingeSide === 'left' ? i * doorW : (i + 1) * doorW;
+        // Hinge pivot sits 2 mm in front of the carcass, door hangs entirely in front
+        fg.position.set(pivotX, legHeight + H / 2, FRONT_OFFSET);
+        doorMesh.position.set(
+          hingeSide === 'left' ? doorW / 2 : -doorW / 2,
+          0,
+          T / 2,
+        );
+        addEdges(doorMesh);
+        fg.add(doorMesh);
+        fg.userData.type = 'door';
+        fg.userData.frontIndex = frontGroups.length;
+        fg.userData.hingeSide = hingeSide;
+        frontGroups.push(fg);
+        openStates.push(false);
+        openProgress.push(0);
+        if (showHandles) {
+          const handleWidth = Math.min(0.4, doorW * 0.5);
+          const handleHeight = 0.02;
+          const handleDepth = 0.03;
+          const handleGeo = new THREE.BoxGeometry(
+            handleWidth,
+            handleHeight,
+            handleDepth,
+          );
+          const handle = new THREE.Mesh(handleGeo, handleMat);
+          const xPos =
+            hingeSide === 'left'
+              ? doorW / 2 - handleWidth / 2
+              : -doorW / 2 + handleWidth / 2;
+          handle.position.set(xPos, H * 0.2, T / 2 + 0.01);
+          doorMesh.add(handle);
+        }
+        group.add(fg);
+      }
     }
   }
 

--- a/tests/cabinetBuilder.test.ts
+++ b/tests/cabinetBuilder.test.ts
@@ -62,6 +62,23 @@ describe('buildCabinetMesh', () => {
     expect(doors.length).toBe(2);
   });
 
+  it('omits front groups when showFronts is false', () => {
+    const g = buildCabinetMesh({
+      width: 1,
+      height: 0.9,
+      depth: 0.5,
+      drawers: 1,
+      gaps: { top: 0, bottom: 0 },
+      family: FAMILY.BASE,
+      showFronts: false,
+    });
+    const fronts = g.children.filter(
+      (c) => c instanceof THREE.Group && (c as any).userData?.type,
+    );
+    expect(fronts.length).toBe(0);
+    expect((g.userData.frontGroups || []).length).toBe(0);
+  });
+
   it('adds divider when dividerPosition provided', () => {
     const g = buildCabinetMesh({
       width: 1,


### PR DESCRIPTION
## Summary
- hide cabinet fronts while editing carcass by toggling a `showFronts` flag
- avoid building front meshes when `showFronts` is false
- test that no front groups are generated when fronts are hidden

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b4962568fc8322b17067f7fe993545