### PR TITLE
Allow configuring leg height per cabinet

### DIFF
--- a/src/ui/CabinetConfigurator.tsx
+++ b/src/ui/CabinetConfigurator.tsx
@@ -55,7 +55,8 @@ const CabinetConfigurator: React.FC<Props> = ({
   const prices = usePlannerStore((s) => s.prices);
   const legTypes = usePlannerStore((s) => s.prices.legs);
   const g = usePlannerStore((s) => s.globals[family]);
-  const legsHeight = gLocal.legs?.height ?? g.legsHeight ?? 0;
+  const globalLegsHeight = g.legsHeight ?? 0;
+  const legsHeight = gLocal.legs?.height ?? globalLegsHeight;
   const { t } = useTranslation();
   const [doorsCount, setDoorsCount] = useState(1);
   const [drawersCount, setDrawersCount] = useState(0);
@@ -162,6 +163,7 @@ const CabinetConfigurator: React.FC<Props> = ({
               carcassType={gLocal.carcassType}
               showFronts={showFronts}
               highlightPart={highlightPart}
+              legHeight={gLocal.legs?.height || globalLegsHeight}
             />
           </div>
           <div className="grid2" style={{ marginTop: 8 }}>

--- a/src/ui/SceneViewer.tsx
+++ b/src/ui/SceneViewer.tsx
@@ -22,8 +22,8 @@ interface Props {
 
 export const getLegHeight = (mod: Module3D, globals: Globals): number => {
   if (mod.family !== FAMILY.BASE) return 0;
-  const famGlobal = globals[mod.family];
-  const h = famGlobal?.legsHeight;
+  const h =
+    mod.adv?.legs?.height ?? globals[mod.family]?.legsHeight;
   if (typeof h === 'number') return h / 1000;
   return 0.1;
 };
@@ -39,12 +39,11 @@ const SceneViewer: React.FC<Props> = ({ threeRef, addCountertop }) => {
     threeRef.current = setupThree(containerRef.current);
   }, [threeRef]);
 
-  const createCabinetMesh = (mod: Module3D) => {
+  const createCabinetMesh = (mod: Module3D, legHeight: number) => {
     const W = mod.size.w;
     const H = mod.size.h;
     const D = mod.size.d;
     const adv: ModuleAdv = mod.adv ?? {};
-    const legHeight = getLegHeight(mod, store.globals);
     const drawers = Array.isArray(adv.drawerFronts)
       ? adv.drawerFronts.length
       : 0;
@@ -111,10 +110,10 @@ const SceneViewer: React.FC<Props> = ({ threeRef, addCountertop }) => {
       }
     });
     store.modules.forEach((m: Module3D) => {
-      const cabMesh = createCabinetMesh(m);
+      const legHeight = getLegHeight(m, store.globals);
+      const cabMesh = createCabinetMesh(m, legHeight);
       const fgs: THREE.Object3D[] = cabMesh.userData.frontGroups || [];
       fgs.forEach((fg) => (fg.visible = showFronts));
-      const legHeight = getLegHeight(m, store.globals);
       const baseY = m.family === FAMILY.BASE ? 0 : m.position[1];
       cabMesh.position.set(m.position[0], baseY, m.position[2]);
       cabMesh.rotation.y = m.rotationY || 0;

--- a/src/ui/components/Cabinet3D.tsx
+++ b/src/ui/components/Cabinet3D.tsx
@@ -31,6 +31,7 @@ export default function Cabinet3D({
   carcassType = 'type1',
   showFronts = true,
   highlightPart = null,
+  legHeight: legHeightMM = 0,
 }: {
   widthMM: number;
   heightMM: number;
@@ -59,6 +60,7 @@ export default function Cabinet3D({
   carcassType?: 'type1' | 'type2' | 'type3' | 'type4' | 'type5' | 'type6';
   showFronts?: boolean;
   highlightPart?: 'top' | 'bottom' | 'shelf' | 'back' | 'leftSide' | 'rightSide' | null;
+  legHeight?: number;
 }) {
   const ref = useRef<HTMLDivElement>(null);
   const rendererRef = useRef<THREE.WebGLRenderer | null>(null);
@@ -121,7 +123,9 @@ export default function Cabinet3D({
     const H = heightMM / 1000;
     const D = depthMM / 1000;
     const legHeight =
-      family === FAMILY.BASE || family === FAMILY.TALL ? 0.04 : 0;
+      family === FAMILY.BASE || family === FAMILY.TALL
+        ? legHeightMM / 1000
+        : 0;
     const cabGroup = buildCabinetMesh({
       width: W,
       height: H,
@@ -224,6 +228,7 @@ export default function Cabinet3D({
     sidePanels,
     carcassType,
     showFronts,
+    legHeightMM,
   ]);
 
   useEffect(() => {
@@ -306,6 +311,7 @@ export default function Cabinet3D({
     sidePanels,
     carcassType,
     showFronts,
+    legHeightMM,
   ]);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- allow Cabinet3D to accept custom leg heights and use them when building meshes
- pass cabinet and global leg heights through the configurator and scene viewer
- compute per-module leg height in SceneViewer and forward to `buildCabinetMesh`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b9820c6c448322929a99a174bc05d7