### PR TITLE
Center orbit control on cabinet midpoint

### DIFF
--- a/src/ui/components/Cabinet3D.tsx
+++ b/src/ui/components/Cabinet3D.tsx
@@ -147,6 +147,7 @@ export default function Cabinet3D({
     });
     cabGroup.userData.animSpeed = 0.15;
     scene.add(cabGroup);
+    const center = new THREE.Vector3(W / 2, legHeight + H / 2, -D / 2);
     renderer.render(scene, camera);
 
     if (controlsRef.current) {
@@ -155,7 +156,11 @@ export default function Cabinet3D({
     const controls = new OrbitControls(camera, renderer.domElement);
     controls.enableRotate = false;
     controls.addEventListener('change', () => renderer.render(scene, camera));
+    controls.target.copy(center);
+    camera.lookAt(center);
+    controls.update();
     controlsRef.current = controls;
+    renderer.render(scene, camera);
 
     sceneRef.current = scene;
     groupRef.current = cabGroup;


### PR DESCRIPTION
## Summary
- compute cabinet center point and use as OrbitControls target
- focus camera on cabinet center and update controls

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b705f98ba88322955253cc49927c9f