### PR TITLE
Add selectable edge banding for back panels

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -131,6 +131,7 @@
     },
     "shelfEdgeBanding": "Shelf edge banding",
     "traverseEdgeBanding": "Traverse edge banding",
+    "backEdgeBanding": "Back panel - edge banding",
     "rightSideEdgeBanding": "Right side - edge banding",
     "leftSideEdgeBanding": "Left side - edge banding",
     "sidePanel": "Side panel",

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -131,6 +131,7 @@
     },
     "shelfEdgeBanding": "Okleina półek",
     "traverseEdgeBanding": "Okleina trawersów",
+    "backEdgeBanding": "Plecy – okleina",
     "rightSideEdgeBanding": "Bok prawy – okleina",
     "leftSideEdgeBanding": "Bok lewy – okleina",
     "sidePanel": "Panel boczny",

--- a/src/scene/cabinetBuilder.ts
+++ b/src/scene/cabinetBuilder.ts
@@ -44,6 +44,12 @@ export interface CabinetOptions {
     left: boolean;
     right: boolean;
   };
+  backEdgeBanding?: {
+    front: boolean;
+    back: boolean;
+    left: boolean;
+    right: boolean;
+  };
   sidePanels?: {
     left?: Record<string, any>;
     right?: Record<string, any>;
@@ -97,6 +103,12 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
       right: false,
       top: false,
       bottom: false,
+    },
+    backEdgeBanding = {
+      front: false,
+      back: false,
+      left: false,
+      right: false,
     },
     sidePanels = {},
     carcassType = 'type1',
@@ -572,6 +584,76 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
     topBack.position.set(W / 2, legHeight + H - halfH / 2, -D + backT / 2);
     addEdges(topBack);
     group.add(topBack);
+  }
+
+  if (backPanel !== 'none' && backT >= 0.018) {
+    const z = -D + backT / 2;
+    if (backPanel === 'full') {
+      if (backEdgeBanding.front) {
+        addBand(W / 2, legHeight + H - bandThickness / 2, z, W, bandThickness, backT);
+      }
+      if (backEdgeBanding.back) {
+        addBand(W / 2, legHeight + bandThickness / 2, z, W, bandThickness, backT);
+      }
+      if (backEdgeBanding.left) {
+        addBand(bandThickness / 2, legHeight + H / 2, z, bandThickness, H, backT);
+      }
+      if (backEdgeBanding.right) {
+        addBand(
+          W - bandThickness / 2,
+          legHeight + H / 2,
+          z,
+          bandThickness,
+          H,
+          backT,
+        );
+      }
+    } else if (backPanel === 'split') {
+      const gap = 0.002;
+      const halfH = (H - gap) / 2;
+      if (backEdgeBanding.front) {
+        addBand(W / 2, legHeight + H - bandThickness / 2, z, W, bandThickness, backT);
+      }
+      if (backEdgeBanding.back) {
+        addBand(W / 2, legHeight + bandThickness / 2, z, W, bandThickness, backT);
+      }
+      if (backEdgeBanding.left) {
+        addBand(
+          bandThickness / 2,
+          legHeight + halfH / 2,
+          z,
+          bandThickness,
+          halfH,
+          backT,
+        );
+        addBand(
+          bandThickness / 2,
+          legHeight + H - halfH / 2,
+          z,
+          bandThickness,
+          halfH,
+          backT,
+        );
+      }
+      if (backEdgeBanding.right) {
+        addBand(
+          W - bandThickness / 2,
+          legHeight + halfH / 2,
+          z,
+          bandThickness,
+          halfH,
+          backT,
+        );
+        addBand(
+          W - bandThickness / 2,
+          legHeight + H - halfH / 2,
+          z,
+          bandThickness,
+          halfH,
+          backT,
+        );
+      }
+    }
   }
 
   // Shelves when there are no drawers

--- a/src/types.ts
+++ b/src/types.ts
@@ -129,6 +129,12 @@ export interface ModuleAdv {
     left: boolean;
     right: boolean;
   };
