### PR TITLE
Ignore handles when selecting cabinet fronts

### DIFF
--- a/src/scene/cabinetBuilder.ts
+++ b/src/scene/cabinetBuilder.ts
@@ -211,6 +211,7 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
       new THREE.EdgesGeometry(mesh.geometry),
       edgeMat,
     );
+    e.userData.ignoreRaycast = true;
     mesh.add(e);
   };
 

--- a/src/ui/SceneViewer.tsx
+++ b/src/ui/SceneViewer.tsx
@@ -168,6 +168,15 @@ const SceneViewer: React.FC<Props> = ({ threeRef, addCountertop }) => {
           obj = null;
           continue;
         }
+        if (obj.userData.isHandle) {
+          obj = obj.parent;
+          if (!obj || obj.userData?.frontIndex === undefined) {
+            obj = null;
+          } else {
+            obj = null;
+          }
+          break;
+        }
         break;
       }
       if (!obj || obj.userData?.frontIndex === undefined) return;

--- a/src/ui/components/Cabinet3D.tsx
+++ b/src/ui/components/Cabinet3D.tsx
@@ -257,6 +257,15 @@ export default function Cabinet3D({
           obj = null;
           continue;
         }
+        if (obj.userData.isHandle) {
+          obj = obj.parent;
+          if (!obj || obj.userData.frontIndex === undefined) {
+            obj = null;
+          } else {
+            obj = null;
+          }
+          break;
+        }
         break;
       }
       if (!obj) {

--- a/tests/manual/front-clicking.md
+++ b/tests/manual/front-clicking.md
@@ -1,0 +1,6 @@
+# Front surface clicking
+
+1. Uruchom tryb podglądu sceny lub komponent Cabinet3D.
+2. Kliknij na płaską powierzchnię frontu – front powinien się otworzyć.
+3. Kliknij na uchwyt frontu – front **nie** powinien się otworzyć.
+4. Kliknij na obrzeże frontu – front **nie** powinien się otworzyć.

--- a/tests/raycast-ignore.test.ts
+++ b/tests/raycast-ignore.test.ts
@@ -20,6 +20,15 @@ const selectFront = (group: THREE.Group, raycaster: THREE.Raycaster) => {
       obj = null;
       continue;
     }
+    if (obj.userData.isHandle) {
+      obj = obj.parent as THREE.Object3D | null;
+      if (!obj || obj.userData.frontIndex === undefined) {
+        obj = null;
+      } else {
+        obj = null;
+      }
+      break;
+    }
     break;
   }
   return obj?.userData.frontIndex;
@@ -51,5 +60,32 @@ describe('handlePointer raycast ignoring', () => {
       openStates[frontIndex] = !openStates[frontIndex];
     }
     expect(openStates[0]).toBe(true);
+  });
+
+  it('does not toggle when clicking handle', () => {
+    const group = new THREE.Group();
+    const door = new THREE.Mesh(
+      new THREE.BoxGeometry(1, 1, 0.02),
+      new THREE.MeshBasicMaterial(),
+    );
+    door.userData.frontIndex = 0;
+    const handle = new THREE.Mesh(
+      new THREE.BoxGeometry(0.1, 0.02, 0.03),
+      new THREE.MeshBasicMaterial(),
+    );
+    handle.position.set(1.2, 0.4, 0.02);
+    handle.userData = { frontIndex: 0, isHandle: true };
+    group.add(door);
+    group.add(handle);
+    const raycaster = new THREE.Raycaster(
+      new THREE.Vector3(1.2, 0.4, 1),
+      new THREE.Vector3(0, 0, -1),
+    );
+    const frontIndex = selectFront(group, raycaster);
+    const openStates = [false];
+    if (frontIndex !== undefined && frontIndex >= 0) {
+      openStates[frontIndex] = !openStates[frontIndex];
+    }
+    expect(openStates[0]).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- Mark edge lines as `ignoreRaycast`
- Skip cabinet handle meshes when raycasting for front toggling
- Add manual and automated tests ensuring only front surfaces open

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b8af9d4104832293d0c6b1d3ba7cc6