### PR TITLE
Fix top traverse depth and banding

### DIFF
--- a/src/scene/cabinetBuilder.ts
+++ b/src/scene/cabinetBuilder.ts
@@ -227,10 +227,18 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
   const addTraverseTop = (tr: Traverse, zBase: number, topWidth: number) => {
     const widthM = tr.width / 1000;
     if (tr.orientation === 'vertical') {
-      const geo = new THREE.BoxGeometry(widthM, T, D - 2 * T);
+      const geo = new THREE.BoxGeometry(topWidth, T, widthM);
       const mesh = new THREE.Mesh(geo, carcMat);
-      const frontEdge = -T - tr.offset / 1000;
-      const backEdge = -D + T - tr.offset / 1000;
+      const isFront = zBase === 0;
+      let frontEdge: number;
+      let backEdge: number;
+      if (isFront) {
+        frontEdge = -tr.offset / 1000;
+        backEdge = frontEdge - widthM;
+      } else {
+        backEdge = -zBase + tr.offset / 1000;
+        frontEdge = backEdge + widthM;
+      }
       const z = (frontEdge + backEdge) / 2;
       const x = W / 2;
       mesh.position.set(x, legHeight + H - T / 2, z);
@@ -239,24 +247,25 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
       if (edgeBanding !== 'none') {
         const zFront = frontEdge + bandThickness / 2;
         const zBack = backEdge - bandThickness / 2;
-        addBand(x, legHeight + H - T / 2, zFront, widthM, T, bandThickness);
-        addBand(x, legHeight + H - T / 2, zBack, widthM, T, bandThickness);
+        addBand(x, legHeight + H - T / 2, zFront, topWidth, T, bandThickness);
+        addBand(x, legHeight + H - T / 2, zBack, topWidth, T, bandThickness);
         if (edgeBanding === 'full') {
+          const topLeft = (W - topWidth) / 2;
           addBand(
-            x - widthM / 2 + bandThickness / 2,
+            topLeft + bandThickness / 2,
             legHeight + H - T / 2,
             z,
             bandThickness,
             T,
-            D - 2 * T,
+            widthM,
           );
           addBand(
-            x + widthM / 2 - bandThickness / 2,
+            W - topLeft - bandThickness / 2,
             legHeight + H - T / 2,
             z,
             bandThickness,
             T,
-            D - 2 * T,
+            widthM,
           );
         }
       }

--- a/tests/cabinetBuilder.test.ts
+++ b/tests/cabinetBuilder.test.ts
@@ -188,41 +188,40 @@ describe('buildCabinetMesh', () => {
     });
     const boardThickness = 0.018;
     const bandThickness = 0.002;
-    const expectedDepth = depth - 2 * boardThickness;
+    const expectedWidth = 1 - 2 * boardThickness;
     const widthM = trWidth / 1000;
     const traverse = g.children.find(
       (c) =>
         c instanceof THREE.Mesh &&
-        Math.abs((c as any).geometry.parameters.width - widthM) < 1e-6 &&
+        Math.abs((c as any).geometry.parameters.width - expectedWidth) < 1e-6 &&
         Math.abs((c as any).geometry.parameters.height - boardThickness) <
           1e-6 &&
-        Math.abs((c as any).geometry.parameters.depth - expectedDepth) < 1e-6,
+        Math.abs((c as any).geometry.parameters.depth - widthM) < 1e-6,
     ) as THREE.Mesh | undefined;
     expect(traverse).toBeTruthy();
     expect(traverse!.position.x).toBeCloseTo(0.5, 5);
-    expect(traverse!.position.z).toBeCloseTo(-depth / 2 - offset / 1000, 5);
+    const expectedZ = -(offset / 1000 + widthM / 2);
+    expect(traverse!.position.z).toBeCloseTo(expectedZ, 5);
     expect(traverse!.position.y).toBeCloseTo(0.9 - boardThickness / 2, 5);
 
     const frontBand = g.children.find(
       (c) =>
         c instanceof THREE.Mesh &&
-        Math.abs((c as any).geometry.parameters.width - widthM) < 1e-6 &&
+        Math.abs((c as any).geometry.parameters.width - expectedWidth) < 1e-6 &&
         Math.abs((c as any).geometry.parameters.height - boardThickness) <
           1e-6 &&
         Math.abs((c as any).geometry.parameters.depth - bandThickness) < 1e-6 &&
-        Math.abs(
-          c.position.z - (-boardThickness - offset / 1000 + bandThickness / 2),
-        ) < 1e-6,
+        Math.abs(c.position.z - (-offset / 1000 + bandThickness / 2)) < 1e-6,
     );
     const backBand = g.children.find(
       (c) =>
         c instanceof THREE.Mesh &&
-        Math.abs((c as any).geometry.parameters.width - widthM) < 1e-6 &&
+        Math.abs((c as any).geometry.parameters.width - expectedWidth) < 1e-6 &&
         Math.abs((c as any).geometry.parameters.height - boardThickness) <
           1e-6 &&
         Math.abs((c as any).geometry.parameters.depth - bandThickness) < 1e-6 &&
         Math.abs(
-          c.position.z - (-depth + boardThickness - offset / 1000 - bandThickness / 2),
+          c.position.z - (-offset / 1000 - widthM - bandThickness / 2),
         ) < 1e-6,
     );
     expect(frontBand).toBeTruthy();


### PR DESCRIPTION
## Summary
- adjust vertical top traverse to only span traverse width and position using zBase
- update edge banding placement for new traverse geometry
- extend tests to verify traverse z-position and front/back bands

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b4aa37b974832290129f3af5c6797b