+  backEdgeBanding?: {
+    front: boolean;
+    back: boolean;
+    left: boolean;
+    right: boolean;
+  };
   sidePanels?: {
     left?: Record<string, any>;
     right?: Record<string, any>;

--- a/src/ui/CabinetConfigurator.tsx
+++ b/src/ui/CabinetConfigurator.tsx
@@ -145,6 +145,7 @@ const CabinetConfigurator: React.FC<Props> = ({
               edgeBanding={gLocal.edgeBanding}
               traverseEdgeBanding={gLocal.traverseEdgeBanding}
               shelfEdgeBanding={gLocal.shelfEdgeBanding}
+              backEdgeBanding={gLocal.backEdgeBanding}
               sidePanels={gLocal.sidePanels}
               carcassType={gLocal.carcassType}
               showFronts={showFronts}
@@ -720,6 +721,30 @@ const CabinetConfigurator: React.FC<Props> = ({
                   </option>
                 </select>
               </div>
+              <div className="small" style={{ marginTop: 8 }}>
+                {t('configurator.backEdgeBanding')}
+              </div>
+              {(['front', 'back', 'left', 'right'] as const).map((edge) => (
+                <label
+                  key={edge}
+                  style={{ display: 'flex', alignItems: 'center', gap: 4 }}
+                >
+                  <input
+                    type="checkbox"
+                    checked={gLocal.backEdgeBanding?.[edge] ?? false}
+                    onChange={(e) =>
+                      setAdv({
+                        ...gLocal,
+                        backEdgeBanding: {
+                          ...gLocal.backEdgeBanding,
+                          [edge]: (e.target as HTMLInputElement).checked,
+                        },
+                      })
+                    }
+                  />
+                  {t(`configurator.edgeBandingOptions.${edge}`)}
+                </label>
+              ))}
             </div>
           </details>
 

--- a/src/ui/components/Cabinet3D.tsx
+++ b/src/ui/components/Cabinet3D.tsx
@@ -41,6 +41,12 @@ export default function Cabinet3D({
     top: false,
     bottom: false,
   },
+  backEdgeBanding = {
+    front: false,
+    back: false,
+    left: false,
+    right: false,
+  },
   sidePanels,
   carcassType = 'type1',
   showFronts = true,
@@ -79,6 +85,12 @@ export default function Cabinet3D({
     right: boolean;
     top: boolean;
     bottom: boolean;
+  };
+  backEdgeBanding?: {
+    front: boolean;
+    back: boolean;
+    left: boolean;
+    right: boolean;
   };
   sidePanels?: {
     left?: Record<string, any>;
@@ -154,6 +166,7 @@ export default function Cabinet3D({
       edgeBanding,
       traverseEdgeBanding,
       shelfEdgeBanding,
+      backEdgeBanding,
       sidePanels,
       carcassType,
       showFronts,
@@ -193,6 +206,7 @@ export default function Cabinet3D({
     edgeBanding,
     traverseEdgeBanding,
     shelfEdgeBanding,
+    backEdgeBanding,
     sidePanels,
     carcassType,
     showFronts,

--- a/src/ui/types.ts
+++ b/src/ui/types.ts
@@ -36,6 +36,12 @@ export interface CabinetConfig {
     left: boolean;
     right: boolean;
   };
+  backEdgeBanding?: {
+    front: boolean;
+    back: boolean;
+    left: boolean;
+    right: boolean;
+  };
   sidePanels?: {
     left?: Record<string, unknown>;
     right?: Record<string, unknown>;

--- a/src/ui/useCabinetConfig.ts
+++ b/src/ui/useCabinetConfig.ts
@@ -56,6 +56,12 @@ export function useCabinetConfig(
         left: false,
         right: false,
       },
+      backEdgeBanding: {
+        front: false,
+        back: false,
+        left: false,
+        right: false,
+      },
       sidePanels: {},
       carcassType: g.carcassType,
     });
@@ -168,6 +174,7 @@ export function useCabinetConfig(
           bottomPanel: g.bottomPanel,
           edgeBanding: g.edgeBanding,
           traverseEdgeBanding: g.traverseEdgeBanding,
+          backEdgeBanding: g.backEdgeBanding,
           carcassType: g.carcassType,
         },
         doorsCount,

--- a/tests/cabinetBuilder.test.ts
+++ b/tests/cabinetBuilder.test.ts
@@ -364,6 +364,80 @@ describe('buildCabinetMesh', () => {
     expect(topBands.length).toBe(2);
   });
 
+  it('adds back panel edge banding on all edges', () => {
+    const backT = 0.018;
+    const g = buildCabinetMesh({
+      width: 1,
+      height: 0.9,
+      depth: 0.5,
+      drawers: 0,
+      gaps: { top: 0, bottom: 0 },
+      family: FAMILY.BASE,
+      shelves: 0,
+      backThickness: backT,
+      backEdgeBanding: {
+        front: true,
+        back: true,
+        left: true,
+        right: true,
+      },
+      edgeBanding: {
+        front: false,
+        back: false,
+        left: false,
+        right: false,
+        top: false,
+        bottom: false,
+      },
+    });
+    const bandThickness = 0.001;
+    const z = -0.5 + backT / 2;
+    const topBand = g.children.find(
+      (c) =>
+        c instanceof THREE.Mesh &&
+        Math.abs((c as any).geometry.parameters.width - 1) < 1e-6 &&
+        Math.abs((c as any).geometry.parameters.height - bandThickness) < 1e-6 &&
+        Math.abs((c as any).geometry.parameters.depth - backT) < 1e-6 &&
+        Math.abs(c.position.x - 0.5) < 1e-6 &&
+        Math.abs(c.position.y - (0.9 - bandThickness / 2)) < 1e-6 &&
+        Math.abs(c.position.z - z) < 1e-6,
+    );
+    const bottomBand = g.children.find(
+      (c) =>
+        c instanceof THREE.Mesh &&
+        Math.abs((c as any).geometry.parameters.width - 1) < 1e-6 &&
+        Math.abs((c as any).geometry.parameters.height - bandThickness) < 1e-6 &&
+        Math.abs((c as any).geometry.parameters.depth - backT) < 1e-6 &&
+        Math.abs(c.position.x - 0.5) < 1e-6 &&
+        Math.abs(c.position.y - bandThickness / 2) < 1e-6 &&
+        Math.abs(c.position.z - z) < 1e-6,
+    );
+    const leftBand = g.children.find(
+      (c) =>
+        c instanceof THREE.Mesh &&
+        Math.abs((c as any).geometry.parameters.width - bandThickness) < 1e-6 &&
+        Math.abs((c as any).geometry.parameters.height - 0.9) < 1e-6 &&
+        Math.abs((c as any).geometry.parameters.depth - backT) < 1e-6 &&
+        Math.abs(c.position.x - bandThickness / 2) < 1e-6 &&
+        Math.abs(c.position.y - 0.45) < 1e-6 &&
+        Math.abs(c.position.z - z) < 1e-6,
+    );
+    const rightBand = g.children.find(
+      (c) =>
+        c instanceof THREE.Mesh &&
+        Math.abs((c as any).geometry.parameters.width - bandThickness) < 1e-6 &&
+        Math.abs((c as any).geometry.parameters.height - 0.9) < 1e-6 &&
+        Math.abs((c as any).geometry.parameters.depth - backT) < 1e-6 &&
+        Math.abs(c.position.x - (1 - bandThickness / 2)) < 1e-6 &&
+        Math.abs(c.position.y - 0.45) < 1e-6 &&
+        Math.abs(c.position.z - z) < 1e-6,
+    );
+    expect(topBand).toBeTruthy();
+    expect(bottomBand).toBeTruthy();
+    expect(leftBand).toBeTruthy();
+    expect(rightBand).toBeTruthy();
+  });
+
   it('positions horizontal traverse by depth offset', () => {
     const offset = 100;
     const trWidth = 100;


### PR DESCRIPTION
## Summary
- allow cabinets to specify back panel edge banding on each edge
- render back panel edging when thick backs are used
- expose controls and translations for back edge banding
- test back panel edge banding generation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b59aeaad2083229f76d333978e74a3