### PR TITLE
Add type6 carcass type

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -102,7 +102,8 @@
       "type2": "Type 2",
       "type3": "Type 3",
       "type4": "Type 4",
-      "type5": "Type 5"
+      "type5": "Type 5",
+      "type6": "Type 6"
     },
     "shelves": "Number of shelves",
     "gapsTitle": "Gaps and front heights (set graphically)",

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -102,7 +102,8 @@
         "type2": "Typ 2",
         "type3": "Typ 3",
         "type4": "Typ 4",
-        "type5": "Typ 5"
+        "type5": "Typ 5",
+        "type6": "Typ 6"
       },
     "shelves": "Liczba półek",
     "gapsTitle": "Szczeliny i wysokości frontów (ustawiaj graficznie)",

--- a/src/scene/cabinetBuilder.ts
+++ b/src/scene/cabinetBuilder.ts
@@ -53,7 +53,7 @@ export interface CabinetOptions {
     left?: Record<string, any>;
     right?: Record<string, any>;
   };
-  carcassType?: 'type1' | 'type2' | 'type3' | 'type4' | 'type5';
+  carcassType?: 'type1' | 'type2' | 'type3' | 'type4' | 'type5' | 'type6';
   showFronts?: boolean;
 }
 
@@ -211,7 +211,7 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
   const sideHeight =
     carcassType === 'type1'
       ? H
-      : carcassType === 'type2' || carcassType === 'type5'
+      : carcassType === 'type2' || carcassType === 'type5' || carcassType === 'type6'
         ? H - T
         : H - 2 * T;
   const sideY =
@@ -219,7 +219,7 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
       ? legHeight + T + (H - T) / 2
       : carcassType === 'type3' || carcassType === 'type4'
         ? legHeight + T + (H - 2 * T) / 2
-        : carcassType === 'type5'
+        : carcassType === 'type5' || carcassType === 'type6'
           ? legHeight + (H - T) / 2
           : legHeight + H / 2;
   const sideGeo = new THREE.BoxGeometry(T, sideHeight, D);
@@ -271,7 +271,7 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
         bandThickness,
       );
     }
