### PR TITLE
Adjust vertical traverse orientation and tests

### DIFF
--- a/src/scene/cabinetBuilder.ts
+++ b/src/scene/cabinetBuilder.ts
@@ -227,45 +227,37 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
   const addTraverseTop = (tr: Traverse, zBase: number, topWidth: number) => {
     const widthM = tr.width / 1000;
     if (tr.orientation === 'vertical') {
-      const geo = new THREE.BoxGeometry(topWidth, T, widthM);
+      const geo = new THREE.BoxGeometry(topWidth, widthM, T);
       const mesh = new THREE.Mesh(geo, carcMat);
       const isFront = zBase === 0;
-      let frontEdge: number;
-      let backEdge: number;
-      if (isFront) {
-        frontEdge = -tr.offset / 1000 + FRONT_OFFSET;
-        backEdge = frontEdge - widthM;
-      } else {
-        backEdge = -zBase + tr.offset / 1000 + backT;
-        frontEdge = backEdge + widthM;
-      }
-      const z = (frontEdge + backEdge) / 2;
       const x = W / 2;
-      mesh.position.set(x, legHeight + H - T / 2, z);
+      const y = legHeight + H - widthM / 2 - tr.offset / 1000;
+      const z = isFront ? FRONT_OFFSET - T / 2 : -D + backT + T / 2;
+      mesh.position.set(x, y, z);
       addEdges(mesh);
       group.add(mesh);
       if (edgeBanding !== 'none') {
-        const zFront = frontEdge + bandThickness / 2;
-        const zBack = backEdge - bandThickness / 2;
-        addBand(x, legHeight + H - T / 2, zFront, topWidth, T, bandThickness);
-        addBand(x, legHeight + H - T / 2, zBack, topWidth, T, bandThickness);
+        const zFront = z + T / 2 - bandThickness / 2;
+        const zBack = z - T / 2 + bandThickness / 2;
+        addBand(x, y, zFront, topWidth, widthM, bandThickness);
+        addBand(x, y, zBack, topWidth, widthM, bandThickness);
         if (edgeBanding === 'full') {
           const topLeft = (W - topWidth) / 2;
           addBand(
             topLeft + bandThickness / 2,
-            legHeight + H - T / 2,
+            y,
             z,
             bandThickness,
-            T,
             widthM,
+            T,
           );
           addBand(
             W - topLeft - bandThickness / 2,
-            legHeight + H - T / 2,
+            y,
             z,
             bandThickness,
-            T,
             widthM,
+            T,
           );
         }
       }

--- a/tests/cabinetBuilder.test.ts
+++ b/tests/cabinetBuilder.test.ts
@@ -142,13 +142,14 @@ describe('buildCabinetMesh', () => {
     expect(size.z).toBeCloseTo(depth + boardThickness + FRONT_OFFSET, 5);
   });
 
-  it('positions vertical traverse centered and by depth offset', () => {
+  it('positions vertical traverse by y offset', () => {
     const offset = 100;
     const trWidth = 100;
     const depth = 0.5;
+    const height = 0.9;
     const g = buildCabinetMesh({
       width: 1,
-      height: 0.9,
+      height,
       depth,
       drawers: 0,
       gaps: { top: 0, bottom: 0 },
@@ -165,22 +166,26 @@ describe('buildCabinetMesh', () => {
       (c) =>
         c instanceof THREE.Mesh &&
         Math.abs((c as any).geometry.parameters.width - expectedWidth) < 1e-6 &&
-        Math.abs((c as any).geometry.parameters.height - boardThickness) <
-          1e-6 &&
-        Math.abs((c as any).geometry.parameters.depth - widthM) < 1e-6,
+        Math.abs((c as any).geometry.parameters.height - widthM) < 1e-6 &&
+        Math.abs((c as any).geometry.parameters.depth - boardThickness) < 1e-6,
     ) as THREE.Mesh | undefined;
     expect(traverse).toBeTruthy();
     expect(traverse!.position.x).toBeCloseTo(0.5, 5);
-    const expectedZ = FRONT_OFFSET - (offset / 1000 + widthM / 2);
-    expect(traverse!.position.z).toBeCloseTo(expectedZ, 5);
+    const expectedY = height - widthM / 2 - offset / 1000;
+    expect(traverse!.position.y).toBeCloseTo(expectedY, 5);
+    expect(traverse!.position.z).toBeCloseTo(
+      FRONT_OFFSET - boardThickness / 2,
+      5,
+    );
   });
 
   it('aligns front vertical traverse with cabinet front', () => {
     const trWidth = 100;
     const depth = 0.5;
+    const height = 0.9;
     const g = buildCabinetMesh({
       width: 1,
-      height: 0.9,
+      height,
       depth,
       drawers: 0,
       gaps: { top: 0, bottom: 0 },
@@ -197,21 +202,26 @@ describe('buildCabinetMesh', () => {
       (c) =>
         c instanceof THREE.Mesh &&
         Math.abs((c as any).geometry.parameters.width - expectedWidth) < 1e-6 &&
-        Math.abs((c as any).geometry.parameters.height - boardThickness) <
-          1e-6 &&
-        Math.abs((c as any).geometry.parameters.depth - widthM) < 1e-6,
+        Math.abs((c as any).geometry.parameters.height - widthM) < 1e-6 &&
+        Math.abs((c as any).geometry.parameters.depth - boardThickness) < 1e-6,
     ) as THREE.Mesh | undefined;
     expect(traverse).toBeTruthy();
     expect(traverse!.position.x).toBeCloseTo(0.5, 5);
-    expect(traverse!.position.z + widthM / 2).toBeCloseTo(FRONT_OFFSET, 5);
+    const expectedY = height - widthM / 2;
+    expect(traverse!.position.y).toBeCloseTo(expectedY, 5);
+    expect(traverse!.position.z).toBeCloseTo(
+      FRONT_OFFSET - boardThickness / 2,
+      5,
+    );
   });
 
   it('positions back vertical traverse taking back thickness into account', () => {
     const depth = 0.5;
     const trWidth = 100;
+    const height = 0.9;
     const g = buildCabinetMesh({
       width: 1,
-      height: 0.9,
+      height,
       depth,
       drawers: 0,
       gaps: { top: 0, bottom: 0 },
@@ -228,13 +238,15 @@ describe('buildCabinetMesh', () => {
       (c) =>
         c instanceof THREE.Mesh &&
         Math.abs((c as any).geometry.parameters.width - expectedWidth) < 1e-6 &&
-        Math.abs((c as any).geometry.parameters.height - boardThickness) < 1e-6 &&
-        Math.abs((c as any).geometry.parameters.depth - widthM) < 1e-6,
+        Math.abs((c as any).geometry.parameters.height - widthM) < 1e-6 &&
+        Math.abs((c as any).geometry.parameters.depth - boardThickness) < 1e-6,
     ) as THREE.Mesh | undefined;
     expect(traverse).toBeTruthy();
     const backThickness = 0.003;
-    expect(traverse!.position.z - widthM / 2).toBeCloseTo(
-      -depth + backThickness,
+    const expectedY = height - widthM / 2;
+    expect(traverse!.position.y).toBeCloseTo(expectedY, 5);
+    expect(traverse!.position.z).toBeCloseTo(
+      -depth + backThickness + boardThickness / 2,
       5,
     );
   });


### PR DESCRIPTION
## Summary
- allow vertical top-panel traverses to shift along Y and align to front/back with board thickness
- update edge banding calculations for new vertical traverse dimensions
- revise cabinet builder tests and add case for non-zero vertical traverse offset

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b56e6d4a20832288ad1ce367750ce5