### PR TITLE
feat: enlarge cabinet preview

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -24,7 +24,7 @@
 .card{border:1px solid var(--border);border-radius:12px;padding:10px;background:#fff;display:flex;flex-direction:column;gap:6px}
 .table{width:100%;border-collapse:collapse;font-size:12px}
 .table th,.table td{border:1px solid var(--border);padding:6px;text-align:left}
-.preview{border:1px dashed var(--border);border-radius:10px;background:#fff;display:flex;align-items:center;justify-content:center;padding:8px}
+.preview{border:1px dashed var(--border);border-radius:10px;background:#fff;display:flex;align-items:center;justify-content:center;padding:8px;margin:0 auto}
 .tabs{display:flex;gap:6px}
 .tabBtn{padding:8px 10px;border-radius:999px;border:1px solid var(--border);background:#fff;cursor:pointer;font-weight:600}
 .tabBtn.active{background:#111827;color:#fff}

--- a/src/ui/components/Cabinet3D.tsx
+++ b/src/ui/components/Cabinet3D.tsx
@@ -78,8 +78,8 @@ export default function Cabinet3D({
 
   useEffect(() => {
     if (!ref.current) return;
-    const w = 260,
-      h = 190;
+    const w = 390,
+      h = 285;
 
     let renderer = rendererRef.current;
     if (!renderer) {
@@ -434,7 +434,7 @@ export default function Cabinet3D({
   };
 
   return (
-    <div style={{ position: 'relative', width: 260, height: 190 }}>
+    <div style={{ position: 'relative', width: 390, height: 285 }}>
       <div
         ref={ref}
         style={{


### PR DESCRIPTION
## Summary
- expand Cabinet3D preview area to 390×285
- center preview container with auto margins

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b6f3d0d2988322abf58e60b167fa53