### PR TITLE
fix: skip ignored objects when selecting fronts

### DIFF
--- a/src/ui/SceneViewer.tsx
+++ b/src/ui/SceneViewer.tsx
@@ -152,13 +152,26 @@ const SceneViewer: React.FC<Props> = ({ threeRef, addCountertop }) => {
       raycaster.setFromCamera(mouse, camera);
       const intersects = raycaster.intersectObjects(group.children, true);
       if (intersects.length === 0) return;
-      let obj: THREE.Object3D | null = intersects[0].object;
-      while (obj && !obj.userData?.type) {
-        obj = obj.parent;
+      let obj: THREE.Object3D | null = null;
+      for (const inter of intersects) {
+        obj = inter.object;
+        let ignore = false;
+        while (obj) {
+          if (obj.userData?.ignoreRaycast) {
+            ignore = true;
+            break;
+          }
+          if (obj.userData?.frontIndex !== undefined) break;
+          obj = obj.parent;
+        }
+        if (ignore || !obj || obj.userData?.frontIndex === undefined) {
+          obj = null;
+          continue;
+        }
+        break;
       }
-      if (!obj || !obj.userData) return;
+      if (!obj || obj.userData?.frontIndex === undefined) return;
       const { frontIndex } = obj.userData as { frontIndex?: number };
-      if (frontIndex === undefined) return;
       let cab: THREE.Object3D | null = obj;
       while (cab && cab.userData?.kind !== 'cab') {
         cab = cab.parent;


### PR DESCRIPTION
## Summary
- iterate over raycast intersections to find first ancestor with frontIndex
- ignore objects marked with `userData.ignoreRaycast` so they don't block fronts

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b89c91a1c08322b7d5acdac83dc602