### PR TITLE
Add carcass type selector to configurator and global settings

### DIFF
--- a/src/ui/CabinetConfigurator.tsx
+++ b/src/ui/CabinetConfigurator.tsx
@@ -22,7 +22,7 @@ interface Props {
   widthMM: number;
   setWidthMM: (n: number) => void;
   gLocal: CabinetConfig;
-  setAdv: (v: CabinetConfig) => void;
+  setAdv: (v: Partial<CabinetConfig>) => void;
   onAdd: (
     width: number,
     adv: CabinetConfig,
@@ -297,6 +297,27 @@ const CabinetConfigurator: React.FC<Props> = ({
                 {Object.keys(prices.board).map((k) => (
                   <option key={k} value={k}>
                     {k}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div>
+              <div className="small">{t('configurator.carcassType')}</div>
+              <select
+                className="input"
+                value={gLocal.carcassType}
+                onChange={(e) =>
+                  setAdv({
+                    carcassType: (e.target as HTMLSelectElement).value as
+                      | 'type1'
+                      | 'type2'
+                      | 'type3',
+                  })
+                }
+              >
+                {(['type1', 'type2', 'type3'] as const).map((type) => (
+                  <option key={type} value={type}>
+                    {t(`configurator.carcassTypes.${type}`)}
                   </option>
                 ))}
               </select>

--- a/src/ui/MainTabs.tsx
+++ b/src/ui/MainTabs.tsx
@@ -23,7 +23,7 @@ interface MainTabsProps {
   widthMM: number;
   setWidthMM: (n: number) => void;
   gLocal: CabinetConfig;
-  setAdv: (v: CabinetConfig) => void;
+  setAdv: (v: Partial<CabinetConfig>) => void;
   onAdd: (
     width: number,
     adv: CabinetConfig,

--- a/src/ui/panels/GlobalSettings.tsx
+++ b/src/ui/panels/GlobalSettings.tsx
@@ -52,6 +52,17 @@ export default function GlobalSettings(){
               options={Object.keys(store.prices.front).filter(k => !k.includes('stowalna'))}
             />
             <Field
+              label={t('configurator.carcassType')}
+              type="select"
+              value={g.carcassType}
+              onChange={(v)=>set({carcassType:v})}
+              options={[
+                { value: 'type1', label: t('configurator.carcassTypes.type1') },
+                { value: 'type2', label: t('configurator.carcassTypes.type2') },
+                { value: 'type3', label: t('configurator.carcassTypes.type3') }
+              ]}
+            />
+            <Field
               label={t('global.backPanel')}
               type="select"
               value={g.backPanel||'full'}

--- a/src/ui/useCabinetConfig.ts
+++ b/src/ui/useCabinetConfig.ts
@@ -304,11 +304,17 @@ export function useCabinetConfig(
 
   const gLocal: CabinetConfig = adv || (store.globals[family] as CabinetConfig);
 
+  const setAdv = (patch: Partial<CabinetConfig>) =>
+    setAdvState((prev) => ({
+      ...(prev || (store.globals[family] as CabinetConfig)),
+      ...patch,
+    }));
+
   return {
     widthMM,
     setWidthMM,
     adv,
-    setAdv: (v: CabinetConfig) => setAdvState(v),
+    setAdv,
     gLocal,
     onAdd,
     doAutoOnSelectedWall,


### PR DESCRIPTION
## Summary
- allow setting carcass type in cabinet configurator and store selection in local config
- expose global carcass type setting in global settings panel
- support partial updates to cabinet config in `useCabinetConfig`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b6d993a7b08322a25c4d1ff5dc5a18