### PR TITLE
feat: add per-edge banding configuration

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -116,9 +116,10 @@
     },
     "edgeBanding": "Edge banding",
     "edgeBandingOptions": {
-      "none": "none",
       "front": "front",
-      "full": "full"
+      "back": "back",
+      "left": "left",
+      "right": "right"
     },
     "orientation": {
       "label": "Orientation",

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -116,9 +116,10 @@
     },
     "edgeBanding": "Okleina",
     "edgeBandingOptions": {
-      "none": "brak",
-      "front": "front",
-      "full": "pełna"
+      "front": "przód",
+      "back": "tył",
+      "left": "lewa",
+      "right": "prawa"
     },
     "orientation": {
       "label": "Orientacja",

--- a/src/scene/cabinetBuilder.ts
+++ b/src/scene/cabinetBuilder.ts
@@ -22,7 +22,12 @@ export interface CabinetOptions {
   hinge?: 'left' | 'right';
   dividerPosition?: 'left' | 'right' | 'center';
   showEdges?: boolean;
-  edgeBanding?: 'none' | 'front' | 'full';
+  edgeBanding?: {
+    front: boolean;
+    back: boolean;
+    left: boolean;
+    right: boolean;
+  };
   carcassType?: 'type1' | 'type2' | 'type3';
   showFronts?: boolean;
 }
@@ -51,7 +56,7 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
     backThickness: backT = 0.003,
     dividerPosition,
     showEdges = false,
-    edgeBanding = 'none',
+    edgeBanding = { front: false, back: false, left: false, right: false },
     carcassType = 'type1',
     showFronts = true,
   } = opts;
@@ -89,9 +94,11 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
     metalness: 0.3,
     roughness: 0.7,
   });
-  const bandThickness = edgeBanding === 'full' ? 0.002 : 0.001;
+  const isFull =
+    edgeBanding.front && edgeBanding.back && edgeBanding.left && edgeBanding.right;
+  const bandThickness = isFull ? 0.002 : 0.001;
   const bandMat = new THREE.MeshStandardMaterial({
-    color: edgeBanding === 'full' ? 0xffaa00 : 0xffdd99,
+    color: isFull ? 0xffaa00 : 0xffdd99,
     metalness: 0.2,
     roughness: 0.6,
   });
@@ -143,38 +150,76 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
   rightSide.position.set(W - T / 2, sideY, -D / 2);
   addEdges(rightSide);
   group.add(rightSide);
