### PR TITLE
feat: allow custom side panel dimensions

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -141,6 +141,8 @@
     "bottomPanelEdgeBanding": "Bottom panel - edge banding",
     "sidePanel": "Side panel",
     "panel": "Panel",
+    "panelWidth": "Panel width (mm)",
+    "panelHeight": "Panel height (mm)",
     "blenda": "Filler",
     "orientation": {
       "label": "Orientation",

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -141,6 +141,8 @@
     "bottomPanelEdgeBanding": "Wieniec dolny – okleina",
     "sidePanel": "Panel boczny",
     "panel": "Panel",
+    "panelWidth": "Szerokość panelu (mm)",
+    "panelHeight": "Wysokość panelu (mm)",
     "blenda": "Blenda",
     "orientation": {
       "label": "Orientacja",

--- a/src/scene/cabinetBuilder.ts
+++ b/src/scene/cabinetBuilder.ts
@@ -303,23 +303,74 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
   bandSide(leftSideEdgeBanding, T / 2);
   bandSide(rightSideEdgeBanding, W - T / 2);
 
+  const bandPanel = (
+    banding: EdgeBanding | undefined,
+    x: number,
+    h: number,
+    w: number,
+  ) => {
+    const centerY = sideBottomY + h / 2;
+    const bottomY = sideBottomY;
+    const topY = bottomY + h;
+    if (shouldBand(banding, 'vertical', 'front')) {
+      addBand(x, centerY, offsetForEdge('front'), T, h, bandThickness);
+    }
+    if (shouldBand(banding, 'vertical', 'back')) {
+      addBand(x, centerY, -w + offsetForEdge('back'), T, h, bandThickness);
+    }
+    if (shouldBand(banding, 'vertical', 'left')) {
+      addBand(
+        x,
+        bottomY + offsetForEdge('bottom'),
+        offsetForEdge('front'),
+        T,
+        bandThickness,
+        bandThickness,
+      );
+    }
+    if (shouldBand(banding, 'vertical', 'right')) {
+      addBand(
+        x,
+        topY + offsetForEdge('top'),
+        offsetForEdge('front'),
+        T,
+        bandThickness,
+        bandThickness,
+      );
+    }
+    if (carcassType !== 'type5' && shouldBand(banding, 'vertical', 'bottom')) {
+      addBand(x, bottomY + offsetForEdge('bottom'), -w / 2, T, bandThickness, w);
+    }
+    if (shouldBand(banding, 'vertical', 'top')) {
+      addBand(x, topY + offsetForEdge('top'), -w / 2, T, bandThickness, w);
+    }
+  };
+
   if (sidePanels.left?.panel) {
-    const panel = new THREE.Mesh(sideGeo.clone(), carcMat);
-    panel.position.set(-T / 2, sideY, -D / 2);
+    const pw = (sidePanels.left.width ?? D * 1000) / 1000;
+    const ph = (sidePanels.left.height ?? sideHeight * 1000) / 1000;
+    const geo = new THREE.BoxGeometry(T, ph, pw);
+    const panel = new THREE.Mesh(geo, carcMat);
+    const y = sideBottomY + ph / 2;
+    panel.position.set(-T / 2, y, -pw / 2);
     panel.userData.part = 'leftSide';
     panel.userData.originalMaterial = panel.material;
     addEdges(panel);
     group.add(panel);
-    bandSide(leftSideEdgeBanding, -T / 2);
+    bandPanel(leftSideEdgeBanding, -T / 2, ph, pw);
   }
   if (sidePanels.right?.panel) {
-    const panel = new THREE.Mesh(sideGeo.clone(), carcMat);
-    panel.position.set(W + T / 2, sideY, -D / 2);
+    const pw = (sidePanels.right.width ?? D * 1000) / 1000;
+    const ph = (sidePanels.right.height ?? sideHeight * 1000) / 1000;
+    const geo = new THREE.BoxGeometry(T, ph, pw);
+    const panel = new THREE.Mesh(geo, carcMat);
+    const y = sideBottomY + ph / 2;
+    panel.position.set(W + T / 2, y, -pw / 2);
     panel.userData.part = 'rightSide';
     panel.userData.originalMaterial = panel.material;
     addEdges(panel);
     group.add(panel);
-    bandSide(rightSideEdgeBanding, W + T / 2);
+    bandPanel(rightSideEdgeBanding, W + T / 2, ph, pw);
   }
 
   if (sidePanels.left?.blenda) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,6 +33,10 @@ export interface Blenda {
 
 export interface SidePanelSpec {
   panel?: boolean;
+  /** width in millimetres */
+  width?: number;
+  /** height in millimetres */
+  height?: number;
   blenda?: Blenda;
 }
 

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -31,6 +31,7 @@ export default function App() {
     onAdd,
     doAutoOnSelectedWall,
     initBlenda,
+    initSidePanel,
   } = useCabinetConfig(family, kind, variant, selWall, setVariant);
 
   const [tab, setTab] = useState<'cab' | 'room' | 'costs' | 'cut' | 'global' | null>(null);
@@ -75,6 +76,7 @@ export default function App() {
           setAdv={setAdv}
           onAdd={onAdd}
           initBlenda={initBlenda}
+          initSidePanel={initSidePanel}
           threeRef={threeRef}
           boardL={boardL}
           setBoardL={setBoardL}

--- a/src/ui/CabinetConfigurator.tsx
+++ b/src/ui/CabinetConfigurator.tsx
@@ -30,6 +30,7 @@ interface Props {
     drawersCount: number,
   ) => void;
   initBlenda: (side: 'left' | 'right') => void;
+  initSidePanel: (side: 'left' | 'right') => void;
 }
 
 const FORM_COMPONENTS: Record<string, React.ComponentType<CabinetFormProps>> = {
@@ -49,6 +50,7 @@ const CabinetConfigurator: React.FC<Props> = ({
   setAdv,
   onAdd,
   initBlenda,
+  initSidePanel,
 }) => {
   const prices = usePlannerStore((s) => s.prices);
   const { t } = useTranslation();
@@ -909,20 +911,66 @@ const CabinetConfigurator: React.FC<Props> = ({
                   checked={!!gLocal.sidePanels?.right?.panel}
                   onChange={(e) => {
                     const checked = (e.target as HTMLInputElement).checked;
-                    setAdv({
-                      ...gLocal,
-                      sidePanels: {
-                        ...gLocal.sidePanels,
-                        right: {
-                          ...(gLocal.sidePanels?.right || {}),
-                          panel: checked || undefined,
+                    if (checked) {
+                      initSidePanel('right');
+                    } else {
+                      setAdv({
+                        ...gLocal,
+                        sidePanels: {
+                          ...gLocal.sidePanels,
+                          right: {
+                            ...(gLocal.sidePanels?.right || {}),
+                            panel: undefined,
+                            width: undefined,
+                            height: undefined,
+                          },
                         },
-                      },
-                    });
+                      });
+                    }
                   }}
                 />
                 {t('configurator.panel')}
               </label>
+              {gLocal.sidePanels?.right?.panel && (
+                <div style={{ marginLeft: 16, display: 'flex', flexDirection: 'column', gap: 4 }}>
+                  <label className="row" style={{ gap: 4 }}>
+                    {t('configurator.panelWidth')}
+                    <input
+                      type="number"
+                      className="input"
+                      value={gLocal.sidePanels.right.width}
+                      onChange={(e) => {
+                        const width = parseFloat((e.target as HTMLInputElement).value);
+                        setAdv({
+                          ...gLocal,
+                          sidePanels: {
+                            ...gLocal.sidePanels,
+                            right: { ...(gLocal.sidePanels?.right || {}), width },
+                          },
+                        });
+                      }}
+                    />
+                  </label>
+                  <label className="row" style={{ gap: 4 }}>
+                    {t('configurator.panelHeight')}
+                    <input
+                      type="number"
+                      className="input"
+                      value={gLocal.sidePanels.right.height}
+                      onChange={(e) => {
+                        const height = parseFloat((e.target as HTMLInputElement).value);
+                        setAdv({
+                          ...gLocal,
+                          sidePanels: {
+                            ...gLocal.sidePanels,
+                            right: { ...(gLocal.sidePanels?.right || {}), height },
+                          },
+                        });
+                      }}
+                    />
+                  </label>
+                </div>
+              )}
               <div className="small" style={{ marginTop: 8 }}>{t('configurator.blenda')}</div>
               <label style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
                 <input
@@ -1044,20 +1092,66 @@ const CabinetConfigurator: React.FC<Props> = ({
                   checked={!!gLocal.sidePanels?.left?.panel}
                   onChange={(e) => {
                     const checked = (e.target as HTMLInputElement).checked;
-                    setAdv({
-                      ...gLocal,
-                      sidePanels: {
-                        ...gLocal.sidePanels,
-                        left: {
-                          ...(gLocal.sidePanels?.left || {}),
-                          panel: checked || undefined,
+                    if (checked) {
+                      initSidePanel('left');
+                    } else {
+                      setAdv({
+                        ...gLocal,
+                        sidePanels: {
+                          ...gLocal.sidePanels,
+                          left: {
+                            ...(gLocal.sidePanels?.left || {}),
+                            panel: undefined,
+                            width: undefined,
+                            height: undefined,
+                          },
                         },
-                      },
-                    });
+                      });
+                    }
                   }}
                 />
                 {t('configurator.panel')}
               </label>
+              {gLocal.sidePanels?.left?.panel && (
+                <div style={{ marginLeft: 16, display: 'flex', flexDirection: 'column', gap: 4 }}>
+                  <label className="row" style={{ gap: 4 }}>
+                    {t('configurator.panelWidth')}
+                    <input
+                      type="number"
+                      className="input"
+                      value={gLocal.sidePanels.left.width}
+                      onChange={(e) => {
+                        const width = parseFloat((e.target as HTMLInputElement).value);
+                        setAdv({
+                          ...gLocal,
+                          sidePanels: {
+                            ...gLocal.sidePanels,
+                            left: { ...(gLocal.sidePanels?.left || {}), width },
+                          },
+                        });
+                      }}
+                    />
+                  </label>
+                  <label className="row" style={{ gap: 4 }}>
+                    {t('configurator.panelHeight')}
+                    <input
+                      type="number"
+                      className="input"
+                      value={gLocal.sidePanels.left.height}
+                      onChange={(e) => {
+                        const height = parseFloat((e.target as HTMLInputElement).value);
+                        setAdv({
+                          ...gLocal,
+                          sidePanels: {
+                            ...gLocal.sidePanels,
+                            left: { ...(gLocal.sidePanels?.left || {}), height },
+                          },
+                        });
+                      }}
+                    />
+                  </label>
+                </div>
+              )}
               <div className="small" style={{ marginTop: 8 }}>{t('configurator.blenda')}</div>
               <label style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
                 <input

--- a/src/ui/MainTabs.tsx
+++ b/src/ui/MainTabs.tsx
@@ -31,6 +31,7 @@ interface MainTabsProps {
     drawersCount: number,
   ) => void;
   initBlenda: (side: 'left' | 'right') => void;
+  initSidePanel: (side: 'left' | 'right') => void;
   threeRef: React.MutableRefObject<any>;
   boardL: number;
   setBoardL: (v: number) => void;
@@ -60,6 +61,7 @@ export default function MainTabs({
   setAdv,
   onAdd,
   initBlenda,
+  initSidePanel,
   threeRef,
   boardL,
   setBoardL,
@@ -157,6 +159,7 @@ export default function MainTabs({
                 setAdv={setAdv}
                 onAdd={onAdd}
                 initBlenda={initBlenda}
+                initSidePanel={initSidePanel}
               />
             )}
 

--- a/src/ui/useCabinetConfig.ts
+++ b/src/ui/useCabinetConfig.ts
@@ -310,6 +310,22 @@ export function useCabinetConfig(
       ...patch,
     }));
 
+  const initSidePanel = (side: 'left' | 'right') => {
+    setAdvState((prev) => {
+      const cfg = prev || (store.globals[family] as CabinetConfig);
+      const height = cfg.height - (cfg.gaps.top || 0) - (cfg.gaps.bottom || 0);
+      const sidePanels = { ...(cfg.sidePanels || {}) } as CabinetConfig['sidePanels'];
+      const sideCfg = { ...(sidePanels?.[side] || {}) };
+      sidePanels![side] = {
+        ...sideCfg,
+        panel: true,
+        width: sideCfg.width ?? cfg.depth,
+        height: sideCfg.height ?? height,
+      };
+      return { ...cfg, sidePanels };
+    });
+  };
+
   const initBlenda = (side: 'left' | 'right') => {
     setAdvState((prev) => {
       const cfg = prev || (store.globals[family] as CabinetConfig);
@@ -332,6 +348,7 @@ export function useCabinetConfig(
     gLocal,
     onAdd,
     doAutoOnSelectedWall,
+    initSidePanel,
     initBlenda,
   };
 }


### PR DESCRIPTION
## Summary
- add optional width/height to side panel specs
- default and edit side panel dimensions in configurator
- build side panels with custom geometry and translations for panel size

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b9520116fc83228166c8ca0470fec1