### PR TITLE
feat: support configurable legs type in pricing

### DIFF
--- a/src/core/pricing.ts
+++ b/src/core/pricing.ts
@@ -45,7 +45,8 @@ export function computeModuleCost(
   const hingesCost = (P.hinges['Blum ClipTop']||0) * hingesPerDoor * doors
   const slidesCost = (P.drawerSlide['BLUM LEGRABOX']||0) * drawers
   const legsCount = params.family===FAMILY.BASE ? Math.max(4, Math.ceil(wMM/300)*2) : 0
-  const legsCost = legsCount * (P.legs['Standard 10cm']||0)
+  const legsType = params.adv.legsType ?? g.legsType
+  const legsCost = legsCount * (P.legs[legsType] || 0)
   const hangersCount = (params.family===FAMILY.WALL || params.family===FAMILY.PAWLACZ) ? 2 : 0
   const hangersCost = hangersCount * (P.hangers['Standard']||0)
   const aventosCost = aventosType ? (P.aventos[aventosType]||0) : 0

--- a/src/types.ts
+++ b/src/types.ts
@@ -161,6 +161,7 @@ export interface ModuleAdv {
     right?: SidePanelSpec;
   };
   carcassType?: 'type1' | 'type2' | 'type3' | 'type4' | 'type5' | 'type6';
+  legsType?: string;
   legs?: { type: string; height: number };
 }
 

--- a/src/ui/useCabinetConfig.ts
+++ b/src/ui/useCabinetConfig.ts
@@ -142,6 +142,7 @@ export function useCabinetConfig(
       d = g.depth / 1000,
       w = widthLocal / 1000;
     const id = `mod_${Date.now()}_${Math.floor(Math.random() * 1e6)}`;
+    const selectedLegsType = advLocal.legs?.type ?? store.globals[family].legsType;
     const price = computeModuleCost(
       {
         family,
@@ -163,6 +164,7 @@ export function useCabinetConfig(
           traverseEdgeBanding: g.traverseEdgeBanding,
           backEdgeBanding: g.backEdgeBanding,
           carcassType: g.carcassType,
+          legsType: selectedLegsType,
         },
         doorsCount,
         drawersCount,
@@ -175,7 +177,11 @@ export function useCabinetConfig(
       drawerSlide?: string;
       animationSpeed?: number;
       doorCount?: number;
-    } = { ...g, legs: { ...(g.legs || {}), ...(advLocal.legs || {}) } };
+    } = {
+      ...g,
+      legsType: selectedLegsType,
+      legs: { ...(g.legs || {}), ...(advLocal.legs || {}) },
+    };
     if (!advAugmented.hinge) advAugmented.hinge = 'left';
     if (!advAugmented.drawerSlide) advAugmented.drawerSlide = 'BLUM LEGRABOX';
     if (advAugmented.animationSpeed === undefined)
@@ -265,6 +271,7 @@ export function useCabinetConfig(
             shelfEdgeBanding: {},
             sidePanels: {},
             carcassType: g.carcassType,
+            legsType: g.legsType,
           },
           doorsCount: 1,
           drawersCount: 0,

--- a/tests/pricing.test.ts
+++ b/tests/pricing.test.ts
@@ -124,5 +124,22 @@ describe('computeModuleCost', () => {
       Math.round(frontArea * defaultPrices.front['DALL·E stowalna'])
     )
   })
+
+  it('uses custom legs type pricing when specified', () => {
+    const adv = { ...advFor(FAMILY.BASE), legsType: 'Metal 10cm' }
+    const price = computeModuleCost(
+      {
+        family: FAMILY.BASE,
+        kind: 'doors',
+        variant: 'doors',
+        width: 600,
+        adv,
+      },
+      { prices: defaultPrices, globals: defaultGlobal }
+    )
+    expect(price.parts.legs).toBe(
+      (defaultPrices.legs['Metal 10cm'] || 0) * price.counts.legs
+    )
+  })
 })
 


### PR DESCRIPTION
## Summary
- factor selected legs type into module price calculations
- allow modules to pass legs type when computing cost
- add test for legs type pricing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b98715da148322bf7de10cd3dd92be