### PR TITLE
Support drop-to-floor side panels

### DIFF
--- a/src/scene/cabinetBuilder.ts
+++ b/src/scene/cabinetBuilder.ts
@@ -350,9 +350,14 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
 
   if (sidePanels.left?.panel && hasValidSidePanelDimensions(sidePanels.left)) {
     const pw = sidePanels.left.width / 1000;
-    const ph = sidePanels.left.height / 1000;
+    const drop = sidePanels.left.dropToFloor;
+    const ph = drop
+      ? (sidePanels.left.height + legHeight) / 1000
+      : sidePanels.left.height / 1000;
+    const bottom = drop
+      ? (gaps.bottom || 0) / 1000
+      : legHeight + (gaps.bottom || 0) / 1000;
     const geo = new THREE.BoxGeometry(T, ph, pw);
-    const bottom = legHeight + (gaps.bottom || 0) / 1000;
     const panel = new THREE.Mesh(geo, carcMat);
     const y = bottom + ph / 2;
     panel.position.set(-T / 2, y, -pw / 2);
@@ -364,9 +369,14 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
   }
   if (sidePanels.right?.panel && hasValidSidePanelDimensions(sidePanels.right)) {
     const pw = sidePanels.right.width / 1000;
-    const ph = sidePanels.right.height / 1000;
+    const drop = sidePanels.right.dropToFloor;
+    const ph = drop
+      ? (sidePanels.right.height + legHeight) / 1000
+      : sidePanels.right.height / 1000;
+    const bottom = drop
+      ? (gaps.bottom || 0) / 1000
+      : legHeight + (gaps.bottom || 0) / 1000;
     const geo = new THREE.BoxGeometry(T, ph, pw);
-    const bottom = legHeight + (gaps.bottom || 0) / 1000;
     const panel = new THREE.Mesh(geo, carcMat);
     const y = bottom + ph / 2;
     panel.position.set(W + T / 2, y, -pw / 2);

--- a/tests/cabinetBuilder.test.ts
+++ b/tests/cabinetBuilder.test.ts
@@ -1110,4 +1110,39 @@ describe('buildCabinetMesh', () => {
     expect(topBands.length).toBe(2);
     expect(bottomBands.length).toBe(2);
   });
+
+  it('drops side panel to floor and extends height by leg height when configured', () => {
+    const legHeight = 0.1;
+    const panelHeight = 720;
+    const g = buildCabinetMesh({
+      width: WIDTH,
+      height: HEIGHT,
+      depth: DEPTH,
+      drawers: 0,
+      gaps: { top: 0, bottom: 0 },
+      family: FAMILY.BASE,
+      legHeight,
+      sidePanels: {
+        left: {
+          panel: true,
+          width: 100,
+          height: panelHeight,
+          dropToFloor: true,
+        },
+      },
+    });
+    const panel = g.children.find(
+      (c) =>
+        c instanceof THREE.Mesh &&
+        (c as any).userData.part === 'leftSide' &&
+        c.position.x < 0,
+    ) as THREE.Mesh;
+    const geometry = panel.geometry as THREE.BoxGeometry;
+    const bottom = panel.position.y - (geometry.parameters.height as number) / 2;
+    expect(bottom).toBeCloseTo(0, 5);
+    expect(geometry.parameters.height).toBeCloseTo(
+      (panelHeight + legHeight) / 1000,
+      5,
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- Allow side panels to drop to the floor and extend height by leg height when configured
- Test that drop-to-floor panels start at floor level and include leg height

## Testing
- `npm test tests/cabinetBuilder.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68b96a4f45248322bdfa8760d29119c6