### PR TITLE
Update edge banding option labels

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -122,8 +122,8 @@
     },
     "edgeBanding": "Edge banding",
     "edgeBandingOptions": {
-      "length": "length",
-      "width": "width"
+      "length": "lengthwise",
+      "width": "widthwise"
     },
     "shelfEdgeBanding": "Shelf edge banding",
     "traverseEdgeBanding": "Traverse edge banding",

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -122,8 +122,8 @@
     },
     "edgeBanding": "Okleina",
     "edgeBandingOptions": {
-      "length": "długość",
-      "width": "szerokość"
+      "length": "po długości",
+      "width": "po szerokości"
     },
     "shelfEdgeBanding": "Okleina półek",
     "traverseEdgeBanding": "Okleina trawersów",


### PR DESCRIPTION
## Summary
- clarify edge banding option labels as "po długości/po szerokości" and "lengthwise/widthwise"
- verify configurator references new length/width keys

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b5cfb8624883229c55899b9db5f196