### PR TITLE
feat: add base countertop kind

### DIFF
--- a/src/core/catalog.ts
+++ b/src/core/catalog.ts
@@ -55,6 +55,13 @@ export const KIND_SETS: Record<FAMILY, Kind[]> = {
         { key:'hob', label:'Pod płytę' },
         { key:'dishwasher', label:'Zmywarka' }
       ]
+    },
+    {
+      key:'countertop',
+      label:'Blaty',
+      variants:[
+        { key:'default', label:'Blat' }
+      ]
     }
   ],
   [FAMILY.TALL]: [


### PR DESCRIPTION
## Summary
- add countertop kind with default variant to base family catalog

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b61f685cc08322a16c0ac256290e42