### PR TITLE
feat(i18n): translate edge banding and panel options

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -106,12 +106,18 @@
       "twoTraverses": "two traverses",
       "frontTraverse": "front traverse",
       "backTraverse": "back traverse",
-      "full": "full",
+      "full": "full panel",
       "none": "none"
     },
     "bottomOptions": {
-      "full": "full",
+      "full": "full panel",
       "none": "none"
+    },
+    "edgeBanding": "Edge banding",
+    "edgeBandingOptions": {
+      "none": "none",
+      "front": "front",
+      "full": "full"
     },
     "orientation": {
       "label": "Orientation",

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -106,12 +106,18 @@
       "twoTraverses": "dwa trawersy",
       "frontTraverse": "przedni trawers",
       "backTraverse": "tylny trawers",
-      "full": "pełny",
+      "full": "pełny panel",
       "none": "brak"
     },
     "bottomOptions": {
-      "full": "pełny",
+      "full": "pełny panel",
       "none": "brak"
+    },
+    "edgeBanding": "Okleina",
+    "edgeBandingOptions": {
+      "none": "brak",
+      "front": "front",
+      "full": "pełna"
     },
     "orientation": {
       "label": "Orientacja",

--- a/src/ui/CabinetConfigurator.tsx
+++ b/src/ui/CabinetConfigurator.tsx
@@ -582,7 +582,7 @@ const CabinetConfigurator: React.FC<Props> = ({
                 </select>
               </div>
               <div>
-                <div className="small">Edge banding</div>
+                <div className="small">{t('configurator.edgeBanding')}</div>
                 <select
                   className="input"
                   value={gLocal.edgeBanding || 'front'}
@@ -594,9 +594,15 @@ const CabinetConfigurator: React.FC<Props> = ({
                     })
                   }
                 >
-                  <option value="none">none</option>
-                  <option value="front">front</option>
-                  <option value="full">full</option>
+                  <option value="none">
+                    {t('configurator.edgeBandingOptions.none')}
+                  </option>
+                  <option value="front">
+                    {t('configurator.edgeBandingOptions.front')}
+                  </option>
+                  <option value="full">
+                    {t('configurator.edgeBandingOptions.full')}
+                  </option>
                 </select>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- refine top/bottom panel option labels and add edge banding translations
- replace hard-coded edge banding text with i18n keys

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4a1866f748322aa0fd78764c6626a