### PR TITLE
feat: add blenda option for side panels

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -141,6 +141,7 @@
     "bottomPanelEdgeBanding": "Bottom panel - edge banding",
     "sidePanel": "Side panel",
     "panel": "Panel",
+    "blenda": "Filler",
     "orientation": {
       "label": "Orientation",
       "horizontal": "horizontal",

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -141,6 +141,7 @@
     "bottomPanelEdgeBanding": "Wieniec dolny – okleina",
     "sidePanel": "Panel boczny",
     "panel": "Panel",
+    "blenda": "Blenda",
     "orientation": {
       "label": "Orientacja",
       "horizontal": "pozioma",

--- a/src/scene/cabinetBuilder.ts
+++ b/src/scene/cabinetBuilder.ts
@@ -1,6 +1,12 @@
 import * as THREE from 'three';
 import { FAMILY, FAMILY_COLORS } from '../core/catalog';
-import { TopPanel, BottomPanel, Traverse, EdgeBanding } from '../types';
+import {
+  TopPanel,
+  BottomPanel,
+  Traverse,
+  EdgeBanding,
+  SidePanelSpec,
+} from '../types';
 
 export type Orientation = 'vertical' | 'horizontal' | 'back';
 export type EdgeName = 'front' | 'back' | 'left' | 'right' | 'top' | 'bottom';
@@ -50,8 +56,8 @@ export interface CabinetOptions {
   topPanelEdgeBanding?: EdgeBanding;
   bottomPanelEdgeBanding?: EdgeBanding;
   sidePanels?: {
-    left?: Record<string, any>;
-    right?: Record<string, any>;
+    left?: SidePanelSpec;
+    right?: SidePanelSpec;
   };
   carcassType?: 'type1' | 'type2' | 'type3' | 'type4' | 'type5' | 'type6';
   showFronts?: boolean;
@@ -295,7 +301,7 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
   bandSide(leftSideEdgeBanding, T / 2);
   bandSide(rightSideEdgeBanding, W - T / 2);
 
-  if (sidePanels.left) {
+  if (sidePanels.left?.panel) {
     const panel = new THREE.Mesh(sideGeo.clone(), carcMat);
     panel.position.set(-T / 2, sideY, -D / 2);
     panel.userData.part = 'leftSide';
@@ -304,7 +310,7 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
     group.add(panel);
     bandSide(leftSideEdgeBanding, -T / 2);
   }
-  if (sidePanels.right) {
+  if (sidePanels.right?.panel) {
     const panel = new THREE.Mesh(sideGeo.clone(), carcMat);
     panel.position.set(W + T / 2, sideY, -D / 2);
     panel.userData.part = 'rightSide';
@@ -312,6 +318,31 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
     addEdges(panel);
     group.add(panel);
     bandSide(rightSideEdgeBanding, W + T / 2);
+  }
+
+  if (sidePanels.left?.blenda) {
+    const bl = sidePanels.left.blenda;
+    const w = bl.width / 1000;
+    const h = bl.height / 1000;
+    const geo = new THREE.BoxGeometry(w, h, T);
+    const mesh = new THREE.Mesh(geo, frontMat);
+    const baseX = sidePanels.left.panel ? -T : 0;
+    const y = legHeight + (gaps.bottom || 0) / 1000 + h / 2;
+    mesh.position.set(baseX - w / 2, y, frontProj - T / 2);
+    addEdges(mesh);
+    group.add(mesh);
+  }
+  if (sidePanels.right?.blenda) {
+    const bl = sidePanels.right.blenda;
+    const w = bl.width / 1000;
+    const h = bl.height / 1000;
+    const geo = new THREE.BoxGeometry(w, h, T);
+    const mesh = new THREE.Mesh(geo, frontMat);
+    const baseX = sidePanels.right.panel ? W + T : W;
+    const y = legHeight + (gaps.bottom || 0) / 1000 + h / 2;
+    mesh.position.set(baseX + w / 2, y, frontProj - T / 2);
+    addEdges(mesh);
+    group.add(mesh);
   }
 
   // Top and bottom

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,6 +26,16 @@ export type EdgeBanding = {
   bottom?: boolean;
 };
 
+export interface Blenda {
+  width: number;
+  height: number;
+}
+
+export interface SidePanelSpec {
+  panel?: boolean;
+  blenda?: Blenda;
+}
+
 export type TopPanel =
   | { type: 'full' }
   | { type: 'none' }
@@ -124,8 +134,8 @@ export interface ModuleAdv {
   topPanelEdgeBanding?: EdgeBanding;
   bottomPanelEdgeBanding?: EdgeBanding;
   sidePanels?: {
-    left?: Record<string, any>;
-    right?: Record<string, any>;
+    left?: SidePanelSpec;
+    right?: SidePanelSpec;
   };
   carcassType?: 'type1' | 'type2' | 'type3' | 'type4' | 'type5' | 'type6';
 }

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -30,6 +30,7 @@ export default function App() {
     setAdv,
     onAdd,
     doAutoOnSelectedWall,
+    initBlenda,
   } = useCabinetConfig(family, kind, variant, selWall, setVariant);
 
   const [tab, setTab] = useState<'cab' | 'room' | 'costs' | 'cut' | 'global' | null>(null);
@@ -73,6 +74,7 @@ export default function App() {
           gLocal={gLocal}
           setAdv={setAdv}
           onAdd={onAdd}
+          initBlenda={initBlenda}
           threeRef={threeRef}
           boardL={boardL}
           setBoardL={setBoardL}

--- a/src/ui/CabinetConfigurator.tsx
+++ b/src/ui/CabinetConfigurator.tsx
@@ -29,6 +29,7 @@ interface Props {
     doorsCount: number,
     drawersCount: number,
   ) => void;
+  initBlenda: (side: 'left' | 'right') => void;
 }
 
 const FORM_COMPONENTS: Record<string, React.ComponentType<CabinetFormProps>> = {
@@ -47,6 +48,7 @@ const CabinetConfigurator: React.FC<Props> = ({
   gLocal,
   setAdv,
   onAdd,
+  initBlenda,
 }) => {
   const prices = usePlannerStore((s) => s.prices);
   const { t } = useTranslation();
@@ -904,20 +906,97 @@ const CabinetConfigurator: React.FC<Props> = ({
               <label style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
                 <input
                   type="checkbox"
-                  checked={!!gLocal.sidePanels?.right}
+                  checked={!!gLocal.sidePanels?.right?.panel}
                   onChange={(e) => {
                     const checked = (e.target as HTMLInputElement).checked;
                     setAdv({
                       ...gLocal,
                       sidePanels: {
                         ...gLocal.sidePanels,
-                        right: checked ? { ...(gLocal.sidePanels?.right || {}) } : undefined,
+                        right: {
+                          ...(gLocal.sidePanels?.right || {}),
+                          panel: checked || undefined,
+                        },
                       },
                     });
                   }}
                 />
                 {t('configurator.panel')}
               </label>
+              <div className="small" style={{ marginTop: 8 }}>{t('configurator.blenda')}</div>
+              <label style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+                <input
+                  type="checkbox"
+                  checked={!!gLocal.sidePanels?.right?.blenda}
+                  onChange={(e) => {
+                    const checked = (e.target as HTMLInputElement).checked;
+                    if (checked) {
+                      initBlenda('right');
+                    } else {
+                      setAdv({
+                        ...gLocal,
+                        sidePanels: {
+                          ...gLocal.sidePanels,
+                          right: { ...(gLocal.sidePanels?.right || {}), blenda: undefined },
+                        },
+                      });
+                    }
+                  }}
+                />
+                {t('configurator.blenda')}
+              </label>
+              {gLocal.sidePanels?.right?.blenda && (
+                <div style={{ marginLeft: 16, display: 'flex', flexDirection: 'column', gap: 4 }}>
+                  <label className="row" style={{ gap: 4 }}>
+                    {t('configurator.width')}
+                    <input
+                      type="number"
+                      className="input"
+                      value={gLocal.sidePanels.right.blenda.width}
+                      onChange={(e) => {
+                        const width = parseFloat((e.target as HTMLInputElement).value);
+                        setAdv({
+                          ...gLocal,
+                          sidePanels: {
+                            ...gLocal.sidePanels,
+                            right: {
+                              ...(gLocal.sidePanels?.right || {}),
+                              blenda: {
+                                ...gLocal.sidePanels.right.blenda,
+                                width,
+                              },
+                            },
+                          },
+                        });
+                      }}
+                    />
+                  </label>
+                  <label className="row" style={{ gap: 4 }}>
+                    {t('configurator.height')}
+                    <input
+                      type="number"
+                      className="input"
+                      value={gLocal.sidePanels.right.blenda.height}
+                      onChange={(e) => {
+                        const height = parseFloat((e.target as HTMLInputElement).value);
+                        setAdv({
+                          ...gLocal,
+                          sidePanels: {
+                            ...gLocal.sidePanels,
+                            right: {
+                              ...(gLocal.sidePanels?.right || {}),
+                              blenda: {
+                                ...gLocal.sidePanels.right.blenda,
+                                height,
+                              },
+                            },
+                          },
+                        });
+                      }}
+                    />
+                  </label>
+                </div>
+              )}
             </div>
           </details>
 
@@ -962,20 +1041,97 @@ const CabinetConfigurator: React.FC<Props> = ({
               <label style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
                 <input
                   type="checkbox"
-                  checked={!!gLocal.sidePanels?.left}
+                  checked={!!gLocal.sidePanels?.left?.panel}
                   onChange={(e) => {
                     const checked = (e.target as HTMLInputElement).checked;
                     setAdv({
                       ...gLocal,
                       sidePanels: {
                         ...gLocal.sidePanels,
-                        left: checked ? { ...(gLocal.sidePanels?.left || {}) } : undefined,
+                        left: {
+                          ...(gLocal.sidePanels?.left || {}),
+                          panel: checked || undefined,
+                        },
                       },
                     });
                   }}
                 />
                 {t('configurator.panel')}
               </label>
+              <div className="small" style={{ marginTop: 8 }}>{t('configurator.blenda')}</div>
+              <label style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+                <input
+                  type="checkbox"
+                  checked={!!gLocal.sidePanels?.left?.blenda}
+                  onChange={(e) => {
+                    const checked = (e.target as HTMLInputElement).checked;
+                    if (checked) {
+                      initBlenda('left');
+                    } else {
+                      setAdv({
+                        ...gLocal,
+                        sidePanels: {
+                          ...gLocal.sidePanels,
+                          left: { ...(gLocal.sidePanels?.left || {}), blenda: undefined },
+                        },
+                      });
+                    }
+                  }}
+                />
+                {t('configurator.blenda')}
+              </label>
+              {gLocal.sidePanels?.left?.blenda && (
+                <div style={{ marginLeft: 16, display: 'flex', flexDirection: 'column', gap: 4 }}>
+                  <label className="row" style={{ gap: 4 }}>
+                    {t('configurator.width')}
+                    <input
+                      type="number"
+                      className="input"
+                      value={gLocal.sidePanels.left.blenda.width}
+                      onChange={(e) => {
+                        const width = parseFloat((e.target as HTMLInputElement).value);
+                        setAdv({
+                          ...gLocal,
+                          sidePanels: {
+                            ...gLocal.sidePanels,
+                            left: {
+                              ...(gLocal.sidePanels?.left || {}),
+                              blenda: {
+                                ...gLocal.sidePanels.left.blenda,
+                                width,
+                              },
+                            },
+                          },
+                        });
+                      }}
+                    />
+                  </label>
+                  <label className="row" style={{ gap: 4 }}>
+                    {t('configurator.height')}
+                    <input
+                      type="number"
+                      className="input"
+                      value={gLocal.sidePanels.left.blenda.height}
+                      onChange={(e) => {
+                        const height = parseFloat((e.target as HTMLInputElement).value);
+                        setAdv({
+                          ...gLocal,
+                          sidePanels: {
+                            ...gLocal.sidePanels,
+                            left: {
+                              ...(gLocal.sidePanels?.left || {}),
+                              blenda: {
+                                ...gLocal.sidePanels.left.blenda,
+                                height,
+                              },
+                            },
+                          },
+                        });
+                      }}
+                    />
+                  </label>
+                </div>
+              )}
             </div>
           </details>
         </div>

--- a/src/ui/MainTabs.tsx
+++ b/src/ui/MainTabs.tsx
@@ -30,6 +30,7 @@ interface MainTabsProps {
     doorsCount: number,
     drawersCount: number,
   ) => void;
+  initBlenda: (side: 'left' | 'right') => void;
   threeRef: React.MutableRefObject<any>;
   boardL: number;
   setBoardL: (v: number) => void;
@@ -58,6 +59,7 @@ export default function MainTabs({
   gLocal,
   setAdv,
   onAdd,
+  initBlenda,
   threeRef,
   boardL,
   setBoardL,
@@ -154,6 +156,7 @@ export default function MainTabs({
                 gLocal={gLocal}
                 setAdv={setAdv}
                 onAdd={onAdd}
+                initBlenda={initBlenda}
               />
             )}
 

--- a/src/ui/components/Cabinet3D.tsx
+++ b/src/ui/components/Cabinet3D.tsx
@@ -4,7 +4,7 @@ import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 import { FAMILY } from '../../core/catalog';
 import { buildCabinetMesh } from '../../scene/cabinetBuilder';
 import { usePlannerStore } from '../../state/store';
-import { TopPanel, BottomPanel, EdgeBanding } from '../../types';
+import { TopPanel, BottomPanel, EdgeBanding, SidePanelSpec } from '../../types';
 
 export default function Cabinet3D({
   widthMM,
@@ -53,8 +53,8 @@ export default function Cabinet3D({
   topPanelEdgeBanding?: EdgeBanding;
   bottomPanelEdgeBanding?: EdgeBanding;
   sidePanels?: {
-    left?: Record<string, any>;
-    right?: Record<string, any>;
+    left?: SidePanelSpec;
+    right?: SidePanelSpec;
   };
   carcassType?: 'type1' | 'type2' | 'type3' | 'type4' | 'type5' | 'type6';
   showFronts?: boolean;

--- a/src/ui/types.ts
+++ b/src/ui/types.ts
@@ -1,4 +1,10 @@
-import { Gaps, TopPanel, BottomPanel, EdgeBanding } from '../types';
+import {
+  Gaps,
+  TopPanel,
+  BottomPanel,
+  EdgeBanding,
+  SidePanelSpec,
+} from '../types';
 
 export interface CabinetConfig {
   height: number;
@@ -22,8 +28,8 @@ export interface CabinetConfig {
   topPanelEdgeBanding?: EdgeBanding;
   bottomPanelEdgeBanding?: EdgeBanding;
   sidePanels?: {
-    left?: Record<string, unknown>;
-    right?: Record<string, unknown>;
+    left?: SidePanelSpec;
+    right?: SidePanelSpec;
   };
   hardware?: any;
   legs?: any;

--- a/src/ui/useCabinetConfig.ts
+++ b/src/ui/useCabinetConfig.ts
@@ -310,6 +310,20 @@ export function useCabinetConfig(
       ...patch,
     }));
 
+  const initBlenda = (side: 'left' | 'right') => {
+    setAdvState((prev) => {
+      const cfg = prev || (store.globals[family] as CabinetConfig);
+      const h = cfg.height - (cfg.gaps.top || 0) - (cfg.gaps.bottom || 0);
+      const sidePanels = { ...(cfg.sidePanels || {}) } as CabinetConfig['sidePanels'];
+      const sideCfg = { ...(sidePanels?.[side] || {}) };
+      sidePanels![side] = {
+        ...sideCfg,
+        blenda: { width: 50, height: h },
+      };
+      return { ...cfg, sidePanels };
+    });
+  };
+
   return {
     widthMM,
     setWidthMM,
@@ -318,6 +332,7 @@ export function useCabinetConfig(
     gLocal,
     onAdd,
     doAutoOnSelectedWall,
+    initBlenda,
   };
 }
 


### PR DESCRIPTION
## Summary
- allow configuring front fillers (blenda) on left and right cabinet sides
- render blenda geometry in cabinet builder
- add missing translations and types for side panel fillers

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b88e58d9908322bf1f49a3f5b95582