### PR TITLE
Add countertop visibility toggle in MainTabs

### DIFF
--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -13,7 +13,7 @@ export default function App() {
   const [kind, setKind] = useState<Kind | null>(null);
   const [variant, setVariant] = useState<Variant | null>(null);
   const [selWall, setSelWall] = useState(0);
-  const [addCountertop] = useState(true);
+  const [addCountertop, setAddCountertop] = useState(true);
   const threeRef = useRef<any>({});
 
   const { t, i18n } = createTranslator();
@@ -82,6 +82,8 @@ export default function App() {
           setBoardKerf={setBoardKerf}
           boardHasGrain={boardHasGrain}
           setBoardHasGrain={setBoardHasGrain}
+          addCountertop={addCountertop}
+          setAddCountertop={setAddCountertop}
         />
       </div>
       <div className="canvasWrap">

--- a/src/ui/MainTabs.tsx
+++ b/src/ui/MainTabs.tsx
@@ -39,6 +39,8 @@ interface MainTabsProps {
   setBoardKerf: (v: number) => void;
   boardHasGrain: boolean;
   setBoardHasGrain: (v: boolean) => void;
+  addCountertop: boolean;
+  setAddCountertop: (v: boolean) => void;
 }
 
 export default function MainTabs({
@@ -65,6 +67,8 @@ export default function MainTabs({
   setBoardKerf,
   boardHasGrain,
   setBoardHasGrain,
+  addCountertop,
+  setAddCountertop,
 }: MainTabsProps) {
   const toggleTab = (name: 'cab' | 'room' | 'costs' | 'cut' | 'global') => {
     setTab(tab === name ? null : name);
@@ -141,16 +145,33 @@ export default function MainTabs({
             )}
 
             {variant && (
-              <CabinetConfigurator
-                family={family}
-                kind={kind}
-                variant={variant}
-                widthMM={widthMM}
-                setWidthMM={setWidthMM}
-                gLocal={gLocal}
-                setAdv={setAdv}
-                onAdd={onAdd}
-              />
+              <>
+                <CabinetConfigurator
+                  family={family}
+                  kind={kind}
+                  variant={variant}
+                  widthMM={widthMM}
+                  setWidthMM={setWidthMM}
+                  gLocal={gLocal}
+                  setAdv={setAdv}
+                  onAdd={onAdd}
+                />
+                {kind?.key === 'countertop' && (
+                  <label
+                    className="small"
+                    style={{ display: 'flex', gap: 8, alignItems: 'center', marginTop: 8 }}
+                  >
+                    <input
+                      type="checkbox"
+                      checked={!addCountertop}
+                      onChange={(e) =>
+                        setAddCountertop(!(e.target as HTMLInputElement).checked)
+                      }
+                    />
+                    {t('configurator.hideCountertop')}
+                  </label>
+                )}
+              </>
             )}
           </>
         )}


### PR DESCRIPTION
## Summary
- expose `addCountertop` state in `App` and forward to tabs and scene viewer
- allow `MainTabs` to toggle countertop visibility via checkbox when selecting countertop modules

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b62096ae6883229f7c3ebc7cbc40c6