### PR TITLE
Remove duplicate dropToFloor field

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -39,7 +39,6 @@ export interface SidePanelSpec {
   height?: number;
   dropToFloor?: boolean;
   blenda?: Blenda;
-  dropToFloor?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Summary
- remove duplicate `dropToFloor` property from `SidePanelSpec`

## Testing
- `npm test`
- `npx tsc --noEmit` *(fails: Property 'gaps' does not exist on type '{}', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68b9794e3f288322ab68c45987f6a3e0