### PR TITLE
feat: add legs config

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -161,6 +161,7 @@ export interface ModuleAdv {
     right?: SidePanelSpec;
   };
   carcassType?: 'type1' | 'type2' | 'type3' | 'type4' | 'type5' | 'type6';
+  legs?: { type: string; height: number };
 }
 
 export interface Module3D {

--- a/src/ui/types.ts
+++ b/src/ui/types.ts
@@ -32,5 +32,5 @@ export interface CabinetConfig {
     right?: SidePanelSpec & { dropToFloor?: boolean };
   };
   hardware?: any;
-  legs?: any;
+  legs?: { type: string; height: number };
 }

--- a/src/ui/useCabinetConfig.ts
+++ b/src/ui/useCabinetConfig.ts
@@ -175,7 +175,7 @@ export function useCabinetConfig(
       drawerSlide?: string;
       animationSpeed?: number;
       doorCount?: number;
-    } = { ...g };
+    } = { ...g, legs: { ...(g.legs || {}), ...(advLocal.legs || {}) } };
     if (!advAugmented.hinge) advAugmented.hinge = 'left';
     if (!advAugmented.drawerSlide) advAugmented.drawerSlide = 'BLUM LEGRABOX';
     if (advAugmented.animationSpeed === undefined)


### PR DESCRIPTION
## Summary
- add typed legs property to CabinetConfig and ModuleAdv
- propagate legs settings when adding modules

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b980467af48322910895f97f258f9f