### PR TITLE
Insert bottom panel between sides for type6 carcass

### DIFF
--- a/src/scene/cabinetBuilder.ts
+++ b/src/scene/cabinetBuilder.ts
@@ -315,7 +315,8 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
   }
 
   // Top and bottom
-  const bottomWidth = carcassType === 'type1' ? W - 2 * T : W;
+  const bottomWidth =
+    carcassType === 'type1' || carcassType === 'type6' ? W - 2 * T : W;
   const topWidth =
     carcassType === 'type3' || carcassType === 'type4' || carcassType === 'type5' || carcassType === 'type6'
       ? W


### PR DESCRIPTION
## Summary
- Treat carcass type6 bottom panel like type1, inserting it between the side panels
- Confirm type6 is handled like type5 for top panel, side panel positioning, and available height calculations

## Testing
- `npm test`
- `npm run build`
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_68b86d4439e08322889383f673061850