### PR TITLE
feat: add carcass type selector

### DIFF
--- a/src/ui/CabinetConfigurator.tsx
+++ b/src/ui/CabinetConfigurator.tsx
@@ -220,19 +220,11 @@ const CabinetConfigurator: React.FC<Props> = ({
             {t('configurator.sections.korpus')}
           </summary>
           <div>
-            {FormComponent && (
-              <div style={{ marginBottom: 8 }}>
-                <FormComponent
-                  values={formValues}
-                  onChange={handleFormChange}
-                />
-              </div>
-            )}
             <div style={{ marginBottom: 8 }}>
               <div className="small">{t('configurator.carcassType')}</div>
               <select
                 className="input"
-                value={gLocal.carcassType || 'type1'}
+                value={gLocal.carcassType}
                 onChange={(e) =>
                   setAdv({
                     ...gLocal,
@@ -252,6 +244,14 @@ const CabinetConfigurator: React.FC<Props> = ({
                 </option>
               </select>
             </div>
+            {FormComponent && (
+              <div style={{ marginBottom: 8 }}>
+                <FormComponent
+                  values={formValues}
+                  onChange={handleFormChange}
+                />
+              </div>
+            )}
             <div className="grid4">
               <div>
                 <div className="small">{t('configurator.height')}</div>

--- a/src/ui/types.ts
+++ b/src/ui/types.ts
@@ -6,7 +6,7 @@ export interface CabinetConfig {
   boardType: string;
   frontType: string;
   gaps: Gaps;
-  carcassType?: 'type1' | 'type2' | 'type3';
+  carcassType: 'type1' | 'type2' | 'type3';
   shelves?: number;
   backPanel?: 'full' | 'split' | 'none';
   topPanel?: TopPanel;


### PR DESCRIPTION
## Summary
- make carcass type a required field in cabinet config
- show carcass type selector at top of Korpus panel

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b49838654c8322879f65adeedd0434