### PR TITLE
feat: add shelf edge banding and side panel options

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -113,6 +113,16 @@ export interface ModuleAdv {
     left: boolean;
     right: boolean;
   };
+  shelfEdgeBanding?: {
+    front: boolean;
+    back: boolean;
+    left: boolean;
+    right: boolean;
+  };
+  sidePanels?: {
+    left?: Record<string, any>;
+    right?: Record<string, any>;
+  };
   carcassType?: 'type1' | 'type2' | 'type3';
 }
 

--- a/src/ui/CabinetConfigurator.tsx
+++ b/src/ui/CabinetConfigurator.tsx
@@ -143,6 +143,8 @@ const CabinetConfigurator: React.FC<Props> = ({
               bottomPanel={gLocal.bottomPanel}
               dividerPosition={gLocal.dividerPosition}
               edgeBanding={gLocal.edgeBanding}
+              shelfEdgeBanding={gLocal.shelfEdgeBanding}
+              sidePanels={gLocal.sidePanels}
               carcassType={gLocal.carcassType}
               showFronts={showFronts}
             />
@@ -630,6 +632,28 @@ const CabinetConfigurator: React.FC<Props> = ({
                       })
                     }
                   />
+                  <div className="small">{t('configurator.edgeBanding')}</div>
+                  {(['front', 'back', 'left', 'right'] as const).map((edge) => (
+                    <label
+                      key={edge}
+                      style={{ display: 'flex', alignItems: 'center', gap: 4 }}
+                    >
+                      <input
+                        type="checkbox"
+                        checked={gLocal.shelfEdgeBanding?.[edge] ?? false}
+                        onChange={(e) =>
+                          setAdv({
+                            ...gLocal,
+                            shelfEdgeBanding: {
+                              ...gLocal.shelfEdgeBanding,
+                              [edge]: (e.target as HTMLInputElement).checked,
+                            },
+                          })
+                        }
+                      />
+                      {t(`configurator.edgeBandingOptions.${edge}`)}
+                    </label>
+                  ))}
                 </div>
               )}
             </div>
@@ -699,6 +723,24 @@ const CabinetConfigurator: React.FC<Props> = ({
                 />
                 {t('configurator.edgeBandingOptions.right')}
               </label>
+              <div className="small" style={{ marginTop: 8 }}>Panel boczny</div>
+              <label style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+                <input
+                  type="checkbox"
+                  checked={!!gLocal.sidePanels?.right}
+                  onChange={(e) => {
+                    const checked = (e.target as HTMLInputElement).checked;
+                    setAdv({
+                      ...gLocal,
+                      sidePanels: {
+                        ...gLocal.sidePanels,
+                        right: checked ? { ...(gLocal.sidePanels?.right || {}) } : undefined,
+                      },
+                    });
+                  }}
+                />
+                Panel
+              </label>
             </div>
           </details>
 
@@ -728,6 +770,24 @@ const CabinetConfigurator: React.FC<Props> = ({
                   }
                 />
                 {t('configurator.edgeBandingOptions.left')}
+              </label>
+              <div className="small" style={{ marginTop: 8 }}>Panel boczny</div>
+              <label style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+                <input
+                  type="checkbox"
+                  checked={!!gLocal.sidePanels?.left}
+                  onChange={(e) => {
+                    const checked = (e.target as HTMLInputElement).checked;
+                    setAdv({
+                      ...gLocal,
+                      sidePanels: {
+                        ...gLocal.sidePanels,
+                        left: checked ? { ...(gLocal.sidePanels?.left || {}) } : undefined,
+                      },
+                    });
+                  }}
+                />
+                Panel
               </label>
             </div>
           </details>

--- a/src/ui/components/Cabinet3D.tsx
+++ b/src/ui/components/Cabinet3D.tsx
@@ -20,6 +20,8 @@ export default function Cabinet3D({
   bottomPanel,
   dividerPosition,
   edgeBanding = { front: true, back: false, left: false, right: false },
+  shelfEdgeBanding = { front: false, back: false, left: false, right: false },
+  sidePanels,
   carcassType = 'type1',
   showFronts = true,
 }: {
@@ -41,6 +43,16 @@ export default function Cabinet3D({
     back: boolean;
     left: boolean;
     right: boolean;
+  };
+  shelfEdgeBanding?: {
+    front: boolean;
+    back: boolean;
+    left: boolean;
+    right: boolean;
+  };
+  sidePanels?: {
+    left?: Record<string, any>;
+    right?: Record<string, any>;
   };
   carcassType?: 'type1' | 'type2' | 'type3';
   showFronts?: boolean;

--- a/src/ui/types.ts
+++ b/src/ui/types.ts
@@ -20,6 +20,16 @@ export interface CabinetConfig {
     left: boolean;
     right: boolean;
   };
+  shelfEdgeBanding?: {
+    front: boolean;
+    back: boolean;
+    left: boolean;
+    right: boolean;
+  };
+  sidePanels?: {
+    left?: Record<string, any>;
+    right?: Record<string, any>;
+  };
   hardware?: any;
   legs?: any;
 }

--- a/src/ui/useCabinetConfig.ts
+++ b/src/ui/useCabinetConfig.ts
@@ -35,6 +35,13 @@ export function useCabinetConfig(
       topPanel: g.topPanel,
       bottomPanel: g.bottomPanel,
       edgeBanding: { front: true, back: false, left: false, right: false },
+      shelfEdgeBanding: {
+        front: false,
+        back: false,
+        left: false,
+        right: false,
+      },
+      sidePanels: {},
       carcassType: g.carcassType,
     });
   }, [family, store.globals]);
@@ -236,6 +243,13 @@ export function useCabinetConfig(
             topPanel: g.topPanel,
             bottomPanel: g.bottomPanel,
             edgeBanding: { front: true, back: false, left: false, right: false },
+            shelfEdgeBanding: {
+              front: false,
+              back: false,
+              left: false,
+              right: false,
+            },
+            sidePanels: {},
             carcassType: g.carcassType,
           },
           doorsCount: 1,
@@ -257,6 +271,13 @@ export function useCabinetConfig(
           ...g,
           doorCount: 1,
           edgeBanding: { front: true, back: false, left: false, right: false },
+          shelfEdgeBanding: {
+            front: false,
+            back: false,
+            left: false,
+            right: false,
+          },
+          sidePanels: {},
         } as ModuleAdv,
       };
       mod = resolveCollisions(mod);


### PR DESCRIPTION
## Summary
- support shelf edge banding and side panel config fields
- wire new fields into cabinet configurator and defaults
- extend Cabinet3D props for future visualisation

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b58cac71308322bc8a5363412ae2c0