### PR TITLE
Validate side panel dimensions

### DIFF
--- a/src/scene/cabinetBuilder.ts
+++ b/src/scene/cabinetBuilder.ts
@@ -6,6 +6,7 @@ import {
   Traverse,
   EdgeBanding,
   SidePanelSpec,
+  hasValidSidePanelDimensions,
 } from '../types';
 
 export type Orientation = 'vertical' | 'horizontal' | 'back';
@@ -231,9 +232,11 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
           ? legHeight + (H - T) / 2
           : legHeight + H / 2;
   const sideBottomY = sideY - sideHeight / 2;
-  const leftWidth = sidePanels.left?.width ? sidePanels.left.width / 1000 : D;
-  const leftHeight = sidePanels.left?.height ? sidePanels.left.height / 1000 : sideHeight;
-  const leftBottom = sidePanels.left?.width || sidePanels.left?.height
+  const leftSpec = sidePanels.left;
+  const leftValid = hasValidSidePanelDimensions(leftSpec);
+  const leftWidth = leftValid ? leftSpec.width / 1000 : D;
+  const leftHeight = leftValid ? leftSpec.height / 1000 : sideHeight;
+  const leftBottom = leftValid
     ? legHeight + (gaps.bottom || 0) / 1000
     : sideBottomY;
   const leftGeo = new THREE.BoxGeometry(T, leftHeight, leftWidth);
@@ -243,9 +246,11 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
   leftSide.userData.originalMaterial = leftSide.material;
   addEdges(leftSide);
   group.add(leftSide);
-  const rightWidth = sidePanels.right?.width ? sidePanels.right.width / 1000 : D;
-  const rightHeight = sidePanels.right?.height ? sidePanels.right.height / 1000 : sideHeight;
-  const rightBottom = sidePanels.right?.width || sidePanels.right?.height
+  const rightSpec = sidePanels.right;
+  const rightValid = hasValidSidePanelDimensions(rightSpec);
+  const rightWidth = rightValid ? rightSpec.width / 1000 : D;
+  const rightHeight = rightValid ? rightSpec.height / 1000 : sideHeight;
+  const rightBottom = rightValid
     ? legHeight + (gaps.bottom || 0) / 1000
     : sideBottomY;
   const rightGeo = new THREE.BoxGeometry(T, rightHeight, rightWidth);
@@ -343,7 +348,7 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
     }
   };
 
