### PR TITLE
Add countertop tab with hide option

### DIFF
--- a/src/core/catalog.ts
+++ b/src/core/catalog.ts
@@ -59,9 +59,7 @@ export const KIND_SETS: Record<FAMILY, Kind[]> = {
     {
       key:'countertop',
       label:'Blaty',
-      variants:[
-        { key:'default', label:'Blat' }
-      ]
+      variants:[]
     }
   ],
   [FAMILY.TALL]: [

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -148,7 +148,7 @@
     "offsetDepth": "Offset (depth mm)",
     "offsetHeight": "Offset (height mm)",
     "traverseWidth": "Traverse width (mm)",
-    "hideCountertop": "Hide countertop"
+    "hideCountertop": "Hide countertops"
   },
   "forms": {
     "width": "Width",

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -148,7 +148,7 @@
     "offsetDepth": "Przesunięcie (głębokość, mm)",
     "offsetHeight": "Przesunięcie (wysokość, mm)",
     "traverseWidth": "Szerokość trawersu (mm)",
-    "hideCountertop": "Ukryj blat"
+    "hideCountertop": "Ukryj blaty"
   },
   "forms": {
     "width": "Szerokość",

--- a/src/ui/MainTabs.tsx
+++ b/src/ui/MainTabs.tsx
@@ -131,7 +131,7 @@ export default function MainTabs({
               </div>
             </div>
 
-            {kind && !variant && (
+            {kind && kind.key !== 'countertop' && !variant && (
               <div className="section">
                 <div className="hd">
                   <div>
@@ -144,34 +144,35 @@ export default function MainTabs({
               </div>
             )}
 
-            {variant && (
-              <>
-                <CabinetConfigurator
-                  family={family}
-                  kind={kind}
-                  variant={variant}
-                  widthMM={widthMM}
-                  setWidthMM={setWidthMM}
-                  gLocal={gLocal}
-                  setAdv={setAdv}
-                  onAdd={onAdd}
-                />
-                {kind?.key === 'countertop' && (
-                  <label
-                    className="small"
-                    style={{ display: 'flex', gap: 8, alignItems: 'center', marginTop: 8 }}
-                  >
-                    <input
-                      type="checkbox"
-                      checked={!addCountertop}
-                      onChange={(e) =>
-                        setAddCountertop(!(e.target as HTMLInputElement).checked)
-                      }
-                    />
-                    {t('configurator.hideCountertop')}
-                  </label>
-                )}
-              </>
+            {variant && kind?.key !== 'countertop' && (
+              <CabinetConfigurator
+                family={family}
+                kind={kind}
+                variant={variant}
+                widthMM={widthMM}
+                setWidthMM={setWidthMM}
+                gLocal={gLocal}
+                setAdv={setAdv}
+                onAdd={onAdd}
+              />
+            )}
+
+            {kind?.key === 'countertop' && (
+              <div className="section">
+                <label
+                  className="small"
+                  style={{ display: 'flex', gap: 8, alignItems: 'center', marginTop: 8 }}
+                >
+                  <input
+                    type="checkbox"
+                    checked={!addCountertop}
+                    onChange={(e) =>
+                      setAddCountertop(!(e.target as HTMLInputElement).checked)
+                    }
+                  />
+                  {t('configurator.hideCountertop')}
+                </label>
+              </div>
             )}
           </>
         )}


### PR DESCRIPTION
## Summary
- add Blaty subcategory for base cabinets
- allow hiding countertops via checkbox without cabinet configurator
- add translations for hide countertop toggle

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b60dae0bbc832281d1ddc7f54ed38c