### PR TITLE
feat: toggle cabinet fronts by click

### DIFF
--- a/src/ui/components/Cabinet3D.tsx
+++ b/src/ui/components/Cabinet3D.tsx
@@ -241,26 +241,25 @@ export default function Cabinet3D({
       );
       raycaster.setFromCamera(mouse, camera);
       const intersects = raycaster.intersectObjects(group.children, true);
-      let obj: THREE.Object3D | null = intersects[0]?.object || null;
-      while (obj && obj.userData.frontIndex === undefined) {
-        obj = obj.parent;
+      let obj: THREE.Object3D | null = null;
+      for (const hit of intersects) {
+        obj = hit.object;
+        while (obj && obj.userData.frontIndex === undefined) {
+          obj = obj.parent;
+        }
+        if (obj && obj.userData.frontIndex !== undefined) {
+          break;
+        }
+        obj = null;
       }
-      if (!obj || obj.userData.isHandle !== true) {
+      if (!obj) {
         return;
       }
       const frontIndex = obj.userData.frontIndex as number;
       const openStates: boolean[] = group.userData.openStates || [];
-      let changed = false;
-      openStates.forEach((_, idx) => {
-        const shouldOpen = frontIndex === idx;
-        if (openStates[idx] !== shouldOpen) {
-          openStates[idx] = shouldOpen;
-          changed = true;
-        }
-      });
-      if (changed) {
-        renderer.render(scene, camera);
-      }
+      group.userData.openStates = openStates;
+      openStates[frontIndex] = !openStates[frontIndex];
+      renderer.render(scene, camera);
     };
     renderer.domElement.addEventListener('pointerdown', handlePointer);
     return () => {


### PR DESCRIPTION
## Summary
- toggle cabinet fronts when clicked on surface or handle
- track first intersect with a front and switch its open state

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b89aa43efc83228d3d6e48a37c8d97