### PR TITLE
Ensure top panel edge banding is visible when top panel is selected

### DIFF
--- a/src/ui/CabinetConfigurator.tsx
+++ b/src/ui/CabinetConfigurator.tsx
@@ -57,7 +57,9 @@ const CabinetConfigurator: React.FC<Props> = ({
   const [openOkucie, setOpenOkucie] = useState(false);
   const [openNozki, setOpenNozki] = useState(false);
   const [openRysunki, setOpenRysunki] = useState(false);
-  const [openTopFrame, setOpenTopFrame] = useState(false);
+  const [openTopFrame, setOpenTopFrame] = useState(
+    gLocal.topPanel?.type === 'full',
+  );
   const [openBottomFrame, setOpenBottomFrame] = useState(false);
   const [openShelves, setOpenShelves] = useState(false);
   const [openBack, setOpenBack] = useState(false);
@@ -114,6 +116,10 @@ const CabinetConfigurator: React.FC<Props> = ({
       setAdv({ ...gLocal, dividerPosition: 'left' });
     }
   }, [doorsCount, drawersCount, gLocal]);
+
+  useEffect(() => {
+    if (gLocal.topPanel?.type === 'full') setOpenTopFrame(true);
+  }, [gLocal.topPanel?.type]);
   return (
     <div className="section">
       <div className="hd">


### PR DESCRIPTION
## Summary
- Automatically expand the top-frame section when a full top panel is chosen
- Show top panel edge banding options immediately for a "Wieniec górny" selection

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b87e05ae8083228fe785ab59433438