### PR TITLE
Fix side panel edge banding duplication

### DIFF
--- a/src/scene/cabinetBuilder.ts
+++ b/src/scene/cabinetBuilder.ts
@@ -192,30 +192,14 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
     addBand(W - T / 2, sideY, bandThickness / 2, T, sideHeight, bandThickness);
   }
   if (shouldBand(edgeBanding, 'vertical', 'back')) {
-    addBand(
-      T / 2,
-      sideBottomY + bandThickness / 2,
-      -D / 2,
-      T,
-      bandThickness,
-      D,
-    );
-    addBand(T / 2, sideTopY - bandThickness / 2, -D / 2, T, bandThickness, D);
+    addBand(T / 2, sideY, -D + bandThickness / 2, T, sideHeight, bandThickness);
     addBand(
       W - T / 2,
-      sideBottomY + bandThickness / 2,
-      -D / 2,
+      sideY,
+      -D + bandThickness / 2,
       T,
+      sideHeight,
       bandThickness,
-      D,
-    );
-    addBand(
-      W - T / 2,
-      sideTopY - bandThickness / 2,
-      -D / 2,
-      T,
-      bandThickness,
-      D,
     );
   }
   if (shouldBand(edgeBanding, 'vertical', 'left')) {
@@ -288,8 +272,14 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
       addBand(-T / 2, sideY, bandThickness / 2, T, sideHeight, bandThickness);
     }
     if (shouldBand(edgeBanding, 'vertical', 'back')) {
-      addBand(-T / 2, sideBottomY + bandThickness / 2, -D / 2, T, bandThickness, D);
-      addBand(-T / 2, sideTopY - bandThickness / 2, -D / 2, T, bandThickness, D);
+      addBand(
+        -T / 2,
+        sideY,
+        -D + bandThickness / 2,
+        T,
+        sideHeight,
+        bandThickness,
+      );
     }
     if (shouldBand(edgeBanding, 'vertical', 'left')) {
       addBand(-T / 2, sideBottomY + bandThickness / 2, bandThickness / 2, T, bandThickness, bandThickness);
@@ -312,8 +302,14 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
       addBand(W + T / 2, sideY, bandThickness / 2, T, sideHeight, bandThickness);
     }
     if (shouldBand(edgeBanding, 'vertical', 'back')) {
-      addBand(W + T / 2, sideBottomY + bandThickness / 2, -D / 2, T, bandThickness, D);
-      addBand(W + T / 2, sideTopY - bandThickness / 2, -D / 2, T, bandThickness, D);
+      addBand(
+        W + T / 2,
+        sideY,
+        -D + bandThickness / 2,
+        T,
+        sideHeight,
+        bandThickness,
+      );
     }
     if (shouldBand(edgeBanding, 'vertical', 'right')) {
       addBand(W + T / 2, sideTopY - bandThickness / 2, bandThickness / 2, T, bandThickness, bandThickness);

--- a/tests/cabinetBuilder.test.ts
+++ b/tests/cabinetBuilder.test.ts
@@ -713,4 +713,62 @@ describe('buildCabinetMesh', () => {
     });
     expect(edgesCount).toBeGreaterThan(0);
   });
+
+  it('bands each side panel edge once when all edge flags enabled', () => {
+    const g = buildCabinetMesh({
+      width: WIDTH,
+      height: HEIGHT,
+      depth: DEPTH,
+      drawers: 0,
+      gaps: { top: 0, bottom: 0 },
+      family: FAMILY.BASE,
+      edgeBanding: {
+        front: true,
+        back: true,
+        left: true,
+        right: true,
+        top: true,
+        bottom: true,
+      },
+    });
+    const bands = g.children.filter(
+      (c) =>
+        c instanceof THREE.Mesh &&
+        (c as any).material instanceof THREE.MeshStandardMaterial &&
+        (c as any).material.color.getHex() === 0xffaa00,
+    ) as THREE.Mesh[];
+    const bandT = 0.002;
+    const frontBands = bands.filter(
+      (b) =>
+        Math.abs(b.position.z - bandT / 2) < 1e-6 &&
+        Math.abs(((b.geometry as any).parameters.width ?? 0) - BOARD_THICKNESS) < 1e-6 &&
+        Math.abs(((b.geometry as any).parameters.height ?? 0) - HEIGHT) < 1e-6 &&
+        Math.abs(((b.geometry as any).parameters.depth ?? 0) - bandT) < 1e-6,
+    );
+    const backBands = bands.filter(
+      (b) =>
+        Math.abs(b.position.z - (-DEPTH + bandT / 2)) < 1e-6 &&
+        Math.abs(((b.geometry as any).parameters.width ?? 0) - BOARD_THICKNESS) < 1e-6 &&
+        Math.abs(((b.geometry as any).parameters.height ?? 0) - HEIGHT) < 1e-6 &&
+        Math.abs(((b.geometry as any).parameters.depth ?? 0) - bandT) < 1e-6,
+    );
+    const topBands = bands.filter(
+      (b) =>
+        Math.abs(b.position.y - (HEIGHT - bandT / 2)) < 1e-6 &&
+        Math.abs(((b.geometry as any).parameters.width ?? 0) - BOARD_THICKNESS) < 1e-6 &&
+        Math.abs(((b.geometry as any).parameters.height ?? 0) - bandT) < 1e-6 &&
+        Math.abs(((b.geometry as any).parameters.depth ?? 0) - DEPTH) < 1e-6,
+    );
+    const bottomBands = bands.filter(
+      (b) =>
+        Math.abs(b.position.y - bandT / 2) < 1e-6 &&
+        Math.abs(((b.geometry as any).parameters.width ?? 0) - BOARD_THICKNESS) < 1e-6 &&
+        Math.abs(((b.geometry as any).parameters.height ?? 0) - bandT) < 1e-6 &&
+        Math.abs(((b.geometry as any).parameters.depth ?? 0) - DEPTH) < 1e-6,
+    );
+    expect(frontBands.length).toBe(2);
+    expect(backBands.length).toBe(2);
+    expect(topBands.length).toBe(2);
+    expect(bottomBands.length).toBe(2);
+  });
 });


### PR DESCRIPTION
## Summary
- Prevent side panel back bands from double-processing horizontal edges
- Cover side panel edge banding with regression test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5db6c17f48322be2e2099f91e8515