### PR TITLE
feat: localize cabinet section options

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -76,7 +76,13 @@
       "fronty": "Fronts",
       "okucie": "Hardware",
       "nozki": "Legs",
-      "rysunki": "Technical drawings"
+      "rysunki": "Technical drawings",
+      "topFrame": "Top",
+      "bottomFrame": "Bottom",
+      "shelves": "Shelves",
+      "back": "Back",
+      "rightSide": "Right side",
+      "leftSide": "Left side"
     },
     "width": "Width (mm)",
     "insertCabinet": "Insert cabinet",
@@ -121,6 +127,11 @@
       "left": "left",
       "right": "right"
     },
+    "shelfEdgeBanding": "Shelf edge banding",
+    "rightSideEdgeBanding": "Right side - edge banding",
+    "leftSideEdgeBanding": "Left side - edge banding",
+    "sidePanel": "Side panel",
+    "panel": "Panel",
     "orientation": {
       "label": "Orientation",
       "horizontal": "horizontal",

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -76,7 +76,13 @@
       "fronty": "Fronty",
       "okucie": "Okucie",
       "nozki": "Nóżki",
-      "rysunki": "Rysunki techniczne"
+      "rysunki": "Rysunki techniczne",
+      "topFrame": "Góra",
+      "bottomFrame": "Dół",
+      "shelves": "Półki",
+      "back": "Plecy",
+      "rightSide": "Bok prawy",
+      "leftSide": "Bok lewy"
     },
     "width": "Szerokość (mm)",
     "insertCabinet": "Wstaw szafkę",
@@ -121,6 +127,11 @@
       "left": "lewa",
       "right": "prawa"
     },
+    "shelfEdgeBanding": "Okleina półek",
+    "rightSideEdgeBanding": "Bok prawy – okleina",
+    "leftSideEdgeBanding": "Bok lewy – okleina",
+    "sidePanel": "Panel boczny",
+    "panel": "Panel",
     "orientation": {
       "label": "Orientacja",
       "horizontal": "pozioma",

--- a/src/ui/CabinetConfigurator.tsx
+++ b/src/ui/CabinetConfigurator.tsx
@@ -306,7 +306,7 @@ const CabinetConfigurator: React.FC<Props> = ({
                 setOpenTopFrame((v) => !v);
               }}
             >
-              {t('configurator.top')}
+              {t('configurator.sections.topFrame')}
             </summary>
             <div>
               <div>
@@ -580,7 +580,7 @@ const CabinetConfigurator: React.FC<Props> = ({
                 setOpenBottomFrame((v) => !v);
               }}
             >
-              {t('configurator.bottom')}
+              {t('configurator.sections.bottomFrame')}
             </summary>
             <div>
               <div>
@@ -613,7 +613,7 @@ const CabinetConfigurator: React.FC<Props> = ({
                 setOpenShelves((v) => !v);
               }}
             >
-              {t('configurator.shelves')}
+              {t('configurator.sections.shelves')}
             </summary>
             <div>
               {drawersCount === 0 && (
@@ -632,7 +632,7 @@ const CabinetConfigurator: React.FC<Props> = ({
                       })
                     }
                   />
-                  <div className="small">{t('configurator.edgeBanding')}</div>
+                  <div className="small">{t('configurator.shelfEdgeBanding')}</div>
                   {(['front', 'back', 'left', 'right'] as const).map((edge) => (
                     <label
                       key={edge}
@@ -666,7 +666,7 @@ const CabinetConfigurator: React.FC<Props> = ({
                 setOpenBack((v) => !v);
               }}
             >
-              {t('configurator.back')}
+              {t('configurator.sections.back')}
             </summary>
             <div>
               <div>
@@ -703,10 +703,10 @@ const CabinetConfigurator: React.FC<Props> = ({
                 setOpenRightSide((v) => !v);
               }}
             >
-              Bok prawy
+              {t('configurator.sections.rightSide')}
             </summary>
             <div>
-              <div className="small">{t('configurator.edgeBanding')}</div>
+              <div className="small">{t('configurator.rightSideEdgeBanding')}</div>
               <label style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
                 <input
                   type="checkbox"
@@ -723,7 +723,7 @@ const CabinetConfigurator: React.FC<Props> = ({
                 />
                 {t('configurator.edgeBandingOptions.right')}
               </label>
-              <div className="small" style={{ marginTop: 8 }}>Panel boczny</div>
+              <div className="small" style={{ marginTop: 8 }}>{t('configurator.sidePanel')}</div>
               <label style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
                 <input
                   type="checkbox"
@@ -739,7 +739,7 @@ const CabinetConfigurator: React.FC<Props> = ({
                     });
                   }}
                 />
-                Panel
+                {t('configurator.panel')}
               </label>
             </div>
           </details>
@@ -751,10 +751,10 @@ const CabinetConfigurator: React.FC<Props> = ({
                 setOpenLeftSide((v) => !v);
               }}
             >
-              Bok lewy
+              {t('configurator.sections.leftSide')}
             </summary>
             <div>
-              <div className="small">{t('configurator.edgeBanding')}</div>
+              <div className="small">{t('configurator.leftSideEdgeBanding')}</div>
               <label style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
                 <input
                   type="checkbox"
@@ -771,7 +771,7 @@ const CabinetConfigurator: React.FC<Props> = ({
                 />
                 {t('configurator.edgeBandingOptions.left')}
               </label>
-              <div className="small" style={{ marginTop: 8 }}>Panel boczny</div>
+              <div className="small" style={{ marginTop: 8 }}>{t('configurator.sidePanel')}</div>
               <label style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
                 <input
                   type="checkbox"
@@ -787,7 +787,7 @@ const CabinetConfigurator: React.FC<Props> = ({
                     });
                   }}
                 />
-                Panel
+                {t('configurator.panel')}
               </label>
             </div>
           </details>


### PR DESCRIPTION
## Summary
- add section and option translation keys for shelves, back, frames and sides
- use translations for cabinet configurator labels instead of hard-coded strings

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b58fde39e883229f93be242b94d184