### PR TITLE
Fix side panel override affecting carcass sides

### DIFF
--- a/src/scene/cabinetBuilder.ts
+++ b/src/scene/cabinetBuilder.ts
@@ -232,30 +232,16 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
           ? legHeight + (H - T) / 2
           : legHeight + H / 2;
   const sideBottomY = sideY - sideHeight / 2;
-  const leftSpec = sidePanels.left;
-  const leftValid = hasValidSidePanelDimensions(leftSpec);
-  const leftWidth = leftValid ? leftSpec.width / 1000 : D;
-  const leftHeight = leftValid ? leftSpec.height / 1000 : sideHeight;
-  const leftBottom = leftValid
-    ? legHeight + (gaps.bottom || 0) / 1000
-    : sideBottomY;
-  const leftGeo = new THREE.BoxGeometry(T, leftHeight, leftWidth);
+  const leftGeo = new THREE.BoxGeometry(T, sideHeight, D);
   const leftSide = new THREE.Mesh(leftGeo, carcMat);
-  leftSide.position.set(T / 2, leftBottom + leftHeight / 2, -leftWidth / 2);
+  leftSide.position.set(T / 2, sideBottomY + sideHeight / 2, -D / 2);
   leftSide.userData.part = 'leftSide';
   leftSide.userData.originalMaterial = leftSide.material;
   addEdges(leftSide);
   group.add(leftSide);
-  const rightSpec = sidePanels.right;
-  const rightValid = hasValidSidePanelDimensions(rightSpec);
-  const rightWidth = rightValid ? rightSpec.width / 1000 : D;
-  const rightHeight = rightValid ? rightSpec.height / 1000 : sideHeight;
-  const rightBottom = rightValid
-    ? legHeight + (gaps.bottom || 0) / 1000
-    : sideBottomY;
-  const rightGeo = new THREE.BoxGeometry(T, rightHeight, rightWidth);
+  const rightGeo = new THREE.BoxGeometry(T, sideHeight, D);
   const rightSide = new THREE.Mesh(rightGeo, carcMat);
-  rightSide.position.set(W - T / 2, rightBottom + rightHeight / 2, -rightWidth / 2);
+  rightSide.position.set(W - T / 2, sideBottomY + sideHeight / 2, -D / 2);
   rightSide.userData.part = 'rightSide';
   rightSide.userData.originalMaterial = rightSide.material;
   addEdges(rightSide);
@@ -302,8 +288,8 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
       addBand(x, topY + offsetForEdge('top'), -w / 2, T, bandThickness, w);
     }
   };
-  bandSide(leftSideEdgeBanding, T / 2, leftBottom, leftHeight, leftWidth);
-  bandSide(rightSideEdgeBanding, W - T / 2, rightBottom, rightHeight, rightWidth);
+  bandSide(leftSideEdgeBanding, T / 2, sideBottomY, sideHeight, D);
+  bandSide(rightSideEdgeBanding, W - T / 2, sideBottomY, sideHeight, D);
 
   const bandPanel = (
     banding: EdgeBanding | undefined,

--- a/tests/cabinetBuilder.test.ts
+++ b/tests/cabinetBuilder.test.ts
@@ -1111,6 +1111,49 @@ describe('buildCabinetMesh', () => {
     expect(bottomBands.length).toBe(2);
   });
 
+  it('ignores side panel dimensions for carcass sides', () => {
+    const g = buildCabinetMesh({
+      width: WIDTH,
+      height: HEIGHT,
+      depth: DEPTH,
+      drawers: 0,
+      gaps: { top: 0, bottom: 0 },
+      family: FAMILY.BASE,
+      sidePanels: {
+        left: { panel: true, width: 100, height: 400 },
+        right: { panel: true, width: 150, height: 450 },
+      },
+    });
+    const leftCarcass = g.children.find(
+      (c) =>
+        c instanceof THREE.Mesh &&
+        (c as any).userData.part === 'leftSide' &&
+        c.position.x > 0,
+    ) as THREE.Mesh;
+    const rightCarcass = g.children.find(
+      (c) =>
+        c instanceof THREE.Mesh &&
+        (c as any).userData.part === 'rightSide' &&
+        c.position.x < WIDTH,
+    ) as THREE.Mesh;
+    expect((leftCarcass.geometry as any).parameters.height).toBeCloseTo(
+      HEIGHT,
+      5,
+    );
+    expect((leftCarcass.geometry as any).parameters.depth).toBeCloseTo(
+      DEPTH,
+      5,
+    );
+    expect((rightCarcass.geometry as any).parameters.height).toBeCloseTo(
+      HEIGHT,
+      5,
+    );
+    expect((rightCarcass.geometry as any).parameters.depth).toBeCloseTo(
+      DEPTH,
+      5,
+    );
+  });
+
   it('drops side panel to floor and extends height by leg height when configured', () => {
     const legHeight = 0.1;
     const panelHeight = 720;


### PR DESCRIPTION
## Summary
- Remove side panel dimension overrides from carcass side setup
- Use carcass dimensions for side edge banding
- Add regression test ensuring carcass sides ignore side panel custom sizes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9771f37b08322a67f5cc4d70320e9