### PR TITLE
Use local preview state for fronts and highlights

### DIFF
--- a/src/ui/CabinetConfigurator.tsx
+++ b/src/ui/CabinetConfigurator.tsx
@@ -48,10 +48,7 @@ const CabinetConfigurator: React.FC<Props> = ({
   setAdv,
   onAdd,
 }) => {
-  const setShowFronts = usePlannerStore((s) => s.setShowFronts);
-  const currentShowFronts = usePlannerStore((s) => s.showFronts);
   const prices = usePlannerStore((s) => s.prices);
-  const setHighlightPart = usePlannerStore((s) => s.setHighlightPart);
   const { t } = useTranslation();
   const [doorsCount, setDoorsCount] = useState(1);
   const [drawersCount, setDrawersCount] = useState(0);
@@ -66,10 +63,10 @@ const CabinetConfigurator: React.FC<Props> = ({
   const [openBack, setOpenBack] = useState(false);
   const [openRightSide, setOpenRightSide] = useState(false);
   const [openLeftSide, setOpenLeftSide] = useState(false);
+  const [highlightPart, setHighlightPart] = useState<
+    'top' | 'bottom' | 'shelf' | 'back' | 'leftSide' | 'rightSide' | null
+  >(null);
   const showFronts = !openKorpus;
-  useEffect(() => {
-    if (currentShowFronts !== showFronts) setShowFronts(showFronts);
-  }, [currentShowFronts, showFronts, setShowFronts]);
   const FormComponent = kind ? FORM_COMPONENTS[kind.key] : null;
   const formValues: CabinetFormValues = {
     height: gLocal.height,
@@ -153,6 +150,7 @@ const CabinetConfigurator: React.FC<Props> = ({
               sidePanels={gLocal.sidePanels}
               carcassType={gLocal.carcassType}
               showFronts={showFronts}
+              highlightPart={highlightPart}
             />
           </div>
           <div className="grid2" style={{ marginTop: 8 }}>

--- a/src/ui/components/Cabinet3D.tsx
+++ b/src/ui/components/Cabinet3D.tsx
@@ -29,6 +29,7 @@ export default function Cabinet3D({
   sidePanels,
   carcassType = 'type1',
   showFronts = true,
+  highlightPart = null,
 }: {
   widthMM: number;
   heightMM: number;
@@ -56,6 +57,7 @@ export default function Cabinet3D({
   };
   carcassType?: 'type1' | 'type2' | 'type3';
   showFronts?: boolean;
+  highlightPart?: 'top' | 'bottom' | 'shelf' | 'back' | 'leftSide' | 'rightSide' | null;
 }) {
   const ref = useRef<HTMLDivElement>(null);
   const rendererRef = useRef<THREE.WebGLRenderer | null>(null);
@@ -132,6 +134,19 @@ export default function Cabinet3D({
       carcassType,
       showFronts,
     });
+    if (highlightPart) {
+      cabGroup.traverse((obj) => {
+        if (obj instanceof THREE.Mesh && obj.userData.part === highlightPart) {
+          const mat = (obj.material as THREE.Material).clone();
+          if ('emissive' in mat) {
+            (mat as THREE.MeshStandardMaterial).emissive = new THREE.Color(0x4444ff);
+          } else if ((mat as any).color) {
+            (mat as any).color = new THREE.Color(0x4444ff);
+          }
+          obj.material = mat;
+        }
+      });
+    }
     scene.add(cabGroup);
     renderer.render(scene, camera);
     sceneRef.current = scene;
@@ -174,6 +189,7 @@ export default function Cabinet3D({
     sidePanels,
     carcassType,
     showFronts,
+    highlightPart,
   ]);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Remove store-backed showFronts and highlightPart from CabinetConfigurator and manage them locally
- Pass local showFronts and highlightPart to Cabinet3D preview
- Add highlight support to Cabinet3D when a part is selected

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b61abdbbc8832298123e48383f4917