### PR TITLE
feat: add type5 carcass translation

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -101,7 +101,8 @@
       "type1": "Type 1",
       "type2": "Type 2",
       "type3": "Type 3",
-      "type4": "Type 4"
+      "type4": "Type 4",
+      "type5": "Type 5"
     },
     "shelves": "Number of shelves",
     "gapsTitle": "Gaps and front heights (set graphically)",

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -101,7 +101,8 @@
         "type1": "Typ 1",
         "type2": "Typ 2",
         "type3": "Typ 3",
-        "type4": "Typ 4"
+        "type4": "Typ 4",
+        "type5": "Typ 5"
       },
     "shelves": "Liczba półek",
     "gapsTitle": "Szczeliny i wysokości frontów (ustawiaj graficznie)",


### PR DESCRIPTION
## Summary
- add missing type5 translation for carcass types in Polish and English i18n files

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b8017caf2c83229c8be86bb7b1544f