### PR TITLE
Fix vertical traverse placement and tests

### DIFF
--- a/src/scene/cabinetBuilder.ts
+++ b/src/scene/cabinetBuilder.ts
@@ -227,28 +227,47 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
   const addTraverseTop = (tr: Traverse, zBase: number, topWidth: number) => {
     const widthM = tr.width / 1000;
     if (tr.orientation === 'vertical') {
-      const geo = new THREE.BoxGeometry(widthM, T, D);
+      const geo = new THREE.BoxGeometry(topWidth, widthM, T);
       const mesh = new THREE.Mesh(geo, carcMat);
-      const x = W / 2 + tr.offset / 1000;
-      const z = -D / 2;
-      mesh.position.set(x, legHeight + H - T / 2, z);
+      const isFront = zBase === 0;
+      let frontEdge: number;
+      let backEdge: number;
+      if (isFront) {
+        frontEdge = -tr.offset / 1000 + FRONT_OFFSET;
+        backEdge = frontEdge - T;
+      } else {
+        backEdge = -zBase + tr.offset / 1000;
+        frontEdge = backEdge + T;
+      }
+      const z = (frontEdge + backEdge) / 2;
+      const x = W / 2;
+      const y = legHeight + H - widthM / 2;
+      mesh.position.set(x, y, z);
       addEdges(mesh);
       group.add(mesh);
       if (edgeBanding !== 'none') {
-        addBand(x, legHeight + H - T / 2, bandThickness / 2, widthM, T, bandThickness);
-        addBand(
-          x,
-          legHeight + H - T / 2,
-          -D + bandThickness / 2,
-          widthM,
-          T,
-          bandThickness,
-        );
+        const zFront = frontEdge + bandThickness / 2;
+        const zBack = backEdge - bandThickness / 2;
+        addBand(x, y, zFront, topWidth, widthM, bandThickness);
+        addBand(x, y, zBack, topWidth, widthM, bandThickness);
         if (edgeBanding === 'full') {
-          const xLeft = x - widthM / 2 + bandThickness / 2;
-          const xRight = x + widthM / 2 - bandThickness / 2;
-          addBand(xLeft, legHeight + H - T / 2, -D / 2, bandThickness, T, D);
-          addBand(xRight, legHeight + H - T / 2, -D / 2, bandThickness, T, D);
+          const topLeft = (W - topWidth) / 2;
+          addBand(
+            topLeft + bandThickness / 2,
+            y,
+            z,
+            bandThickness,
+            widthM,
+            T,
+          );
+          addBand(
+            W - topLeft - bandThickness / 2,
+            y,
+            z,
+            bandThickness,
+            widthM,
+            T,
+          );
         }
       }
     } else {

--- a/tests/cabinetBuilder.test.ts
+++ b/tests/cabinetBuilder.test.ts
@@ -142,7 +142,7 @@ describe('buildCabinetMesh', () => {
     expect(size.z).toBeCloseTo(depth + boardThickness + FRONT_OFFSET, 5);
   });
 
-  it('positions vertical traverse by width offset', () => {
+  it('positions vertical traverse centered and by depth offset', () => {
     const offset = 100;
     const trWidth = 100;
     const depth = 0.5;
@@ -159,18 +159,52 @@ describe('buildCabinetMesh', () => {
       },
     });
     const boardThickness = 0.018;
+    const expectedWidth = 1 - 2 * boardThickness;
     const widthM = trWidth / 1000;
     const traverse = g.children.find(
       (c) =>
         c instanceof THREE.Mesh &&
-        Math.abs((c as any).geometry.parameters.width - widthM) < 1e-6 &&
-        Math.abs((c as any).geometry.parameters.height - boardThickness) <
-          1e-6 &&
-        Math.abs((c as any).geometry.parameters.depth - depth) < 1e-6,
+        Math.abs((c as any).geometry.parameters.width - expectedWidth) < 1e-6 &&
+        Math.abs((c as any).geometry.parameters.height - widthM) < 1e-6 &&
+        Math.abs((c as any).geometry.parameters.depth - boardThickness) < 1e-6,
     ) as THREE.Mesh | undefined;
     expect(traverse).toBeTruthy();
-    expect(traverse!.position.x).toBeCloseTo(0.5 + offset / 1000, 5);
-    expect(traverse!.position.z).toBeCloseTo(-depth / 2, 5);
+    expect(traverse!.position.x).toBeCloseTo(0.5, 5);
+    const expectedZ = FRONT_OFFSET - offset / 1000 - boardThickness / 2;
+    expect(traverse!.position.z).toBeCloseTo(expectedZ, 5);
+  });
+
+  it('aligns front vertical traverse with cabinet front', () => {
+    const trWidth = 100;
+    const depth = 0.5;
+    const g = buildCabinetMesh({
+      width: 1,
+      height: 0.9,
+      depth,
+      drawers: 0,
+      gaps: { top: 0, bottom: 0 },
+      family: FAMILY.BASE,
+      topPanel: {
+        type: 'frontTraverse',
+        traverse: { orientation: 'vertical', offset: 0, width: trWidth },
+      },
+    });
+    const boardThickness = 0.018;
+    const expectedWidth = 1 - 2 * boardThickness;
+    const widthM = trWidth / 1000;
+    const traverse = g.children.find(
+      (c) =>
+        c instanceof THREE.Mesh &&
+        Math.abs((c as any).geometry.parameters.width - expectedWidth) < 1e-6 &&
+        Math.abs((c as any).geometry.parameters.height - widthM) < 1e-6 &&
+        Math.abs((c as any).geometry.parameters.depth - boardThickness) < 1e-6,
+    ) as THREE.Mesh | undefined;
+    expect(traverse).toBeTruthy();
+    expect(traverse!.position.x).toBeCloseTo(0.5, 5);
+    expect(traverse!.position.z + boardThickness / 2).toBeCloseTo(
+      FRONT_OFFSET,
+      5,
+    );
   });
 
   it('positions horizontal traverse by depth offset', () => {


### PR DESCRIPTION
## Summary
- rotate vertical top traverses upright and adjust depth offsets and banding
- revise tests for upright vertical traverses and front alignment

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4bfa6e90c8322a987c005d5671ac2