### PR TITLE
Align traverse orientation axes

### DIFF
--- a/src/scene/cabinetBuilder.ts
+++ b/src/scene/cabinetBuilder.ts
@@ -229,14 +229,16 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
     if (tr.orientation === 'vertical') {
       const geo = new THREE.BoxGeometry(widthM, T, D - 2 * T);
       const mesh = new THREE.Mesh(geo, carcMat);
-      const x = T + tr.offset / 1000;
-      const z = -D / 2;
+      const frontEdge = -T - tr.offset / 1000;
+      const backEdge = -D + T - tr.offset / 1000;
+      const z = (frontEdge + backEdge) / 2;
+      const x = W / 2;
       mesh.position.set(x, legHeight + H - T / 2, z);
       addEdges(mesh);
       group.add(mesh);
       if (edgeBanding !== 'none') {
-        const zFront = -T + bandThickness / 2;
-        const zBack = -D + T - bandThickness / 2;
+        const zFront = frontEdge + bandThickness / 2;
+        const zBack = backEdge - bandThickness / 2;
         addBand(x, legHeight + H - T / 2, zFront, widthM, T, bandThickness);
         addBand(x, legHeight + H - T / 2, zBack, widthM, T, bandThickness);
         if (edgeBanding === 'full') {
@@ -261,11 +263,8 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
     } else {
       const geo = new THREE.BoxGeometry(topWidth, T, widthM);
       const mesh = new THREE.Mesh(geo, carcMat);
-      const z =
-        zBase === 0
-          ? -(tr.offset + tr.width / 2) / 1000
-          : -D + (tr.offset + tr.width / 2) / 1000;
-      const x = (W - topWidth) / 2 + topWidth / 2;
+      const x = W / 2 + tr.offset / 1000;
+      const z = -D / 2;
       mesh.position.set(x, legHeight + H - T / 2, z);
       addEdges(mesh);
       group.add(mesh);

--- a/src/ui/CabinetConfigurator.tsx
+++ b/src/ui/CabinetConfigurator.tsx
@@ -412,8 +412,8 @@ const CabinetConfigurator: React.FC<Props> = ({
                     <div className="small" style={{ marginTop: 4 }}>
                       {t(
                         gLocal.topPanel.traverse.orientation === 'vertical'
-                          ? 'configurator.offsetHeight'
-                          : 'configurator.offsetDepth',
+                          ? 'configurator.offsetDepth'
+                          : 'configurator.offsetWidth',
                       )}
                     </div>
                     <input
@@ -422,8 +422,8 @@ const CabinetConfigurator: React.FC<Props> = ({
                       min={0}
                       max={
                         gLocal.topPanel.traverse.orientation === 'vertical'
-                          ? gLocal.height - gLocal.topPanel.traverse.width
-                          : gLocal.depth
+                          ? gLocal.depth - gLocal.topPanel.traverse.width
+                          : gLocal.width - gLocal.topPanel.traverse.width
                       }
                       value={gLocal.topPanel.traverse.offset}
                       onChange={(e) =>
@@ -502,8 +502,8 @@ const CabinetConfigurator: React.FC<Props> = ({
                         <div className="small" style={{ marginTop: 4 }}>
                           {t(
                             gLocal.topPanel[pos].orientation === 'vertical'
-                              ? 'configurator.offsetHeight'
-                              : 'configurator.offsetDepth',
+                              ? 'configurator.offsetDepth'
+                              : 'configurator.offsetWidth',
                           )}
                         </div>
                         <input
@@ -512,8 +512,8 @@ const CabinetConfigurator: React.FC<Props> = ({
                           min={0}
                           max={
                             gLocal.topPanel[pos].orientation === 'vertical'
-                              ? gLocal.height - gLocal.topPanel[pos].width
-                              : gLocal.depth
+                              ? gLocal.depth - gLocal.topPanel[pos].width
+                              : gLocal.width - gLocal.topPanel[pos].width
                           }
                           value={gLocal.topPanel[pos].offset}
                           onChange={(e) =>

--- a/tests/cabinetBuilder.test.ts
+++ b/tests/cabinetBuilder.test.ts
@@ -142,7 +142,7 @@ describe('buildCabinetMesh', () => {
     expect(size.z).toBeCloseTo(depth + boardThickness + FRONT_OFFSET, 5);
   });
 
-  it('positions horizontal traverse by depth offset', () => {
+  it('positions horizontal traverse by width offset', () => {
     const offset = 100;
     const trWidth = 100;
     const g = buildCabinetMesh({
@@ -166,10 +166,10 @@ describe('buildCabinetMesh', () => {
         Math.abs((c as any).geometry.parameters.depth - trWidth / 1000) < 1e-6,
     ) as THREE.Mesh | undefined;
     expect(traverse).toBeTruthy();
-    expect(traverse!.position.z).toBeCloseTo(-(offset + trWidth / 2) / 1000, 5);
+    expect(traverse!.position.x).toBeCloseTo(0.5 + offset / 1000, 5);
   });
 
-  it('positions vertical traverse by offset', () => {
+  it('positions vertical traverse by depth offset', () => {
     const offset = 100;
     const trWidth = 100;
     const depth = 0.5;
@@ -199,8 +199,8 @@ describe('buildCabinetMesh', () => {
         Math.abs((c as any).geometry.parameters.depth - expectedDepth) < 1e-6,
     ) as THREE.Mesh | undefined;
     expect(traverse).toBeTruthy();
-    expect(traverse!.position.x).toBeCloseTo(boardThickness + offset / 1000, 5);
-    expect(traverse!.position.z).toBeCloseTo(-depth / 2, 5);
+    expect(traverse!.position.x).toBeCloseTo(0.5, 5);
+    expect(traverse!.position.z).toBeCloseTo(-depth / 2 - offset / 1000, 5);
     expect(traverse!.position.y).toBeCloseTo(0.9 - boardThickness / 2, 5);
 
     const frontBand = g.children.find(
@@ -210,7 +210,9 @@ describe('buildCabinetMesh', () => {
         Math.abs((c as any).geometry.parameters.height - boardThickness) <
           1e-6 &&
         Math.abs((c as any).geometry.parameters.depth - bandThickness) < 1e-6 &&
-        Math.abs(c.position.z - (-boardThickness + bandThickness / 2)) < 1e-6,
+        Math.abs(
+          c.position.z - (-boardThickness - offset / 1000 + bandThickness / 2),
+        ) < 1e-6,
     );
     const backBand = g.children.find(
       (c) =>
@@ -219,14 +221,15 @@ describe('buildCabinetMesh', () => {
         Math.abs((c as any).geometry.parameters.height - boardThickness) <
           1e-6 &&
         Math.abs((c as any).geometry.parameters.depth - bandThickness) < 1e-6 &&
-        Math.abs(c.position.z - (-depth + boardThickness - bandThickness / 2)) <
-          1e-6,
+        Math.abs(
+          c.position.z - (-depth + boardThickness - offset / 1000 - bandThickness / 2),
+        ) < 1e-6,
     );
     expect(frontBand).toBeTruthy();
     expect(backBand).toBeTruthy();
   });
 
-  it('positions back traverse by depth offset', () => {
+  it('positions back traverse by width offset', () => {
     const depth = 0.6;
     const offset = 80;
     const trWidth = 90;
@@ -252,10 +255,8 @@ describe('buildCabinetMesh', () => {
         Math.abs((c as any).geometry.parameters.depth - trWidth / 1000) < 1e-6,
     ) as THREE.Mesh | undefined;
     expect(traverse).toBeTruthy();
-    expect(traverse!.position.z).toBeCloseTo(
-      -depth + (offset + trWidth / 2) / 1000,
-      5,
-    );
+    expect(traverse!.position.x).toBeCloseTo(0.5 + offset / 1000, 5);
+    expect(traverse!.position.z).toBeCloseTo(-depth / 2, 5);
   });
 
   it('creates two traverses for topPanel.twoTraverses', () => {
@@ -286,14 +287,17 @@ describe('buildCabinetMesh', () => {
         Math.abs((c as any).geometry.parameters.depth - widthM) < 1e-6,
     ) as THREE.Mesh[];
     expect(traverses.length).toBe(2);
-    const frontExpected = -(20 + trWidth / 2) / 1000;
-    const backExpected = -depth + (30 + trWidth / 2) / 1000;
+    const frontExpected = 0.5 + 20 / 1000;
+    const backExpected = 0.5 + 30 / 1000;
     expect(
-      traverses.some((t) => Math.abs(t.position.z - frontExpected) < 1e-6),
+      traverses.some((t) => Math.abs(t.position.x - frontExpected) < 1e-6),
     ).toBe(true);
     expect(
-      traverses.some((t) => Math.abs(t.position.z - backExpected) < 1e-6),
+      traverses.some((t) => Math.abs(t.position.x - backExpected) < 1e-6),
     ).toBe(true);
+    traverses.forEach((t) =>
+      expect(t.position.z).toBeCloseTo(-depth / 2, 5),
+    );
   });
 
   it('omits bottom panel when bottomPanel is none', () => {


### PR DESCRIPTION
## Summary
- Interpret vertical traverses to offset along cabinet depth and horizontal traverses along width.
- Sync configurator sliders and ranges with new traverse axes.
- Update traverse tests for the new axis logic.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b49d43e3008322a2f325d1379f9f11