### PR TITLE
Add zoom controls to scene viewer

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -2,6 +2,7 @@
 .app{display:flex;flex-direction:column;height:100vh;width:100vw;color:var(--ink);position:relative}
 .canvasWrap{flex:1;position:relative;background:#F3F4F6}
 .topbar{position:absolute;top:12px;left:12px;z-index:10;display:flex;gap:8px;background:rgba(255,255,255,.85);border:1px solid var(--border);border-radius:10px;padding:8px;backdrop-filter:blur(6px)}
+.zoomControls{position:absolute;bottom:12px;right:12px;z-index:10;display:flex;flex-direction:column;gap:8px;background:rgba(255,255,255,.85);border:1px solid var(--border);border-radius:10px;padding:8px;backdrop-filter:blur(6px)}
 .h1{font-size:18px;font-weight:700}
 .small{font-size:12px;color:var(--muted)}
 .btn{padding:8px 10px;background:var(--accent);color:var(--white);border-radius:8px;border:none;cursor:pointer;font-weight:600}

--- a/src/ui/SceneViewer.tsx
+++ b/src/ui/SceneViewer.tsx
@@ -221,7 +221,35 @@ const SceneViewer: React.FC<Props> = ({ threeRef, addCountertop }) => {
     };
   }, []);
 
-  return <div ref={containerRef} style={{ position: 'absolute', inset: 0 }} />;
+  const handleZoomIn = () => {
+    const controls = threeRef.current?.controls;
+    if (controls) {
+      controls.dollyIn(0.95);
+      controls.update();
+    }
+  };
+
+  const handleZoomOut = () => {
+    const controls = threeRef.current?.controls;
+    if (controls) {
+      controls.dollyOut(0.95);
+      controls.update();
+    }
+  };
+
+  return (
+    <div style={{ position: 'absolute', inset: 0 }}>
+      <div ref={containerRef} style={{ position: 'absolute', inset: 0 }} />
+      <div className="zoomControls">
+        <button className="btnGhost" onClick={handleZoomIn}>
+          +
+        </button>
+        <button className="btnGhost" onClick={handleZoomOut}>
+          −
+        </button>
+      </div>
+    </div>
+  );
 };
 
 export default SceneViewer;


### PR DESCRIPTION
## Summary
- add "+" and "−" zoom buttons to the main viewer
- adjust OrbitControls via dollyIn/dollyOut and update render
- style zoom controls overlay to match existing UI

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b6e121a2288322b011dc98a9c7e058