### PR TITLE
Gate traverse edge banding by top panel type

### DIFF
--- a/src/ui/CabinetConfigurator.tsx
+++ b/src/ui/CabinetConfigurator.tsx
@@ -616,32 +616,38 @@ const CabinetConfigurator: React.FC<Props> = ({
                   </div>
                 )}
               </div>
-              <div style={{ marginTop: 8 }}>
-                <div className="small">{t('configurator.traverseEdgeBanding')}</div>
-                <div className="row" style={{ gap: 8 }}>
-                  {(['front', 'back', 'left', 'right'] as const).map((edge) => (
-                    <label
-                      key={edge}
-                      style={{ display: 'flex', alignItems: 'center', gap: 4 }}
-                    >
-                      <input
-                        type="checkbox"
-                        checked={gLocal.traverseEdgeBanding?.[edge] ?? false}
-                        onChange={(e) =>
-                          setAdv({
-                            ...gLocal,
-                            traverseEdgeBanding: {
-                              ...gLocal.traverseEdgeBanding,
-                              [edge]: (e.target as HTMLInputElement).checked,
-                            },
-                          })
-                        }
-                      />
-                      {t(`configurator.edgeBandingOptions.${edge}`)}
-                    </label>
-                  ))}
+              {['twoTraverses', 'frontTraverse', 'backTraverse'].includes(
+                gLocal.topPanel?.type ?? '',
+              ) && (
+                <div style={{ marginTop: 8 }}>
+                  <div className="small">
+                    {t('configurator.traverseEdgeBanding')}
+                  </div>
+                  <div className="row" style={{ gap: 8 }}>
+                    {(['front', 'back', 'left', 'right'] as const).map((edge) => (
+                      <label
+                        key={edge}
+                        style={{ display: 'flex', alignItems: 'center', gap: 4 }}
+                      >
+                        <input
+                          type="checkbox"
+                          checked={gLocal.traverseEdgeBanding?.[edge] ?? false}
+                          onChange={(e) =>
+                            setAdv({
+                              ...gLocal,
+                              traverseEdgeBanding: {
+                                ...gLocal.traverseEdgeBanding,
+                                [edge]: (e.target as HTMLInputElement).checked,
+                              },
+                            })
+                          }
+                        />
+                        {t(`configurator.edgeBandingOptions.${edge}`)}
+                      </label>
+                    ))}
+                  </div>
                 </div>
-              </div>
+              )}
             </div>
           </details>
 


### PR DESCRIPTION
## Summary
- Show traverse edge banding only when the top panel uses traverses
- Keep top panel edge banding exclusive to full top panels

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b87e88cf78832299e0a0e17206ab22