### PR TITLE
feat: add type5 carcass

### DIFF
--- a/src/scene/cabinetBuilder.ts
+++ b/src/scene/cabinetBuilder.ts
@@ -53,7 +53,7 @@ export interface CabinetOptions {
     left?: Record<string, any>;
     right?: Record<string, any>;
   };
-  carcassType?: 'type1' | 'type2' | 'type3' | 'type4';
+  carcassType?: 'type1' | 'type2' | 'type3' | 'type4' | 'type5';
   showFronts?: boolean;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,7 +48,7 @@ export interface GlobalsItem {
   backPanel?: 'full' | 'split' | 'none';
   topPanel?: TopPanel;
   bottomPanel?: BottomPanel;
-  carcassType?: 'type1' | 'type2' | 'type3' | 'type4';
+  carcassType?: 'type1' | 'type2' | 'type3' | 'type4' | 'type5';
 }
 
 export type Globals = Record<FAMILY, GlobalsItem>;
@@ -127,7 +127,7 @@ export interface ModuleAdv {
     left?: Record<string, any>;
     right?: Record<string, any>;
   };
-  carcassType?: 'type1' | 'type2' | 'type3' | 'type4';
+  carcassType?: 'type1' | 'type2' | 'type3' | 'type4' | 'type5';
 }
 
 export interface Module3D {

--- a/src/ui/CabinetConfigurator.tsx
+++ b/src/ui/CabinetConfigurator.tsx
@@ -312,11 +312,12 @@ const CabinetConfigurator: React.FC<Props> = ({
                       | 'type1'
                       | 'type2'
                       | 'type3'
-                      | 'type4',
+                      | 'type4'
+                      | 'type5',
                   })
                 }
               >
-                {(['type1', 'type2', 'type3', 'type4'] as const).map((type) => (
+                {(['type1', 'type2', 'type3', 'type4', 'type5'] as const).map((type) => (
                   <option key={type} value={type}>
                     {t(`configurator.carcassTypes.${type}`)}
                   </option>

--- a/src/ui/components/Cabinet3D.tsx
+++ b/src/ui/components/Cabinet3D.tsx
@@ -56,7 +56,7 @@ export default function Cabinet3D({
     left?: Record<string, any>;
     right?: Record<string, any>;
   };
-  carcassType?: 'type1' | 'type2' | 'type3' | 'type4';
+  carcassType?: 'type1' | 'type2' | 'type3' | 'type4' | 'type5';
   showFronts?: boolean;
   highlightPart?: 'top' | 'bottom' | 'shelf' | 'back' | 'leftSide' | 'rightSide' | null;
 }) {

--- a/src/ui/panels/GlobalSettings.tsx
+++ b/src/ui/panels/GlobalSettings.tsx
@@ -60,7 +60,8 @@ export default function GlobalSettings(){
                 { value: 'type1', label: t('configurator.carcassTypes.type1') },
                 { value: 'type2', label: t('configurator.carcassTypes.type2') },
                 { value: 'type3', label: t('configurator.carcassTypes.type3') },
-                { value: 'type4', label: t('configurator.carcassTypes.type4') }
+                { value: 'type4', label: t('configurator.carcassTypes.type4') },
+                { value: 'type5', label: t('configurator.carcassTypes.type5') }
               ]}
             />
             <Field

--- a/src/ui/types.ts
+++ b/src/ui/types.ts
@@ -7,7 +7,7 @@ export interface CabinetConfig {
   frontType: string;
   frontFoldable?: boolean;
   gaps: Gaps;
-  carcassType: 'type1' | 'type2' | 'type3' | 'type4';
+  carcassType: 'type1' | 'type2' | 'type3' | 'type4' | 'type5';
   shelves?: number;
   backPanel?: 'full' | 'split' | 'none';
   topPanel?: TopPanel;


### PR DESCRIPTION
## Summary
- extend carcass type unions with `type5`
- expose `type5` option in cabinet configurator and global settings

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b804bb77608322b5c213326027b539