-  if (sidePanels.left?.panel && sidePanels.left.width && sidePanels.left.height) {
+  if (sidePanels.left?.panel && hasValidSidePanelDimensions(sidePanels.left)) {
     const pw = sidePanels.left.width / 1000;
     const ph = sidePanels.left.height / 1000;
     const geo = new THREE.BoxGeometry(T, ph, pw);
@@ -357,7 +362,7 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
     group.add(panel);
     bandPanel(leftSideEdgeBanding, -T / 2, bottom, ph, pw);
   }
-  if (sidePanels.right?.panel && sidePanels.right.width && sidePanels.right.height) {
+  if (sidePanels.right?.panel && hasValidSidePanelDimensions(sidePanels.right)) {
     const pw = sidePanels.right.width / 1000;
     const ph = sidePanels.right.height / 1000;
     const geo = new THREE.BoxGeometry(T, ph, pw);

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,6 +40,24 @@ export interface SidePanelSpec {
   blenda?: Blenda;
 }
 
+/**
+ * Type guard ensuring side panel specifications include numeric dimensions.
+ * Used before attempting to build meshes that rely on width/height.
+ */
+export function hasValidSidePanelDimensions(
+  spec?: SidePanelSpec,
+): spec is SidePanelSpec & { width: number; height: number } {
+  return (
+    !!spec &&
+    typeof spec.width === 'number' &&
+    typeof spec.height === 'number' &&
+    Number.isFinite(spec.width) &&
+    Number.isFinite(spec.height) &&
+    spec.width > 0 &&
+    spec.height > 0
+  );
+}
+
 export type TopPanel =
   | { type: 'full' }
   | { type: 'none' }

--- a/src/ui/CabinetConfigurator.tsx
+++ b/src/ui/CabinetConfigurator.tsx
@@ -171,9 +171,10 @@ const CabinetConfigurator: React.FC<Props> = ({
                 max={2400}
                 step={1}
                 value={widthMM}
-                onChange={(e) =>
-                  setWidthMM(Number((e.target as HTMLInputElement).value) || 0)
-                }
+                onChange={(e) => {
+                  const val = parseFloat((e.target as HTMLInputElement).value);
+                  setWidthMM(Number.isFinite(val) && val > 0 ? val : 0);
+                }}
                 onKeyDown={(e) => {
                   if (e.key === 'Enter') {
                     const v = Number((e.target as HTMLInputElement).value) || 0;
@@ -262,9 +263,10 @@ const CabinetConfigurator: React.FC<Props> = ({
                 max={2400}
                 step={1}
                 value={widthMM}
-                onChange={(e) =>
-                  setWidthMM(Number((e.target as HTMLInputElement).value) || 0)
-                }
+                onChange={(e) => {
+                  const val = parseFloat((e.target as HTMLInputElement).value);
+                  setWidthMM(Number.isFinite(val) && val > 0 ? val : 0);
+                }}
               />
             </div>
             <div>
@@ -273,12 +275,13 @@ const CabinetConfigurator: React.FC<Props> = ({
                 className="input"
                 type="number"
                 value={gLocal.height}
-                onChange={(e) =>
+                onChange={(e) => {
+                  const val = parseFloat((e.target as HTMLInputElement).value);
                   setAdv({
                     ...gLocal,
-                    height: Number((e.target as HTMLInputElement).value) || 0,
-                  })
-                }
+                    height: Number.isFinite(val) && val > 0 ? val : 0,
+                  });
+                }}
               />
             </div>
             <div>
@@ -938,9 +941,11 @@ const CabinetConfigurator: React.FC<Props> = ({
                     <input
                       type="number"
                       className="input"
-                      value={gLocal.sidePanels.right.width}
+                      min={1}
+                      value={gLocal.sidePanels.right.width ?? ''}
                       onChange={(e) => {
-                        const width = parseFloat((e.target as HTMLInputElement).value);
+                        const val = parseFloat((e.target as HTMLInputElement).value);
+                        const width = Number.isFinite(val) && val > 0 ? val : undefined;
                         setAdv({
                           ...gLocal,
                           sidePanels: {
@@ -956,9 +961,11 @@ const CabinetConfigurator: React.FC<Props> = ({
                     <input
                       type="number"
                       className="input"
-                      value={gLocal.sidePanels.right.height}
+                      min={1}
+                      value={gLocal.sidePanels.right.height ?? ''}
                       onChange={(e) => {
-                        const height = parseFloat((e.target as HTMLInputElement).value);
+                        const val = parseFloat((e.target as HTMLInputElement).value);
+                        const height = Number.isFinite(val) && val > 0 ? val : undefined;
                         setAdv({
                           ...gLocal,
                           sidePanels: {
@@ -1000,9 +1007,11 @@ const CabinetConfigurator: React.FC<Props> = ({
                     <input
                       type="number"
                       className="input"
-                      value={gLocal.sidePanels.right.blenda.width}
+                      min={1}
+                      value={gLocal.sidePanels.right.blenda.width ?? ''}
                       onChange={(e) => {
-                        const width = parseFloat((e.target as HTMLInputElement).value);
+                        const val = parseFloat((e.target as HTMLInputElement).value);
+                        const width = Number.isFinite(val) && val > 0 ? val : undefined;
                         setAdv({
                           ...gLocal,
                           sidePanels: {
@@ -1024,9 +1033,11 @@ const CabinetConfigurator: React.FC<Props> = ({
                     <input
                       type="number"
                       className="input"
-                      value={gLocal.sidePanels.right.blenda.height}
+                      min={1}
+                      value={gLocal.sidePanels.right.blenda.height ?? ''}
                       onChange={(e) => {
-                        const height = parseFloat((e.target as HTMLInputElement).value);
+                        const val = parseFloat((e.target as HTMLInputElement).value);
+                        const height = Number.isFinite(val) && val > 0 ? val : undefined;
                         setAdv({
                           ...gLocal,
                           sidePanels: {
@@ -1119,9 +1130,11 @@ const CabinetConfigurator: React.FC<Props> = ({
                     <input
                       type="number"
                       className="input"
-                      value={gLocal.sidePanels.left.width}
+                      min={1}
+                      value={gLocal.sidePanels.left.width ?? ''}
                       onChange={(e) => {
-                        const width = parseFloat((e.target as HTMLInputElement).value);
+                        const val = parseFloat((e.target as HTMLInputElement).value);
+                        const width = Number.isFinite(val) && val > 0 ? val : undefined;
                         setAdv({
                           ...gLocal,
                           sidePanels: {
@@ -1137,9 +1150,11 @@ const CabinetConfigurator: React.FC<Props> = ({
                     <input
                       type="number"
                       className="input"
-                      value={gLocal.sidePanels.left.height}
+                      min={1}
+                      value={gLocal.sidePanels.left.height ?? ''}
                       onChange={(e) => {
-                        const height = parseFloat((e.target as HTMLInputElement).value);
+                        const val = parseFloat((e.target as HTMLInputElement).value);
+                        const height = Number.isFinite(val) && val > 0 ? val : undefined;
                         setAdv({
                           ...gLocal,
                           sidePanels: {
@@ -1181,9 +1196,11 @@ const CabinetConfigurator: React.FC<Props> = ({
                     <input
                       type="number"
                       className="input"
-                      value={gLocal.sidePanels.left.blenda.width}
+                      min={1}
+                      value={gLocal.sidePanels.left.blenda.width ?? ''}
                       onChange={(e) => {
-                        const width = parseFloat((e.target as HTMLInputElement).value);
+                        const val = parseFloat((e.target as HTMLInputElement).value);
+                        const width = Number.isFinite(val) && val > 0 ? val : undefined;
                         setAdv({
                           ...gLocal,
                           sidePanels: {
@@ -1205,9 +1222,11 @@ const CabinetConfigurator: React.FC<Props> = ({
                     <input
                       type="number"
                       className="input"
-                      value={gLocal.sidePanels.left.blenda.height}
+                      min={1}
+                      value={gLocal.sidePanels.left.blenda.height ?? ''}
                       onChange={(e) => {
-                        const height = parseFloat((e.target as HTMLInputElement).value);
+                        const val = parseFloat((e.target as HTMLInputElement).value);
+                        const height = Number.isFinite(val) && val > 0 ? val : undefined;
                         setAdv({
                           ...gLocal,
                           sidePanels: {


### PR DESCRIPTION
## Summary
- add type guard to verify side panel specs include numeric width/height
- use helper in cabinet builder and clamp panel dimensions to cabinet defaults when invalid
- restrict UI inputs to positive numbers for side panels and related blenda sizes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b962d894588322a9037efde5ae73ff