### PR TITLE
Update camera rotation logic for back highlight

### DIFF
--- a/src/ui/SceneViewer.tsx
+++ b/src/ui/SceneViewer.tsx
@@ -175,8 +175,14 @@ const SceneViewer: React.FC<Props> = ({ threeRef, addCountertop }) => {
       target.material = mat;
     }
 
-    if (highlightPart === 'back' && three.controls) {
-      three.controls.rotateLeft(Math.PI);
+    if (highlightPart === 'back' && three.controls && three.camera) {
+      const vector = three.camera.position
+        .clone()
+        .sub(three.controls.target);
+      vector.applyAxisAngle(new THREE.Vector3(0, 1, 0), Math.PI);
+      three.camera.position.copy(
+        three.controls.target.clone().add(vector),
+      );
       three.controls.update();
     }
   }, [highlightPart, store.modules]);


### PR DESCRIPTION
## Summary
- Adjust back highlight behavior to reposition camera behind the target instead of rotating controls

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b613e3016483229e84012336ef52a0