### PR TITLE
feat: add drop-to-floor option for side panels

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -143,6 +143,7 @@
     "panel": "Panel",
     "panelWidth": "Panel width (mm)",
     "panelHeight": "Panel height (mm)",
+    "dropToFloor": "Drop to floor",
     "blenda": "Filler",
     "orientation": {
       "label": "Orientation",

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -143,6 +143,7 @@
     "panel": "Panel",
     "panelWidth": "Szerokość panelu (mm)",
     "panelHeight": "Wysokość panelu (mm)",
+    "dropToFloor": "Do podłogi",
     "blenda": "Blenda",
     "orientation": {
       "label": "Orientacja",

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -143,7 +143,7 @@
     "panel": "Panel",
     "panelWidth": "Szerokość panelu (mm)",
     "panelHeight": "Wysokość panelu (mm)",
-    "dropToFloor": "Do podłogi",
+    "dropToFloor": "Opuść do ziemi",
     "blenda": "Blenda",
     "orientation": {
       "label": "Orientacja",

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,6 +37,7 @@ export interface SidePanelSpec {
   width?: number;
   /** height in millimetres */
   height?: number;
+  dropToFloor?: boolean;
   blenda?: Blenda;
 }
 

--- a/src/ui/CabinetConfigurator.tsx
+++ b/src/ui/CabinetConfigurator.tsx
@@ -926,6 +926,7 @@ const CabinetConfigurator: React.FC<Props> = ({
                             panel: undefined,
                             width: undefined,
                             height: undefined,
+                            dropToFloor: undefined,
                           },
                         },
                       });
@@ -975,6 +976,23 @@ const CabinetConfigurator: React.FC<Props> = ({
                         });
                       }}
                     />
+                  </label>
+                  <label style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+                    <input
+                      type="checkbox"
+                      checked={gLocal.sidePanels.right.dropToFloor ?? false}
+                      onChange={(e) => {
+                        const dropToFloor = (e.target as HTMLInputElement).checked;
+                        setAdv({
+                          ...gLocal,
+                          sidePanels: {
+                            ...gLocal.sidePanels,
+                            right: { ...(gLocal.sidePanels?.right || {}), dropToFloor },
+                          },
+                        });
+                      }}
+                    />
+                    {t('configurator.dropToFloor')}
                   </label>
                 </div>
               )}
@@ -1115,6 +1133,7 @@ const CabinetConfigurator: React.FC<Props> = ({
                             panel: undefined,
                             width: undefined,
                             height: undefined,
+                            dropToFloor: undefined,
                           },
                         },
                       });
@@ -1164,6 +1183,23 @@ const CabinetConfigurator: React.FC<Props> = ({
                         });
                       }}
                     />
+                  </label>
+                  <label style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+                    <input
+                      type="checkbox"
+                      checked={gLocal.sidePanels.left.dropToFloor ?? false}
+                      onChange={(e) => {
+                        const dropToFloor = (e.target as HTMLInputElement).checked;
+                        setAdv({
+                          ...gLocal,
+                          sidePanels: {
+                            ...gLocal.sidePanels,
+                            left: { ...(gLocal.sidePanels?.left || {}), dropToFloor },
+                          },
+                        });
+                      }}
+                    />
+                    {t('configurator.dropToFloor')}
                   </label>
                 </div>
               )}


### PR DESCRIPTION
## Summary
- add `dropToFloor` flag to side panel spec and translations
- expose drop-to-floor checkbox for left and right side panels
- clear drop-to-floor when side panel is deselected

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b96731b3e8832294b233fd7b3c1c03