### PR TITLE
Handle type5 side panel inset

### DIFF
--- a/src/scene/cabinetBuilder.ts
+++ b/src/scene/cabinetBuilder.ts
@@ -211,15 +211,15 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
   const sideHeight =
     carcassType === 'type1'
       ? H
-      : carcassType === 'type2' || carcassType === 'type5' || carcassType === 'type6'
+      : carcassType === 'type2' || carcassType === 'type6'
         ? H - T
         : H - 2 * T;
   const sideY =
     carcassType === 'type2'
       ? legHeight + T + (H - T) / 2
-      : carcassType === 'type3' || carcassType === 'type4'
+      : carcassType === 'type3' || carcassType === 'type4' || carcassType === 'type5'
         ? legHeight + T + (H - 2 * T) / 2
-        : carcassType === 'type5' || carcassType === 'type6'
+        : carcassType === 'type6'
           ? legHeight + (H - T) / 2
           : legHeight + H / 2;
   const sideGeo = new THREE.BoxGeometry(T, sideHeight, D);

--- a/tests/cabinetBuilder.test.ts
+++ b/tests/cabinetBuilder.test.ts
@@ -222,6 +222,21 @@ describe('buildCabinetMesh', () => {
       5,
     );
 
+    const sideMesh = carcass.children.find(
+      (c) => c instanceof THREE.Mesh && (c as any).userData.part === 'leftSide',
+    ) as THREE.Mesh;
+    expect((sideMesh.geometry as any).parameters.height).toBeCloseTo(
+      HEIGHT - 2 * BOARD_THICKNESS,
+      5,
+    );
+    const rightSide = carcass.children.find(
+      (c) => c instanceof THREE.Mesh && (c as any).userData.part === 'rightSide',
+    ) as THREE.Mesh;
+    expect((rightSide.geometry as any).parameters.height).toBeCloseTo(
+      HEIGHT - 2 * BOARD_THICKNESS,
+      5,
+    );
+
     const gDoor = buildCabinetMesh({
       width: WIDTH,
       height: HEIGHT,


### PR DESCRIPTION
## Summary
- Treat type5 cabinets like type3 by insetting side panels by top and bottom thicknesses
- Test that type5 cabinet sides are reduced by two board thicknesses

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b8783b53c083228efde92f6793ca84