### PR TITLE
Fix edge band raycasting

### DIFF
--- a/src/scene/cabinetBuilder.ts
+++ b/src/scene/cabinetBuilder.ts
@@ -195,6 +195,7 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
     const geo = new THREE.BoxGeometry(w, h, d);
     const mesh = new THREE.Mesh(geo, bandMat);
     mesh.position.set(x, y, z);
+    mesh.userData.ignoreRaycast = true;
     group.add(mesh);
   };
 

--- a/src/ui/components/Cabinet3D.tsx
+++ b/src/ui/components/Cabinet3D.tsx
@@ -244,13 +244,20 @@ export default function Cabinet3D({
       let obj: THREE.Object3D | null = null;
       for (const hit of intersects) {
         obj = hit.object;
-        while (obj && obj.userData.frontIndex === undefined) {
+        let ignore = false;
+        while (obj) {
+          if (obj.userData?.ignoreRaycast) {
+            ignore = true;
+            break;
+          }
+          if (obj.userData.frontIndex !== undefined) break;
           obj = obj.parent;
         }
-        if (obj && obj.userData.frontIndex !== undefined) {
-          break;
+        if (ignore || !obj || obj.userData.frontIndex === undefined) {
+          obj = null;
+          continue;
         }
-        obj = null;
+        break;
       }
       if (!obj) {
         return;

--- a/tests/raycast-ignore.test.ts
+++ b/tests/raycast-ignore.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import * as THREE from 'three';
+
+// A helper replicating the core of handlePointer logic for ignoring raycast objects
+const selectFront = (group: THREE.Group, raycaster: THREE.Raycaster) => {
+  const intersects = raycaster.intersectObjects(group.children, true);
+  let obj: THREE.Object3D | null = null;
+  for (const hit of intersects) {
+    obj = hit.object;
+    let ignore = false;
+    while (obj) {
+      if (obj.userData?.ignoreRaycast) {
+        ignore = true;
+        break;
+      }
+      if (obj.userData.frontIndex !== undefined) break;
+      obj = obj.parent as THREE.Object3D | null;
+    }
+    if (ignore || !obj || obj.userData.frontIndex === undefined) {
+      obj = null;
+      continue;
+    }
+    break;
+  }
+  return obj?.userData.frontIndex;
+};
+
+describe('handlePointer raycast ignoring', () => {
+  it('toggles front state despite edge band in front', () => {
+    const group = new THREE.Group();
+    const door = new THREE.Mesh(
+      new THREE.BoxGeometry(1, 1, 0.02),
+      new THREE.MeshBasicMaterial(),
+    );
+    door.userData.frontIndex = 0;
+    group.add(door);
+    const band = new THREE.Mesh(
+      new THREE.BoxGeometry(1, 1, 0.001),
+      new THREE.MeshBasicMaterial(),
+    );
+    band.position.set(0, 0, 0.011);
+    band.userData.ignoreRaycast = true;
+    group.add(band);
+    const raycaster = new THREE.Raycaster(
+      new THREE.Vector3(0, 0, 1),
+      new THREE.Vector3(0, 0, -1),
+    );
+    const frontIndex = selectFront(group, raycaster);
+    const openStates = [false];
+    if (frontIndex !== undefined && frontIndex >= 0) {
+      openStates[frontIndex] = !openStates[frontIndex];
+    }
+    expect(openStates[0]).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- ignore raycasts on edge band meshes
- avoid selecting ignored meshes in Cabinet3D
- add regression test ensuring fronts toggle even when banded

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b89d6eebbc8322a8ec722b90bc9e55