### PR TITLE
Adjust door vertical placement for type4 carcass

### DIFF
--- a/src/scene/cabinetBuilder.ts
+++ b/src/scene/cabinetBuilder.ts
@@ -801,11 +801,9 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
           gapLeft / 1000 + i * (doorW + gapBetween / 1000);
         const pivotX = hingeSide === 'left' ? leftEdge : leftEdge + doorW;
         // Hinge pivot sits 2 mm in front of the carcass, door hangs entirely in front
-        fg.position.set(
-          pivotX,
-          legHeight + gapBottom / 1000 + doorH / 2,
-          frontProj - T,
-        );
+        const baseY =
+          legHeight + (carcassType === 'type4' ? T : 0) + gapBottom / 1000 + doorH / 2;
+        fg.position.set(pivotX, baseY, frontProj - T);
         doorMesh.position.set(
           hingeSide === 'left' ? doorW / 2 : -doorW / 2,
           0,


### PR DESCRIPTION
## Summary
- adjust door hinge group position by computing `baseY` including type4 offset
## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b74e7b67f48322b11f78e87665ca81