-    if (carcassType !== 'type5' && shouldBand(banding, 'vertical', 'bottom')) {
+    if (carcassType !== 'type5' && carcassType !== 'type6' && shouldBand(banding, 'vertical', 'bottom')) {
       addBand(
         x,
         sideBottomY + offsetForEdge('bottom'),
@@ -317,11 +317,11 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
   // Top and bottom
   const bottomWidth = carcassType === 'type1' ? W - 2 * T : W;
   const topWidth =
-    carcassType === 'type3' || carcassType === 'type4' || carcassType === 'type5'
+    carcassType === 'type3' || carcassType === 'type4' || carcassType === 'type5' || carcassType === 'type6'
       ? W
       : W - 2 * T;
   const sideInset =
-    carcassType === 'type3' || carcassType === 'type4' || carcassType === 'type5'
+    carcassType === 'type3' || carcassType === 'type4' || carcassType === 'type5' || carcassType === 'type6'
       ? 0
       : T;
   if (bottomPanel !== 'none') {
@@ -401,7 +401,7 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
       const x = W / 2;
       const y = legHeight + H - widthM / 2 - tr.offset / 1000;
       const z = isFront
-        ? carcassType === 'type4' || carcassType === 'type5'
+        ? carcassType === 'type4' || carcassType === 'type5' || carcassType === 'type6'
           ? frontProj - T / 2
           : FRONT_OFFSET - T / 2
         : -D + backT + T / 2;
@@ -447,7 +447,7 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
       let backEdge: number;
       if (isFront) {
         const frontBase =
-          carcassType === 'type4' || carcassType === 'type5' ? frontProj : 0;
+          carcassType === 'type4' || carcassType === 'type5' || carcassType === 'type6' ? frontProj : 0;
         frontEdge = frontBase - tr.offset / 1000;
         backEdge = frontEdge - widthM;
       } else {
@@ -493,9 +493,9 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
   };
   if (!topPanel || topPanel.type === 'full') {
     const topDepth =
-      carcassType === 'type4' || carcassType === 'type5' ? D + frontProj : D;
+      carcassType === 'type4' || carcassType === 'type5' || carcassType === 'type6' ? D + frontProj : D;
     const topZ =
-      carcassType === 'type4' || carcassType === 'type5'
+      carcassType === 'type4' || carcassType === 'type5' || carcassType === 'type6'
         ? -D / 2 + frontProj / 2
         : -D / 2;
     const top = new THREE.Mesh(new THREE.BoxGeometry(topWidth, T, topDepth), carcMat);
@@ -506,7 +506,7 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
     group.add(top);
     if (shouldBand(topPanelEdgeBanding, 'horizontal', 'front')) {
       const zFront =
-        carcassType === 'type4' || carcassType === 'type5'
+        carcassType === 'type4' || carcassType === 'type5' || carcassType === 'type6'
           ? frontProj + offsetForEdge('front')
           : offsetForEdge('front');
       addBand(
@@ -534,11 +534,11 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
     ) {
       const topLeft = (W - topWidth) / 2;
       const zCenter =
-        carcassType === 'type4' || carcassType === 'type5'
+        carcassType === 'type4' || carcassType === 'type5' || carcassType === 'type6'
           ? -D / 2 + frontProj / 2
           : -D / 2;
       const depth =
-        carcassType === 'type4' || carcassType === 'type5'
+        carcassType === 'type4' || carcassType === 'type5' || carcassType === 'type6'
           ? D + frontProj
           : D;
       if (shouldBand(topPanelEdgeBanding, 'horizontal', 'left')) {
@@ -759,7 +759,7 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
     const availH =
       (carcassType === 'type4'
         ? H - 2 * T
-        : carcassType === 'type5'
+        : carcassType === 'type5' || carcassType === 'type6'
           ? H - T
           : H) -
       (gapTop + gapBottom) / 1000;

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,7 +48,7 @@ export interface GlobalsItem {
   backPanel?: 'full' | 'split' | 'none';
   topPanel?: TopPanel;
   bottomPanel?: BottomPanel;
-  carcassType?: 'type1' | 'type2' | 'type3' | 'type4' | 'type5';
+  carcassType?: 'type1' | 'type2' | 'type3' | 'type4' | 'type5' | 'type6';
 }
 
 export type Globals = Record<FAMILY, GlobalsItem>;
@@ -127,7 +127,7 @@ export interface ModuleAdv {
     left?: Record<string, any>;
     right?: Record<string, any>;
   };
-  carcassType?: 'type1' | 'type2' | 'type3' | 'type4' | 'type5';
+  carcassType?: 'type1' | 'type2' | 'type3' | 'type4' | 'type5' | 'type6';
 }
 
 export interface Module3D {

--- a/src/ui/CabinetConfigurator.tsx
+++ b/src/ui/CabinetConfigurator.tsx
@@ -313,11 +313,12 @@ const CabinetConfigurator: React.FC<Props> = ({
                       | 'type2'
                       | 'type3'
                       | 'type4'
-                      | 'type5',
+                      | 'type5'
+                      | 'type6',
                   })
                 }
               >
-                {(['type1', 'type2', 'type3', 'type4', 'type5'] as const).map((type) => (
+                {(['type1', 'type2', 'type3', 'type4', 'type5', 'type6'] as const).map((type) => (
                   <option key={type} value={type}>
                     {t(`configurator.carcassTypes.${type}`)}
                   </option>

--- a/src/ui/components/Cabinet3D.tsx
+++ b/src/ui/components/Cabinet3D.tsx
@@ -56,7 +56,7 @@ export default function Cabinet3D({
     left?: Record<string, any>;
     right?: Record<string, any>;
   };
-  carcassType?: 'type1' | 'type2' | 'type3' | 'type4' | 'type5';
+  carcassType?: 'type1' | 'type2' | 'type3' | 'type4' | 'type5' | 'type6';
   showFronts?: boolean;
   highlightPart?: 'top' | 'bottom' | 'shelf' | 'back' | 'leftSide' | 'rightSide' | null;
 }) {

--- a/src/ui/panels/GlobalSettings.tsx
+++ b/src/ui/panels/GlobalSettings.tsx
@@ -61,7 +61,8 @@ export default function GlobalSettings(){
                 { value: 'type2', label: t('configurator.carcassTypes.type2') },
                 { value: 'type3', label: t('configurator.carcassTypes.type3') },
                 { value: 'type4', label: t('configurator.carcassTypes.type4') },
-                { value: 'type5', label: t('configurator.carcassTypes.type5') }
+                { value: 'type5', label: t('configurator.carcassTypes.type5') },
+                { value: 'type6', label: t('configurator.carcassTypes.type6') }
               ]}
             />
             <Field

--- a/src/ui/types.ts
+++ b/src/ui/types.ts
@@ -7,7 +7,7 @@ export interface CabinetConfig {
   frontType: string;
   frontFoldable?: boolean;
   gaps: Gaps;
-  carcassType: 'type1' | 'type2' | 'type3' | 'type4' | 'type5';
+  carcassType: 'type1' | 'type2' | 'type3' | 'type4' | 'type5' | 'type6';
   shelves?: number;
   backPanel?: 'full' | 'split' | 'none';
   topPanel?: TopPanel;

--- a/tests/cabinetBuilder.test.ts
+++ b/tests/cabinetBuilder.test.ts
@@ -259,6 +259,62 @@ describe('buildCabinetMesh', () => {
     );
   });
 
+  it('handles carcass type6 depth and front heights', () => {
+    const carcass = buildCabinetMesh({
+      width: WIDTH,
+      height: HEIGHT,
+      depth: DEPTH,
+      drawers: 0,
+      gaps: { top: 0, bottom: 0 },
+      family: FAMILY.BASE,
+      carcassType: 'type6',
+      showFronts: false,
+    });
+    carcass.updateMatrixWorld(true);
+    const carcBox = new THREE.Box3().setFromObject(carcass);
+    const carcSize = carcBox.getSize(new THREE.Vector3());
+    expect(carcSize.z).toBeCloseTo(
+      DEPTH + BOARD_THICKNESS + FRONT_OFFSET,
+      5,
+    );
+
+    const gDoor = buildCabinetMesh({
+      width: WIDTH,
+      height: HEIGHT,
+      depth: DEPTH,
+      drawers: 0,
+      gaps: { top: 0, bottom: 0 },
+      family: FAMILY.BASE,
+      carcassType: 'type6',
+    });
+    const doorGroup = gDoor.children.find(
+      (c) => c instanceof THREE.Group && (c as any).userData.type === 'door',
+    ) as THREE.Group;
+    const doorMesh = doorGroup.children[0] as THREE.Mesh;
+    expect((doorMesh.geometry as any).parameters.height).toBeCloseTo(
+      HEIGHT - BOARD_THICKNESS,
+      5,
+    );
+
+    const gDrawer = buildCabinetMesh({
+      width: WIDTH,
+      height: HEIGHT,
+      depth: DEPTH,
+      drawers: 1,
+      gaps: { top: 0, bottom: 0 },
+      family: FAMILY.BASE,
+      carcassType: 'type6',
+    });
+    const drawerGroup = gDrawer.children.find(
+      (c) => c instanceof THREE.Group && (c as any).userData.type === 'drawer',
+    ) as THREE.Group;
+    const drawerMesh = drawerGroup.children[0] as THREE.Mesh;
+    expect((drawerMesh.geometry as any).parameters.height).toBeCloseTo(
+      HEIGHT - BOARD_THICKNESS,
+      5,
+    );
+  });
+
   it('positions vertical traverse by y offset', () => {
     const offset = 100;
     const trWidth = 100;


### PR DESCRIPTION
## Summary
- expand carcassType unions to include new `type6`
- update UI selections, translations and builder logic for `type6`
- add tests verifying `type6` dimensions

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b83b7097988322b650c6c0dcd77c40