### PR TITLE
Skip bottom side banding for type5 cabinets

### DIFF
--- a/src/scene/cabinetBuilder.ts
+++ b/src/scene/cabinetBuilder.ts
@@ -271,7 +271,7 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
         bandThickness,
       );
     }
-    if (shouldBand(banding, 'vertical', 'bottom')) {
+    if (carcassType !== 'type5' && shouldBand(banding, 'vertical', 'bottom')) {
       addBand(
         x,
         sideBottomY + offsetForEdge('bottom'),


### PR DESCRIPTION
## Summary
- avoid adding bottom edge band to side panels when carcass is type5
- ensure side panel banding uses updated rule on both sides

## Testing
- `npm test`
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b81d66f1c88322b1b291121fa100ca