### PR TITLE
Support length/width edge banding structure

### DIFF
--- a/src/ui/SceneViewer.tsx
+++ b/src/ui/SceneViewer.tsx
@@ -76,6 +76,8 @@ const SceneViewer: React.FC<Props> = ({ threeRef, addCountertop }) => {
       showEdges,
       edgeBanding: adv.edgeBanding,
       traverseEdgeBanding: adv.traverseEdgeBanding,
+      shelfEdgeBanding: adv.shelfEdgeBanding,
+      backEdgeBanding: adv.backEdgeBanding,
       carcassType: adv.carcassType,
       showFronts,
     });

--- a/src/ui/components/TechDrawing.tsx
+++ b/src/ui/components/TechDrawing.tsx
@@ -247,9 +247,11 @@ export default function TechDrawing({
   const outerW = Math.round(widthMM);
   const innerClearW = Math.round(widthMM - (gaps.left + gaps.right));
   const outerH = Math.round(heightMM);
-  const eb = edgeBanding || {
-    length: false,
-    width: false,
+  const eb = {
+    front: edgeBanding?.length ?? false,
+    back: edgeBanding?.length ?? false,
+    left: edgeBanding?.width ?? false,
+    right: edgeBanding?.width ?? false,
   };
 
   return (


### PR DESCRIPTION
## Summary
- propagate shelf and back edge banding through SceneViewer so 3D modules render with full banding info
- adapt TechDrawing to interpret edge banding using new `{length,width}` format

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5c674f2d883228bd2608e73bd7c22