### PR TITLE
feat: render shelf edge banding and side panels

### DIFF
--- a/src/scene/cabinetBuilder.ts
+++ b/src/scene/cabinetBuilder.ts
@@ -28,6 +28,16 @@ export interface CabinetOptions {
     left: boolean;
     right: boolean;
   };
+  shelfEdgeBanding?: {
+    front: boolean;
+    back: boolean;
+    left: boolean;
+    right: boolean;
+  };
+  sidePanels?: {
+    left?: Record<string, any>;
+    right?: Record<string, any>;
+  };
   carcassType?: 'type1' | 'type2' | 'type3';
   showFronts?: boolean;
 }
@@ -57,6 +67,8 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
     dividerPosition,
     showEdges = false,
     edgeBanding = { front: false, back: false, left: false, right: false },
+    shelfEdgeBanding = { front: false, back: false, left: false, right: false },
+    sidePanels = {},
     carcassType = 'type1',
     showFronts = true,
   } = opts;
@@ -220,6 +232,45 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
       bandThickness,
       bandThickness,
     );
+  }
+
+  if (sidePanels.left) {
+    const panel = new THREE.Mesh(sideGeo.clone(), carcMat);
+    panel.position.set(-T / 2, sideY, -D / 2);
+    addEdges(panel);
+    group.add(panel);
+    if (edgeBanding.front) {
+      addBand(-T / 2, sideY, bandThickness / 2, T, sideHeight, bandThickness);
+    }
+    if (edgeBanding.back) {
+      const sideBottomY = sideY - sideHeight / 2;
+      const sideTopY = sideY + sideHeight / 2;
+      addBand(-T / 2, sideBottomY + bandThickness / 2, -D / 2, T, bandThickness, D);
+      addBand(-T / 2, sideTopY - bandThickness / 2, -D / 2, T, bandThickness, D);
+    }
+    if (edgeBanding.left) {
+      const sideBottomY = sideY - sideHeight / 2;
+      addBand(-T / 2, sideBottomY + bandThickness / 2, bandThickness / 2, T, bandThickness, bandThickness);
+    }
+  }
+  if (sidePanels.right) {
+    const panel = new THREE.Mesh(sideGeo.clone(), carcMat);
+    panel.position.set(W + T / 2, sideY, -D / 2);
+    addEdges(panel);
+    group.add(panel);
+    if (edgeBanding.front) {
+      addBand(W + T / 2, sideY, bandThickness / 2, T, sideHeight, bandThickness);
+    }
+    if (edgeBanding.back) {
+      const sideBottomY = sideY - sideHeight / 2;
+      const sideTopY = sideY + sideHeight / 2;
+      addBand(W + T / 2, sideBottomY + bandThickness / 2, -D / 2, T, bandThickness, D);
+      addBand(W + T / 2, sideTopY - bandThickness / 2, -D / 2, T, bandThickness, D);
+    }
+    if (edgeBanding.right) {
+      const sideTopY = sideY + sideHeight / 2;
+      addBand(W + T / 2, sideTopY - bandThickness / 2, bandThickness / 2, T, bandThickness, bandThickness);
+    }
   }
 
   // Top and bottom
@@ -464,16 +515,16 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
       shelf.position.set(W / 2, y, -D / 2);
       addEdges(shelf);
       group.add(shelf);
-      if (edgeBanding.front) {
+      if (shelfEdgeBanding.front) {
         addBand(W / 2, y, bandThickness / 2, W - 2 * T, T, bandThickness);
       }
-      if (edgeBanding.back) {
+      if (shelfEdgeBanding.back) {
         addBand(W / 2, y, -D + bandThickness / 2, W - 2 * T, T, bandThickness);
       }
-      if (edgeBanding.left) {
+      if (shelfEdgeBanding.left) {
         addBand(T + bandThickness / 2, y, -D / 2, bandThickness, T, D);
       }
-      if (edgeBanding.right) {
+      if (shelfEdgeBanding.right) {
         addBand(W - T - bandThickness / 2, y, -D / 2, bandThickness, T, D);
       }
     }

--- a/src/ui/components/Cabinet3D.tsx
+++ b/src/ui/components/Cabinet3D.tsx
@@ -122,6 +122,8 @@ export default function Cabinet3D({
       dividerPosition: drawersCount > 0 ? undefined : dividerPosition,
       showEdges,
       edgeBanding,
+      shelfEdgeBanding,
+      sidePanels,
       carcassType,
       showFronts,
     });
@@ -158,6 +160,8 @@ export default function Cabinet3D({
     dividerPosition,
     showEdges,
     edgeBanding,
+    shelfEdgeBanding,
+    sidePanels,
     carcassType,
     showFronts,
   ]);

--- a/src/ui/types.ts
+++ b/src/ui/types.ts
@@ -27,8 +27,8 @@ export interface CabinetConfig {
     right: boolean;
   };
   sidePanels?: {
-    left?: Record<string, any>;
-    right?: Record<string, any>;
+    left?: Record<string, unknown>;
+    right?: Record<string, unknown>;
   };
   hardware?: any;
   legs?: any;


### PR DESCRIPTION
## Summary
- refine side panel typing in CabinetConfig
- forward shelf edge banding and side panel options to cabinet renderer
- extend cabinet builder to render shelf edge banding and side panel boards

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b58e4e33988322bdef6cf4c5c779a0