-  if (edgeBanding !== 'none') {
+  if (edgeBanding.front) {
     addBand(T / 2, sideY, bandThickness / 2, T, sideHeight, bandThickness);
     addBand(W - T / 2, sideY, bandThickness / 2, T, sideHeight, bandThickness);
-    if (edgeBanding === 'full') {
-      const sideBottomY = sideY - sideHeight / 2;
-      const sideTopY = sideY + sideHeight / 2;
-      addBand(
-        T / 2,
-        sideBottomY + bandThickness / 2,
-        -D / 2,
-        T,
-        bandThickness,
-        D,
-      );
-      addBand(T / 2, sideTopY - bandThickness / 2, -D / 2, T, bandThickness, D);
-      addBand(
-        W - T / 2,
-        sideBottomY + bandThickness / 2,
-        -D / 2,
-        T,
-        bandThickness,
-        D,
-      );
-      addBand(
-        W - T / 2,
-        sideTopY - bandThickness / 2,
-        -D / 2,
-        T,
-        bandThickness,
-        D,
-      );
-    }
+  }
+  if (edgeBanding.back) {
+    const sideBottomY = sideY - sideHeight / 2;
+    const sideTopY = sideY + sideHeight / 2;
+    addBand(
+      T / 2,
+      sideBottomY + bandThickness / 2,
+      -D / 2,
+      T,
+      bandThickness,
+      D,
+    );
+    addBand(T / 2, sideTopY - bandThickness / 2, -D / 2, T, bandThickness, D);
+    addBand(
+      W - T / 2,
+      sideBottomY + bandThickness / 2,
+      -D / 2,
+      T,
+      bandThickness,
+      D,
+    );
+    addBand(
+      W - T / 2,
+      sideTopY - bandThickness / 2,
+      -D / 2,
+      T,
+      bandThickness,
+      D,
+    );
+  }
+  if (edgeBanding.left) {
+    const sideBottomY = sideY - sideHeight / 2;
+    addBand(
+      T / 2,
+      sideBottomY + bandThickness / 2,
+      bandThickness / 2,
+      T,
+      bandThickness,
+      bandThickness,
+    );
+    addBand(
+      W - T / 2,
+      sideBottomY + bandThickness / 2,
+      bandThickness / 2,
+      T,
+      bandThickness,
+      bandThickness,
+    );
+  }
+  if (edgeBanding.right) {
+    const sideTopY = sideY + sideHeight / 2;
+    addBand(
+      T / 2,
+      sideTopY - bandThickness / 2,
+      bandThickness / 2,
+      T,
+      bandThickness,
+      bandThickness,
+    );
+    addBand(
+      W - T / 2,
+      sideTopY - bandThickness / 2,
+      bandThickness / 2,
+      T,
+      bandThickness,
+      bandThickness,
+    );
   }
 
   // Top and bottom
@@ -194,7 +239,7 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
     bottom.position.set(W / 2, legHeight + T / 2, -D / 2);
     addEdges(bottom);
     group.add(bottom);
-    if (edgeBanding !== 'none') {
+    if (edgeBanding.front) {
       addBand(
         W / 2,
         legHeight + T / 2,
@@ -203,8 +248,20 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
         T,
         bandThickness,
       );
-      if (edgeBanding === 'full') {
-        const bottomLeft = (W - bottomWidth) / 2;
+    }
+    if (edgeBanding.back) {
+      addBand(
+        W / 2,
+        legHeight + T / 2,
+        -D + bandThickness / 2,
+        bottomWidth,
+        T,
+        bandThickness,
+      );
+    }
+    if (edgeBanding.left || edgeBanding.right) {
+      const bottomLeft = (W - bottomWidth) / 2;
+      if (edgeBanding.left) {
         addBand(
           bottomLeft + bandThickness / 2,
           legHeight + T / 2,
@@ -213,6 +270,8 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
           T,
           D,
         );
+      }
+      if (edgeBanding.right) {
         addBand(
           W - bottomLeft - bandThickness / 2,
           legHeight + T / 2,
@@ -236,31 +295,36 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
       mesh.position.set(x, y, z);
       addEdges(mesh);
       group.add(mesh);
-      if (edgeBanding !== 'none') {
-        const halfHeight = widthM / 2;
-        const yTop = y + halfHeight - bandThickness / 2;
-        const yBottom = y - halfHeight + bandThickness / 2;
+      const halfHeight = widthM / 2;
+      const yTop = y + halfHeight - bandThickness / 2;
+      const yBottom = y - halfHeight + bandThickness / 2;
+      if (edgeBanding.front) {
         addBand(x, yTop, z, topWidth, bandThickness, T);
+      }
+      if (edgeBanding.back) {
         addBand(x, yBottom, z, topWidth, bandThickness, T);
-        if (edgeBanding === 'full') {
-          const topLeft = (W - topWidth) / 2;
-          addBand(
-            topLeft + bandThickness / 2,
-            y,
-            z,
-            bandThickness,
-            widthM,
-            T,
-          );
-          addBand(
-            W - topLeft - bandThickness / 2,
-            y,
-            z,
-            bandThickness,
-            widthM,
-            T,
-          );
-        }
+      }
+      if (edgeBanding.left) {
+        const topLeft = (W - topWidth) / 2;
+        addBand(
+          topLeft + bandThickness / 2,
+          y,
+          z,
+          bandThickness,
+          widthM,
+          T,
+        );
+      }
+      if (edgeBanding.right) {
+        const topLeft = (W - topWidth) / 2;
+        addBand(
+          W - topLeft - bandThickness / 2,
+          y,
+          z,
+          bandThickness,
+          widthM,
+          T,
+        );
       }
     } else {
       const geo = new THREE.BoxGeometry(topWidth, T, widthM);
@@ -280,30 +344,35 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
       mesh.position.set(x, legHeight + H - T / 2, z);
       addEdges(mesh);
       group.add(mesh);
-      if (edgeBanding !== 'none') {
-        const zFront = frontEdge + bandThickness / 2;
-        const zBack = backEdge - bandThickness / 2;
+      const zFront = frontEdge + bandThickness / 2;
+      const zBack = backEdge - bandThickness / 2;
+      if (edgeBanding.front) {
         addBand(x, legHeight + H - T / 2, zFront, topWidth, T, bandThickness);
+      }
+      if (edgeBanding.back) {
         addBand(x, legHeight + H - T / 2, zBack, topWidth, T, bandThickness);
-        if (edgeBanding === 'full') {
-          const topLeft = (W - topWidth) / 2;
-          addBand(
-            topLeft + bandThickness / 2,
-            legHeight + H - T / 2,
-            z,
-            bandThickness,
-            T,
-            widthM,
-          );
-          addBand(
-            W - topLeft - bandThickness / 2,
-            legHeight + H - T / 2,
-            z,
-            bandThickness,
-            T,
-            widthM,
-          );
-        }
+      }
+      if (edgeBanding.left) {
+        const topLeft = (W - topWidth) / 2;
+        addBand(
+          topLeft + bandThickness / 2,
+          legHeight + H - T / 2,
+          z,
+          bandThickness,
+          T,
+          widthM,
+        );
+      }
+      if (edgeBanding.right) {
+        const topLeft = (W - topWidth) / 2;
+        addBand(
+          W - topLeft - bandThickness / 2,
+          legHeight + H - T / 2,
+          z,
+          bandThickness,
+          T,
+          widthM,
+        );
       }
     }
   };
@@ -312,7 +381,7 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
     top.position.set(W / 2, legHeight + H - T / 2, -D / 2);
     addEdges(top);
     group.add(top);
-    if (edgeBanding !== 'none') {
+    if (edgeBanding.front) {
       addBand(
         W / 2,
         legHeight + H - T / 2,
@@ -321,8 +390,20 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
         T,
         bandThickness,
       );
-      if (edgeBanding === 'full') {
-        const topLeft = (W - topWidth) / 2;
+    }
+    if (edgeBanding.back) {
+      addBand(
+        W / 2,
+        legHeight + H - T / 2,
+        -D + bandThickness / 2,
+        topWidth,
+        T,
+        bandThickness,
+      );
+    }
+    if (edgeBanding.left || edgeBanding.right) {
+      const topLeft = (W - topWidth) / 2;
+      if (edgeBanding.left) {
         addBand(
           topLeft + bandThickness / 2,
           legHeight + H - T / 2,
@@ -331,6 +412,8 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
           T,
           D,
         );
+      }
+      if (edgeBanding.right) {
         addBand(
           W - topLeft - bandThickness / 2,
           legHeight + H - T / 2,
@@ -381,12 +464,17 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
       shelf.position.set(W / 2, y, -D / 2);
       addEdges(shelf);
       group.add(shelf);
-      if (edgeBanding !== 'none') {
+      if (edgeBanding.front) {
         addBand(W / 2, y, bandThickness / 2, W - 2 * T, T, bandThickness);
-        if (edgeBanding === 'full') {
-          addBand(T + bandThickness / 2, y, -D / 2, bandThickness, T, D);
-          addBand(W - T - bandThickness / 2, y, -D / 2, bandThickness, T, D);
-        }
+      }
+      if (edgeBanding.back) {
+        addBand(W / 2, y, -D + bandThickness / 2, W - 2 * T, T, bandThickness);
+      }
+      if (edgeBanding.left) {
+        addBand(T + bandThickness / 2, y, -D / 2, bandThickness, T, D);
+      }
+      if (edgeBanding.right) {
+        addBand(W - T - bandThickness / 2, y, -D / 2, bandThickness, T, D);
       }
     }
   }
@@ -400,19 +488,24 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
     divider.position.set(x, legHeight + H / 2, -D / 2);
     addEdges(divider);
     group.add(divider);
-    if (edgeBanding !== 'none') {
+    if (edgeBanding.front) {
       addBand(x, legHeight + H / 2, bandThickness / 2, T, H, bandThickness);
-      if (edgeBanding === 'full') {
-        addBand(x, legHeight + bandThickness / 2, -D / 2, T, bandThickness, D);
-        addBand(
-          x,
-          legHeight + H - bandThickness / 2,
-          -D / 2,
-          T,
-          bandThickness,
-          D,
-        );
-      }
+    }
+    if (edgeBanding.back) {
+      addBand(x, legHeight + H / 2, -D + bandThickness / 2, T, H, bandThickness);
+    }
+    if (edgeBanding.left) {
+      addBand(x, legHeight + bandThickness / 2, -D / 2, T, bandThickness, D);
+    }
+    if (edgeBanding.right) {
+      addBand(
+        x,
+        legHeight + H - bandThickness / 2,
+        -D / 2,
+        T,
+        bandThickness,
+        D,
+      );
     }
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -107,7 +107,12 @@ export interface ModuleAdv {
   topPanel?: TopPanel;
   bottomPanel?: BottomPanel;
   dividerPosition?: 'left' | 'right' | 'center';
-  edgeBanding?: 'none' | 'front' | 'full';
+  edgeBanding?: {
+    front: boolean;
+    back: boolean;
+    left: boolean;
+    right: boolean;
+  };
   carcassType?: 'type1' | 'type2' | 'type3';
 }
 

--- a/src/ui/CabinetConfigurator.tsx
+++ b/src/ui/CabinetConfigurator.tsx
@@ -572,27 +572,29 @@ const CabinetConfigurator: React.FC<Props> = ({
               </div>
               <div>
                 <div className="small">{t('configurator.edgeBanding')}</div>
-                <select
-                  className="input"
-                  value={gLocal.edgeBanding || 'front'}
-                  onChange={(e) =>
-                    setAdv({
-                      ...gLocal,
-                      edgeBanding: (e.target as HTMLSelectElement)
-                        .value as CabinetConfig['edgeBanding'],
-                    })
-                  }
-                >
-                  <option value="none">
-                    {t('configurator.edgeBandingOptions.none')}
-                  </option>
-                  <option value="front">
-                    {t('configurator.edgeBandingOptions.front')}
-                  </option>
-                  <option value="full">
-                    {t('configurator.edgeBandingOptions.full')}
-                  </option>
-                </select>
+                <div className="row" style={{ gap: 8 }}>
+                  {(['front', 'back', 'left', 'right'] as const).map((edge) => (
+                    <label
+                      key={edge}
+                      style={{ display: 'flex', alignItems: 'center', gap: 4 }}
+                    >
+                      <input
+                        type="checkbox"
+                        checked={gLocal.edgeBanding?.[edge] ?? false}
+                        onChange={(e) =>
+                          setAdv({
+                            ...gLocal,
+                            edgeBanding: {
+                              ...gLocal.edgeBanding,
+                              [edge]: (e.target as HTMLInputElement).checked,
+                            },
+                          })
+                        }
+                      />
+                      {t(`configurator.edgeBandingOptions.${edge}`)}
+                    </label>
+                  ))}
+                </div>
               </div>
             </div>
             {drawersCount === 0 && (
@@ -766,6 +768,7 @@ const CabinetConfigurator: React.FC<Props> = ({
               drawersCount={drawersCount}
               drawerFronts={gLocal.drawerFronts}
               dividerPosition={gLocal.dividerPosition}
+              edgeBanding={gLocal.edgeBanding}
               onChangeGaps={(gg: Gaps) => setAdv({ ...gLocal, gaps: gg })}
               onChangeDrawerFronts={(arr: number[]) =>
                 setAdv({ ...gLocal, drawerFronts: arr })

--- a/src/ui/components/Cabinet3D.tsx
+++ b/src/ui/components/Cabinet3D.tsx
@@ -19,7 +19,7 @@ export default function Cabinet3D({
   topPanel,
   bottomPanel,
   dividerPosition,
-  edgeBanding = 'front',
+  edgeBanding = { front: true, back: false, left: false, right: false },
   carcassType = 'type1',
   showFronts = true,
 }: {
@@ -36,7 +36,12 @@ export default function Cabinet3D({
   topPanel?: TopPanel;
   bottomPanel?: BottomPanel;
   dividerPosition?: 'left' | 'right' | 'center';
-  edgeBanding?: 'none' | 'front' | 'full';
+  edgeBanding?: {
+    front: boolean;
+    back: boolean;
+    left: boolean;
+    right: boolean;
+  };
   carcassType?: 'type1' | 'type2' | 'type3';
   showFronts?: boolean;
 }) {

--- a/src/ui/components/TechDrawing.tsx
+++ b/src/ui/components/TechDrawing.tsx
@@ -20,6 +20,12 @@ type Props = {
   dividerPosition?: 'left' | 'right' | 'center';
   onChangeGaps?: (g: Gaps) => void;
   onChangeDrawerFronts?: (arr: number[]) => void;
+  edgeBanding?: {
+    front: boolean;
+    back: boolean;
+    left: boolean;
+    right: boolean;
+  };
 };
 
 function parseThickness(boardType?: string) {
@@ -118,6 +124,7 @@ export default function TechDrawing({
   dividerPosition,
   onChangeGaps,
   onChangeDrawerFronts,
+  edgeBanding,
 }: Props) {
   const W = 360,
     H = 230;
@@ -242,6 +249,7 @@ export default function TechDrawing({
   const outerW = Math.round(widthMM);
   const innerClearW = Math.round(widthMM - (gaps.left + gaps.right));
   const outerH = Math.round(heightMM);
+  const eb = edgeBanding || { front: false, back: false, left: false, right: false };
 
   return (
     <div className="row" style={{ gap: 12, alignItems: 'flex-start' }}>
@@ -278,6 +286,32 @@ export default function TechDrawing({
           fill="url(#hatch)"
           stroke="#999"
         />
+        {eb.front && (
+          <>
+            <line x1={pad} y1={pad} x2={W - pad} y2={pad} stroke="#f00" strokeWidth={2} />
+            <line
+              x1={pad}
+              y1={H - pad}
+              x2={W - pad}
+              y2={H - pad}
+              stroke="#f00"
+              strokeWidth={2}
+            />
+          </>
+        )}
+        {eb.left && (
+          <line x1={pad} y1={pad} x2={pad} y2={H - pad} stroke="#f00" strokeWidth={2} />
+        )}
+        {eb.right && (
+          <line
+            x1={W - pad}
+            y1={pad}
+            x2={W - pad}
+            y2={H - pad}
+            stroke="#f00"
+            strokeWidth={2}
+          />
+        )}
         {/* front */}
         <rect
           x={front.x}
@@ -390,6 +424,19 @@ export default function TechDrawing({
         </defs>
         {/* puste tło */}
         <rect x={pad} y={pad} width={innerW} height={innerH} fill="#fff" />
+        {eb.back && (
+          <line x1={pad} y1={pad} x2={pad} y2={H - pad} stroke="#f00" strokeWidth={2} />
+        )}
+        {eb.front && (
+          <line
+            x1={W - pad}
+            y1={pad}
+            x2={W - pad}
+            y2={H - pad}
+            stroke="#f00"
+            strokeWidth={2}
+          />
+        )}
         {/* boki */}
         <rect
           x={pad}

--- a/src/ui/types.ts
+++ b/src/ui/types.ts
@@ -14,7 +14,12 @@ export interface CabinetConfig {
   bottomPanel?: BottomPanel;
   drawerFronts?: number[];
   dividerPosition?: 'left' | 'right' | 'center';
-  edgeBanding?: 'none' | 'front' | 'full';
+  edgeBanding?: {
+    front: boolean;
+    back: boolean;
+    left: boolean;
+    right: boolean;
+  };
   hardware?: any;
   legs?: any;
 }

--- a/src/ui/useCabinetConfig.ts
+++ b/src/ui/useCabinetConfig.ts
@@ -34,7 +34,7 @@ export function useCabinetConfig(
       backPanel: g.backPanel,
       topPanel: g.topPanel,
       bottomPanel: g.bottomPanel,
-      edgeBanding: 'front',
+      edgeBanding: { front: true, back: false, left: false, right: false },
       carcassType: g.carcassType,
     });
   }, [family, store.globals]);
@@ -235,7 +235,7 @@ export function useCabinetConfig(
             backPanel: g.backPanel,
             topPanel: g.topPanel,
             bottomPanel: g.bottomPanel,
-            edgeBanding: 'front',
+            edgeBanding: { front: true, back: false, left: false, right: false },
             carcassType: g.carcassType,
           },
           doorsCount: 1,
@@ -253,7 +253,11 @@ export function useCabinetConfig(
         rotationY: pl.rot,
         segIndex: selWall,
         price,
-        adv: { ...g, doorCount: 1, edgeBanding: 'front' } as ModuleAdv,
+        adv: {
+          ...g,
+          doorCount: 1,
+          edgeBanding: { front: true, back: false, left: false, right: false },
+        } as ModuleAdv,
       };
       mod = resolveCollisions(mod);
       store.addModule(mod);

--- a/tests/cabinetBuilder.test.ts
+++ b/tests/cabinetBuilder.test.ts
@@ -260,7 +260,7 @@ describe('buildCabinetMesh', () => {
       drawers: 0,
       gaps: { top: 0, bottom: 0 },
       family: FAMILY.BASE,
-      edgeBanding: 'full',
+      edgeBanding: { front: true, back: true, left: true, right: true },
       topPanel: {
         type: 'frontTraverse',
         traverse: { orientation: 'vertical', offset: 0, width: trWidth },
@@ -335,7 +335,7 @@ describe('buildCabinetMesh', () => {
       drawers: 0,
       gaps: { top: 0, bottom: 0 },
       family: FAMILY.BASE,
-      edgeBanding: 'full',
+      edgeBanding: { front: true, back: true, left: true, right: true },
       topPanel: {
         type: 'frontTraverse',
         traverse: { orientation: 'horizontal', offset, width: trWidth },
@@ -394,7 +394,7 @@ describe('buildCabinetMesh', () => {
       drawers: 0,
       gaps: { top: 0, bottom: 0 },
       family: FAMILY.BASE,
-      edgeBanding: 'none',
+      edgeBanding: { front: false, back: false, left: false, right: false },
       topPanel: {
         type: 'backTraverse',
         traverse: { orientation: 'horizontal', offset, width: trWidth },
@@ -425,7 +425,7 @@ describe('buildCabinetMesh', () => {
       drawers: 0,
       gaps: { top: 0, bottom: 0 },
       family: FAMILY.BASE,
-      edgeBanding: 'none',
+      edgeBanding: { front: false, back: false, left: false, right: false },
       topPanel: {
         type: 'twoTraverses',
         front: { orientation: 'horizontal', offset: 20, width: trWidth },
@@ -465,7 +465,7 @@ describe('buildCabinetMesh', () => {
       family: FAMILY.BASE,
       topPanel: { type: 'none' },
       bottomPanel: 'none',
-      edgeBanding: 'none',
+      edgeBanding: { front: false, back: false, left: false, right: false },
     });
     const boardThickness = 0.018;
     const bottomWidth = 1 - 2 * boardThickness;


### PR DESCRIPTION
## Summary
- allow configuring edge banding per cabinet edge
- show edge banding switches and labels in configurator
- render selected edge banding in 3D, tests and tech drawing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5841d93c083229992cea142587212