### PR TITLE
Account for door gap spacing in tech drawing

### DIFF
--- a/src/ui/components/TechDrawing.tsx
+++ b/src/ui/components/TechDrawing.tsx
@@ -166,13 +166,14 @@ export default function TechDrawing({
 
   const doorSplits = useMemo(() => {
     if (doorsCount <= 1) return [];
-    const step = front.w / doorsCount;
+    const totalBetween = gaps.between * (doorsCount - 1);
+    const leafW = (front.w - totalBetween) / doorsCount;
     const xs: number[] = [];
     for (let i = 1; i < doorsCount; i++) {
-      xs.push(front.x + step * i);
+      xs.push(front.x + i * leafW + gaps.between * (i - 0.5));
     }
     return xs;
-  }, [doorsCount, front.w, front.x]);
+  }, [doorsCount, front.w, front.x, gaps.between]);
 
   const dividerX = useMemo(() => {
     if (!dividerPosition || doorsCount < 3) return null


### PR DESCRIPTION
## Summary
- consider between gaps when calculating door split positions
- trigger door split recalculation when gap between setting changes

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b748f3857883228c2eaa47e7aaa438