### PR TITLE
Add drop-to-floor option for side panels

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -143,6 +143,7 @@
     "panel": "Panel",
     "panelWidth": "Panel width (mm)",
     "panelHeight": "Panel height (mm)",
+    "dropToFloor": "Drop to floor",
     "blenda": "Filler",
     "orientation": {
       "label": "Orientation",

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -143,6 +143,7 @@
     "panel": "Panel",
     "panelWidth": "Szerokość panelu (mm)",
     "panelHeight": "Wysokość panelu (mm)",
+    "dropToFloor": "Opuść do ziemi",
     "blenda": "Blenda",
     "orientation": {
       "label": "Orientacja",

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,6 +38,7 @@ export interface SidePanelSpec {
   /** height in millimetres */
   height?: number;
   blenda?: Blenda;
+  dropToFloor?: boolean;
 }
 
 /**

--- a/src/ui/types.ts
+++ b/src/ui/types.ts
@@ -28,8 +28,8 @@ export interface CabinetConfig {
   topPanelEdgeBanding?: EdgeBanding;
   bottomPanelEdgeBanding?: EdgeBanding;
   sidePanels?: {
-    left?: SidePanelSpec;
-    right?: SidePanelSpec;
+    left?: SidePanelSpec & { dropToFloor?: boolean };
+    right?: SidePanelSpec & { dropToFloor?: boolean };
   };
   hardware?: any;
   legs?: any;

--- a/src/ui/useCabinetConfig.ts
+++ b/src/ui/useCabinetConfig.ts
@@ -321,6 +321,7 @@ export function useCabinetConfig(
         panel: true,
         width: sideCfg.width ?? cfg.depth,
         height: sideCfg.height ?? height,
+        dropToFloor: false,
       };
       return { ...cfg, sidePanels };
     });


### PR DESCRIPTION
## Summary
- extend `SidePanelSpec` and UI config with optional `dropToFloor`
- default side panels to `dropToFloor: false` on initialization
- add English and Polish translations for "Drop to floor"

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9674fd3a483228cfaf71bc5c9c171