### PR TITLE
Band vertical traverse on top and bottom edges

### DIFF
--- a/src/scene/cabinetBuilder.ts
+++ b/src/scene/cabinetBuilder.ts
@@ -237,10 +237,10 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
       addEdges(mesh);
       group.add(mesh);
       if (edgeBanding !== 'none') {
-        const zFront = z + T / 2 - bandThickness / 2;
-        const zBack = z - T / 2 + bandThickness / 2;
-        addBand(x, y, zFront, topWidth, widthM, bandThickness);
-        addBand(x, y, zBack, topWidth, widthM, bandThickness);
+        const yTop = y + widthM / 2 - bandThickness / 2;
+        const yBottom = y - widthM / 2 + bandThickness / 2;
+        addBand(x, yTop, z, topWidth, bandThickness, T);
+        addBand(x, yBottom, z, topWidth, bandThickness, T);
         if (edgeBanding === 'full') {
           const topLeft = (W - topWidth) / 2;
           addBand(

--- a/tests/cabinetBuilder.test.ts
+++ b/tests/cabinetBuilder.test.ts
@@ -251,6 +251,79 @@ describe('buildCabinetMesh', () => {
     );
   });
 
+  it('adds edge banding to vertical traverse on top and bottom', () => {
+    const trWidth = 100;
+    const g = buildCabinetMesh({
+      width: 1,
+      height: 0.9,
+      depth: 0.5,
+      drawers: 0,
+      gaps: { top: 0, bottom: 0 },
+      family: FAMILY.BASE,
+      edgeBanding: 'full',
+      topPanel: {
+        type: 'frontTraverse',
+        traverse: { orientation: 'vertical', offset: 0, width: trWidth },
+      },
+    });
+    const boardThickness = 0.018;
+    const bandThickness = 0.002;
+    const topWidth = 1 - 2 * boardThickness;
+    const widthM = trWidth / 1000;
+    const traverseY = 0.9 - widthM / 2;
+    const traverseZ = FRONT_OFFSET - boardThickness / 2;
+    const topBand = g.children.find(
+      (c) =>
+        c instanceof THREE.Mesh &&
+        Math.abs((c as any).geometry.parameters.width - topWidth) < 1e-6 &&
+        Math.abs((c as any).geometry.parameters.height - bandThickness) < 1e-6 &&
+        Math.abs((c as any).geometry.parameters.depth - boardThickness) < 1e-6 &&
+        Math.abs(c.position.x - 0.5) < 1e-6 &&
+        Math.abs(
+          c.position.y - (traverseY + widthM / 2 - bandThickness / 2),
+        ) < 1e-6 &&
+        Math.abs(c.position.z - traverseZ) < 1e-6,
+    );
+    const bottomBand = g.children.find(
+      (c) =>
+        c instanceof THREE.Mesh &&
+        Math.abs((c as any).geometry.parameters.width - topWidth) < 1e-6 &&
+        Math.abs((c as any).geometry.parameters.height - bandThickness) < 1e-6 &&
+        Math.abs((c as any).geometry.parameters.depth - boardThickness) < 1e-6 &&
+        Math.abs(c.position.x - 0.5) < 1e-6 &&
+        Math.abs(
+          c.position.y - (traverseY - widthM / 2 + bandThickness / 2),
+        ) < 1e-6 &&
+        Math.abs(c.position.z - traverseZ) < 1e-6,
+    );
+    const leftBand = g.children.find(
+      (c) =>
+        c instanceof THREE.Mesh &&
+        Math.abs((c as any).geometry.parameters.width - bandThickness) < 1e-6 &&
+        Math.abs((c as any).geometry.parameters.height - widthM) < 1e-6 &&
+        Math.abs((c as any).geometry.parameters.depth - boardThickness) < 1e-6 &&
+        Math.abs(c.position.x - (boardThickness + bandThickness / 2)) < 1e-6 &&
+        Math.abs(c.position.y - traverseY) < 1e-6 &&
+        Math.abs(c.position.z - traverseZ) < 1e-6,
+    );
+    const rightBand = g.children.find(
+      (c) =>
+        c instanceof THREE.Mesh &&
+        Math.abs((c as any).geometry.parameters.width - bandThickness) < 1e-6 &&
+        Math.abs((c as any).geometry.parameters.height - widthM) < 1e-6 &&
+        Math.abs((c as any).geometry.parameters.depth - boardThickness) < 1e-6 &&
+        Math.abs(
+          c.position.x - (1 - boardThickness - bandThickness / 2),
+        ) < 1e-6 &&
+        Math.abs(c.position.y - traverseY) < 1e-6 &&
+        Math.abs(c.position.z - traverseZ) < 1e-6,
+    );
+    expect(topBand).toBeTruthy();
+    expect(bottomBand).toBeTruthy();
+    expect(leftBand).toBeTruthy();
+    expect(rightBand).toBeTruthy();
+  });
+
   it('positions horizontal traverse by depth offset', () => {
     const offset = 100;
     const trWidth = 100;


### PR DESCRIPTION
## Summary
- Apply edge banding to the top and bottom faces of vertical traverses
- Expand unit tests to cover vertical traverse edge banding

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b567662d2c8322bc1ee9e3edabc79c