### PR TITLE
refactor: add per-edge top/bottom banding

### DIFF
--- a/src/core/cutlist.ts
+++ b/src/core/cutlist.ts
@@ -51,11 +51,11 @@ export function cutlistForModule(
   const boardMat = `Płyta ${t}mm`;
   const leftBanding = g.leftSideEdgeBanding || {};
   const rightBanding = g.rightSideEdgeBanding || {};
-  const edgeBanding: EdgeBanding = {
+  const topBanding = g.topPanelEdgeBanding || {};
+  const bottomBanding = g.bottomPanelEdgeBanding || {};
+  const fillerBanding: EdgeBanding = {
     front: leftBanding.front || rightBanding.front,
     back: leftBanding.back || rightBanding.back,
-    left: leftBanding.left || rightBanding.left,
-    right: leftBanding.right || rightBanding.right,
     top: leftBanding.top || rightBanding.top,
     bottom: leftBanding.bottom || rightBanding.bottom,
   };
@@ -114,7 +114,7 @@ export function cutlistForModule(
       h: clampPos(D),
     });
     addEdge(
-      edgeBanding,
+      topBanding,
       'front',
       'ABS 1mm',
       W - 2 * t - tol.assembly,
@@ -122,15 +122,15 @@ export function cutlistForModule(
       boardMat,
     );
     addEdge(
-      edgeBanding,
+      topBanding,
       'back',
       'ABS 1mm',
       W - 2 * t - tol.assembly,
       'Wieniec górny — tył',
       boardMat,
     );
-    addEdge(edgeBanding, 'left', 'ABS 1mm', D, 'Wieniec górny — lewa', boardMat);
-    addEdge(edgeBanding, 'right', 'ABS 1mm', D, 'Wieniec górny — prawa', boardMat);
+    addEdge(topBanding, 'left', 'ABS 1mm', D, 'Wieniec górny — lewa', boardMat);
+    addEdge(topBanding, 'right', 'ABS 1mm', D, 'Wieniec górny — prawa', boardMat);
     add({
       moduleId: m.id,
       moduleLabel: m.label,
@@ -141,7 +141,7 @@ export function cutlistForModule(
       h: clampPos(D),
     });
     addEdge(
-      edgeBanding,
+      bottomBanding,
       'front',
       'ABS 1mm',
       W - 2 * t - tol.assembly,
@@ -149,15 +149,15 @@ export function cutlistForModule(
       boardMat,
     );
     addEdge(
-      edgeBanding,
+      bottomBanding,
       'back',
       'ABS 1mm',
       W - 2 * t - tol.assembly,
       'Wieniec dolny — tył',
       boardMat,
     );
-    addEdge(edgeBanding, 'left', 'ABS 1mm', D, 'Wieniec dolny — lewa', boardMat);
-    addEdge(edgeBanding, 'right', 'ABS 1mm', D, 'Wieniec dolny — prawa', boardMat);
+    addEdge(bottomBanding, 'left', 'ABS 1mm', D, 'Wieniec dolny — lewa', boardMat);
+    addEdge(bottomBanding, 'right', 'ABS 1mm', D, 'Wieniec dolny — prawa', boardMat);
     if ((g.backPanel || 'full') !== 'none') {
       if ((g.backPanel || 'full') === 'split') {
         const hPiece = clampPos((H - tol.backGroove) / 2);
@@ -249,7 +249,7 @@ export function cutlistForModule(
       h: clampPos(H),
     });
     addEdge(
-      edgeBanding,
+      fillerBanding,
       'front',
       'ABS 1mm',
       H,
@@ -257,15 +257,29 @@ export function cutlistForModule(
       boardMat,
     );
     addEdge(
-      edgeBanding,
+      fillerBanding,
       'back',
       'ABS 1mm',
       H,
       'Zaślepka narożna — krawędź tylna',
       boardMat,
     );
-    addEdge(edgeBanding, 'top', 'ABS 1mm', filler, 'Zaślepka narożna — krawędź górna', boardMat);
-    addEdge(edgeBanding, 'bottom', 'ABS 1mm', filler, 'Zaślepka narożna — krawędź dolna', boardMat);
+    addEdge(
+      fillerBanding,
+      'top',
+      'ABS 1mm',
+      filler,
+      'Zaślepka narożna — krawędź górna',
+      boardMat,
+    );
+    addEdge(
+      fillerBanding,
+      'bottom',
+      'ABS 1mm',
+      filler,
+      'Zaślepka narożna — krawędź dolna',
+      boardMat,
+    );
     addStandardBox();
     addShelves();
   } else {
@@ -382,7 +396,7 @@ export function cutlistForModule(
         h: boxD,
       });
       addEdge(
-        edgeBanding,
+        fillerBanding,
         'top',
         'ABS 1mm',
         (boxW - 2 * t) * 2,

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -134,6 +134,8 @@
     "backEdgeBanding": "Back panel - edge banding",
     "rightSideEdgeBanding": "Right side - edge banding",
     "leftSideEdgeBanding": "Left side - edge banding",
+    "topPanelEdgeBanding": "Top panel - edge banding",
+    "bottomPanelEdgeBanding": "Bottom panel - edge banding",
     "sidePanel": "Side panel",
     "panel": "Panel",
     "orientation": {

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -134,6 +134,8 @@
     "backEdgeBanding": "Plecy – okleina",
     "rightSideEdgeBanding": "Bok prawy – okleina",
     "leftSideEdgeBanding": "Bok lewy – okleina",
+    "topPanelEdgeBanding": "Wieniec górny – okleina",
+    "bottomPanelEdgeBanding": "Wieniec dolny – okleina",
     "sidePanel": "Panel boczny",
     "panel": "Panel",
     "orientation": {

--- a/src/scene/cabinetBuilder.ts
+++ b/src/scene/cabinetBuilder.ts
@@ -41,6 +41,8 @@ export interface CabinetOptions {
   shelfEdgeBanding?: EdgeBanding;
   traverseEdgeBanding?: EdgeBanding;
   backEdgeBanding?: EdgeBanding;
+  topPanelEdgeBanding?: EdgeBanding;
+  bottomPanelEdgeBanding?: EdgeBanding;
   sidePanels?: {
     left?: Record<string, any>;
     right?: Record<string, any>;
@@ -78,6 +80,8 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
     traverseEdgeBanding: traverseEdgeBandingInput = {},
     shelfEdgeBanding: shelfEdgeBandingInput = {},
     backEdgeBanding: backEdgeBandingInput = {},
+    topPanelEdgeBanding: topPanelEdgeBandingInput = {},
+    bottomPanelEdgeBanding: bottomPanelEdgeBandingInput = {},
     sidePanels = {},
     carcassType = 'type1',
     showFronts = true,
@@ -93,17 +97,11 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
 
   const rightSideEdgeBanding = rightSideEdgeBandingInput;
   const leftSideEdgeBanding = leftSideEdgeBandingInput;
-  const edgeBanding: EdgeBanding = {
-    front: rightSideEdgeBanding.front || leftSideEdgeBanding.front,
-    back: rightSideEdgeBanding.back || leftSideEdgeBanding.back,
-    left: rightSideEdgeBanding.left || leftSideEdgeBanding.left,
-    right: rightSideEdgeBanding.right || leftSideEdgeBanding.right,
-    top: rightSideEdgeBanding.top || leftSideEdgeBanding.top,
-    bottom: rightSideEdgeBanding.bottom || leftSideEdgeBanding.bottom,
-  };
   const traverseEdgeBanding = traverseEdgeBandingInput;
   const shelfEdgeBanding = shelfEdgeBandingInput;
   const backEdgeBanding = backEdgeBandingInput;
+  const topPanelEdgeBanding = topPanelEdgeBandingInput;
+  const bottomPanelEdgeBanding = bottomPanelEdgeBandingInput;
 
   const FRONT_OFFSET = 0.002;
 
@@ -138,9 +136,29 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
     metalness: 0.3,
     roughness: 0.7,
   });
-  const isFull =
-    (edgeBanding.front || edgeBanding.back || false) &&
-    (edgeBanding.left || edgeBanding.right || edgeBanding.top || edgeBanding.bottom || false);
+  const hasFrontBack =
+    rightSideEdgeBanding.front ||
+    rightSideEdgeBanding.back ||
+    leftSideEdgeBanding.front ||
+    leftSideEdgeBanding.back ||
+    topPanelEdgeBanding.front ||
+    topPanelEdgeBanding.back ||
+    bottomPanelEdgeBanding.front ||
+    bottomPanelEdgeBanding.back;
+  const hasOther =
+    rightSideEdgeBanding.left ||
+    rightSideEdgeBanding.right ||
+    rightSideEdgeBanding.top ||
+    rightSideEdgeBanding.bottom ||
+    leftSideEdgeBanding.left ||
+    leftSideEdgeBanding.right ||
+    leftSideEdgeBanding.top ||
+    leftSideEdgeBanding.bottom ||
+    topPanelEdgeBanding.left ||
+    topPanelEdgeBanding.right ||
+    bottomPanelEdgeBanding.left ||
+    bottomPanelEdgeBanding.right;
+  const isFull = !!(hasFrontBack && hasOther);
   const bandThickness = isFull ? 0.002 : 0.001;
   const bandMat = new THREE.MeshStandardMaterial({
     color: isFull ? 0xffaa00 : 0xffdd99,
@@ -266,7 +284,7 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
     bottom.position.set(W / 2, legHeight + T / 2, -D / 2);
     addEdges(bottom);
     group.add(bottom);
-    if (shouldBand(edgeBanding, 'horizontal', 'front')) {
+    if (shouldBand(bottomPanelEdgeBanding, 'horizontal', 'front')) {
       addBand(
         W / 2,
         legHeight + T / 2,
@@ -276,7 +294,7 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
         bandThickness,
       );
     }
-    if (shouldBand(edgeBanding, 'horizontal', 'back')) {
+    if (shouldBand(bottomPanelEdgeBanding, 'horizontal', 'back')) {
       addBand(
         W / 2,
         legHeight + T / 2,
@@ -287,11 +305,11 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
       );
     }
     if (
-      shouldBand(edgeBanding, 'horizontal', 'left') ||
-      shouldBand(edgeBanding, 'horizontal', 'right')
+      shouldBand(bottomPanelEdgeBanding, 'horizontal', 'left') ||
+      shouldBand(bottomPanelEdgeBanding, 'horizontal', 'right')
     ) {
       const bottomLeft = (W - bottomWidth) / 2;
-      if (shouldBand(edgeBanding, 'horizontal', 'left')) {
+      if (shouldBand(bottomPanelEdgeBanding, 'horizontal', 'left')) {
         addBand(
           bottomLeft + bandThickness / 2,
           legHeight + T / 2,
@@ -301,7 +319,7 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
           D,
         );
       }
-      if (shouldBand(edgeBanding, 'horizontal', 'right')) {
+      if (shouldBand(bottomPanelEdgeBanding, 'horizontal', 'right')) {
         addBand(
           W - bottomLeft - bandThickness / 2,
           legHeight + T / 2,
@@ -415,7 +433,7 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
     top.position.set(W / 2, legHeight + H - T / 2, -D / 2);
     addEdges(top);
     group.add(top);
-    if (shouldBand(edgeBanding, 'horizontal', 'front')) {
+    if (shouldBand(topPanelEdgeBanding, 'horizontal', 'front')) {
       addBand(
         W / 2,
         legHeight + H - T / 2,
@@ -425,7 +443,7 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
         bandThickness,
       );
     }
-    if (shouldBand(edgeBanding, 'horizontal', 'back')) {
+    if (shouldBand(topPanelEdgeBanding, 'horizontal', 'back')) {
       addBand(
         W / 2,
         legHeight + H - T / 2,
@@ -436,11 +454,11 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
       );
     }
     if (
-      shouldBand(edgeBanding, 'horizontal', 'left') ||
-      shouldBand(edgeBanding, 'horizontal', 'right')
+      shouldBand(topPanelEdgeBanding, 'horizontal', 'left') ||
+      shouldBand(topPanelEdgeBanding, 'horizontal', 'right')
     ) {
       const topLeft = (W - topWidth) / 2;
-      if (shouldBand(edgeBanding, 'horizontal', 'left')) {
+      if (shouldBand(topPanelEdgeBanding, 'horizontal', 'left')) {
         addBand(
           topLeft + bandThickness / 2,
           legHeight + H - T / 2,
@@ -450,7 +468,7 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
           D,
         );
       }
-      if (shouldBand(edgeBanding, 'horizontal', 'right')) {
+      if (shouldBand(topPanelEdgeBanding, 'horizontal', 'right')) {
         addBand(
           W - topLeft - bandThickness / 2,
           legHeight + H - T / 2,
@@ -595,25 +613,6 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
     divider.position.set(x, legHeight + H / 2, -D / 2);
     addEdges(divider);
     group.add(divider);
-    if (shouldBand(edgeBanding, 'vertical', 'front')) {
-      addBand(x, legHeight + H / 2, bandThickness / 2, T, H, bandThickness);
-    }
-    if (shouldBand(edgeBanding, 'vertical', 'back')) {
-      addBand(x, legHeight + H / 2, -D + bandThickness / 2, T, H, bandThickness);
-    }
-    if (shouldBand(edgeBanding, 'vertical', 'left')) {
-      addBand(x, legHeight + bandThickness / 2, -D / 2, T, bandThickness, D);
-    }
-    if (shouldBand(edgeBanding, 'vertical', 'right')) {
-      addBand(
-        x,
-        legHeight + H - bandThickness / 2,
-        -D / 2,
-        T,
-        bandThickness,
-        D,
-      );
-    }
   }
 
   // Fronts

--- a/src/types.ts
+++ b/src/types.ts
@@ -121,6 +121,8 @@ export interface ModuleAdv {
   shelfEdgeBanding?: EdgeBanding;
   traverseEdgeBanding?: EdgeBanding;
   backEdgeBanding?: EdgeBanding;
+  topPanelEdgeBanding?: EdgeBanding;
+  bottomPanelEdgeBanding?: EdgeBanding;
   sidePanels?: {
     left?: Record<string, any>;
     right?: Record<string, any>;

--- a/src/ui/CabinetConfigurator.tsx
+++ b/src/ui/CabinetConfigurator.tsx
@@ -147,6 +147,8 @@ const CabinetConfigurator: React.FC<Props> = ({
               traverseEdgeBanding={gLocal.traverseEdgeBanding}
               shelfEdgeBanding={gLocal.shelfEdgeBanding}
               backEdgeBanding={gLocal.backEdgeBanding}
+              topPanelEdgeBanding={gLocal.topPanelEdgeBanding}
+              bottomPanelEdgeBanding={gLocal.bottomPanelEdgeBanding}
               sidePanels={gLocal.sidePanels}
               carcassType={gLocal.carcassType}
               showFronts={showFronts}
@@ -546,6 +548,46 @@ const CabinetConfigurator: React.FC<Props> = ({
                     ))}
                   </div>
                 ) : null}
+                {gLocal.topPanel?.type === 'full' && (
+                  <div style={{ marginTop: 8 }}>
+                    <div className="small">
+                      {t('configurator.topPanelEdgeBanding')}
+                    </div>
+                    <div className="row" style={{ gap: 8 }}>
+                      {(['front', 'back', 'left', 'right'] as const).map(
+                        (edge) => (
+                          <label
+                            key={edge}
+                            style={{
+                              display: 'flex',
+                              alignItems: 'center',
+                              gap: 4,
+                            }}
+                          >
+                            <input
+                              type="checkbox"
+                              checked={
+                                gLocal.topPanelEdgeBanding?.[edge] ?? false
+                              }
+                              onChange={(e) =>
+                                setAdv({
+                                  ...gLocal,
+                                  topPanelEdgeBanding: {
+                                    ...gLocal.topPanelEdgeBanding,
+                                    [edge]: (
+                                      e.target as HTMLInputElement
+                                    ).checked,
+                                  },
+                                })
+                              }
+                            />
+                            {t(`configurator.edgeBandingOptions.${edge}`)}
+                          </label>
+                        ),
+                      )}
+                    </div>
+                  </div>
+                )}
               </div>
               <div style={{ marginTop: 8 }}>
                 <div className="small">{t('configurator.traverseEdgeBanding')}</div>
@@ -606,6 +648,46 @@ const CabinetConfigurator: React.FC<Props> = ({
                   </option>
                 </select>
               </div>
+              {gLocal.bottomPanel !== 'none' && (
+                <div style={{ marginTop: 8 }}>
+                  <div className="small">
+                    {t('configurator.bottomPanelEdgeBanding')}
+                  </div>
+                  <div className="row" style={{ gap: 8 }}>
+                    {(['front', 'back', 'left', 'right'] as const).map(
+                      (edge) => (
+                        <label
+                          key={edge}
+                          style={{
+                            display: 'flex',
+                            alignItems: 'center',
+                            gap: 4,
+                          }}
+                        >
+                          <input
+                            type="checkbox"
+                            checked={
+                              gLocal.bottomPanelEdgeBanding?.[edge] ?? false
+                            }
+                            onChange={(e) =>
+                              setAdv({
+                                ...gLocal,
+                                bottomPanelEdgeBanding: {
+                                  ...gLocal.bottomPanelEdgeBanding,
+                                  [edge]: (
+                                    e.target as HTMLInputElement
+                                  ).checked,
+                                },
+                              })
+                            }
+                          />
+                          {t(`configurator.edgeBandingOptions.${edge}`)}
+                        </label>
+                      ),
+                    )}
+                  </div>
+                </div>
+              )}
             </div>
           </details>
 

--- a/src/ui/SceneViewer.tsx
+++ b/src/ui/SceneViewer.tsx
@@ -79,6 +79,8 @@ const SceneViewer: React.FC<Props> = ({ threeRef, addCountertop }) => {
       traverseEdgeBanding: adv.traverseEdgeBanding,
       shelfEdgeBanding: adv.shelfEdgeBanding,
       backEdgeBanding: adv.backEdgeBanding,
+      topPanelEdgeBanding: adv.topPanelEdgeBanding,
+      bottomPanelEdgeBanding: adv.bottomPanelEdgeBanding,
       carcassType: adv.carcassType,
       showFronts,
     });

--- a/src/ui/components/Cabinet3D.tsx
+++ b/src/ui/components/Cabinet3D.tsx
@@ -24,6 +24,8 @@ export default function Cabinet3D({
   traverseEdgeBanding = {},
   shelfEdgeBanding = {},
   backEdgeBanding = {},
+  topPanelEdgeBanding = {},
+  bottomPanelEdgeBanding = {},
   sidePanels,
   carcassType = 'type1',
   showFronts = true,
@@ -46,6 +48,8 @@ export default function Cabinet3D({
   traverseEdgeBanding?: EdgeBanding;
   shelfEdgeBanding?: EdgeBanding;
   backEdgeBanding?: EdgeBanding;
+  topPanelEdgeBanding?: EdgeBanding;
+  bottomPanelEdgeBanding?: EdgeBanding;
   sidePanels?: {
     left?: Record<string, any>;
     right?: Record<string, any>;
@@ -122,6 +126,8 @@ export default function Cabinet3D({
       traverseEdgeBanding,
       shelfEdgeBanding,
       backEdgeBanding,
+      topPanelEdgeBanding,
+      bottomPanelEdgeBanding,
       sidePanels,
       carcassType,
       showFronts,
@@ -163,6 +169,8 @@ export default function Cabinet3D({
     traverseEdgeBanding,
     shelfEdgeBanding,
     backEdgeBanding,
+    topPanelEdgeBanding,
+    bottomPanelEdgeBanding,
     sidePanels,
     carcassType,
     showFronts,

--- a/src/ui/types.ts
+++ b/src/ui/types.ts
@@ -19,6 +19,8 @@ export interface CabinetConfig {
   shelfEdgeBanding?: EdgeBanding;
   traverseEdgeBanding?: EdgeBanding;
   backEdgeBanding?: EdgeBanding;
+  topPanelEdgeBanding?: EdgeBanding;
+  bottomPanelEdgeBanding?: EdgeBanding;
   sidePanels?: {
     left?: Record<string, unknown>;
     right?: Record<string, unknown>;

--- a/src/ui/useCabinetConfig.ts
+++ b/src/ui/useCabinetConfig.ts
@@ -34,6 +34,8 @@ export function useCabinetConfig(
       backPanel: g.backPanel,
       topPanel: g.topPanel,
       bottomPanel: g.bottomPanel,
+      topPanelEdgeBanding: {},
+      bottomPanelEdgeBanding: {},
       rightSideEdgeBanding: {
         front: true,
         back: true,
@@ -249,6 +251,8 @@ export function useCabinetConfig(
             backPanel: g.backPanel,
             topPanel: g.topPanel,
             bottomPanel: g.bottomPanel,
+            topPanelEdgeBanding: {},
+            bottomPanelEdgeBanding: {},
             rightSideEdgeBanding: {
               front: true,
               back: true,
@@ -279,6 +283,8 @@ export function useCabinetConfig(
         adv: {
           ...g,
           doorCount: 1,
+          topPanelEdgeBanding: {},
+          bottomPanelEdgeBanding: {},
           rightSideEdgeBanding: {
             front: true,
             back: true,

--- a/tests/cabinetBuilder.test.ts
+++ b/tests/cabinetBuilder.test.ts
@@ -369,6 +369,78 @@ describe('buildCabinetMesh', () => {
     expect(topBands.length).toBe(2);
   });
 
+  it('does not band top or bottom panels when side front banding selected', () => {
+    const g = buildCabinetMesh({
+      width: WIDTH,
+      height: HEIGHT,
+      depth: DEPTH,
+      drawers: 0,
+      gaps: { top: 0, bottom: 0 },
+      family: FAMILY.BASE,
+      leftSideEdgeBanding: { front: true },
+    });
+    const bottomWidth = WIDTH - 2 * BOARD_THICKNESS;
+    const topWidth = WIDTH - 2 * BOARD_THICKNESS;
+    const bottomBand = g.children.find(
+      (c) =>
+        c instanceof THREE.Mesh &&
+        Math.abs((c as any).geometry.parameters.width - bottomWidth) < 1e-6 &&
+        Math.abs((c as any).geometry.parameters.height - BOARD_THICKNESS) < 1e-6 &&
+        Math.abs((c as any).geometry.parameters.depth - BAND_THICKNESS) < 1e-6 &&
+        Math.abs(c.position.x - WIDTH / 2) < 1e-6 &&
+        Math.abs(c.position.y - BOARD_THICKNESS / 2) < 1e-6 &&
+        Math.abs(c.position.z - BAND_THICKNESS / 2) < 1e-6,
+    );
+    const topBand = g.children.find(
+      (c) =>
+        c instanceof THREE.Mesh &&
+        Math.abs((c as any).geometry.parameters.width - topWidth) < 1e-6 &&
+        Math.abs((c as any).geometry.parameters.height - BOARD_THICKNESS) < 1e-6 &&
+        Math.abs((c as any).geometry.parameters.depth - BAND_THICKNESS) < 1e-6 &&
+        Math.abs(c.position.x - WIDTH / 2) < 1e-6 &&
+        Math.abs(c.position.y - (HEIGHT - BOARD_THICKNESS / 2)) < 1e-6 &&
+        Math.abs(c.position.z - BAND_THICKNESS / 2) < 1e-6,
+    );
+    expect(bottomBand).toBeUndefined();
+    expect(topBand).toBeUndefined();
+  });
+
+  it('bands top and bottom panels when edge flags set', () => {
+    const g = buildCabinetMesh({
+      width: WIDTH,
+      height: HEIGHT,
+      depth: DEPTH,
+      drawers: 0,
+      gaps: { top: 0, bottom: 0 },
+      family: FAMILY.BASE,
+      topPanelEdgeBanding: { front: true },
+      bottomPanelEdgeBanding: { front: true },
+    });
+    const panelWidth = WIDTH - 2 * BOARD_THICKNESS;
+    const bottomBand = g.children.find(
+      (c) =>
+        c instanceof THREE.Mesh &&
+        Math.abs((c as any).geometry.parameters.width - panelWidth) < 1e-6 &&
+        Math.abs((c as any).geometry.parameters.height - BOARD_THICKNESS) < 1e-6 &&
+        Math.abs((c as any).geometry.parameters.depth - BAND_THICKNESS) < 1e-6 &&
+        Math.abs(c.position.x - WIDTH / 2) < 1e-6 &&
+        Math.abs(c.position.y - BOARD_THICKNESS / 2) < 1e-6 &&
+        Math.abs(c.position.z - BAND_THICKNESS / 2) < 1e-6,
+    );
+    const topBand = g.children.find(
+      (c) =>
+        c instanceof THREE.Mesh &&
+        Math.abs((c as any).geometry.parameters.width - panelWidth) < 1e-6 &&
+        Math.abs((c as any).geometry.parameters.height - BOARD_THICKNESS) < 1e-6 &&
+        Math.abs((c as any).geometry.parameters.depth - BAND_THICKNESS) < 1e-6 &&
+        Math.abs(c.position.x - WIDTH / 2) < 1e-6 &&
+        Math.abs(c.position.y - (HEIGHT - BOARD_THICKNESS / 2)) < 1e-6 &&
+        Math.abs(c.position.z - BAND_THICKNESS / 2) < 1e-6,
+    );
+    expect(bottomBand).toBeTruthy();
+    expect(topBand).toBeTruthy();
+  });
+
   it('bands only right side when rightSideEdgeBanding is set', () => {
     const g = buildCabinetMesh({
       width: WIDTH,


### PR DESCRIPTION
## Summary
- support explicit edge banding controls for top and bottom panels
- update builder and cutlist to handle per-edge top/bottom banding
- expand tests to cover new edge banding behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5eab161dc8322ba89d5cf40dd78af