### PR TITLE
Handle leg defaults when updating globals

### DIFF
--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -163,6 +163,16 @@ export const usePlannerStore = create<Store>((set, get) => ({
           newAdv.bottomPanel = patch.bottomPanel;
         if (patch.carcassType !== undefined)
           newAdv.carcassType = patch.carcassType;
+        if (patch.legsType !== undefined && newAdv.legsType === undefined)
+          newAdv.legsType = patch.legsType;
+        if (patch.legsType !== undefined || patch.legsHeight !== undefined) {
+          const legs = { ...(m.adv?.legs || {}) };
+          if (patch.legsType !== undefined && legs.type === undefined)
+            legs.type = patch.legsType;
+          if (patch.legsHeight !== undefined && legs.height === undefined)
+            legs.height = patch.legsHeight;
+          newAdv.legs = legs;
+        }
         const newSize = { ...m.size };
         if (patch.height !== undefined) newSize.h = patch.height / 1000;
         if (patch.depth !== undefined) newSize.d = patch.depth / 1000;

--- a/tests/updateGlobals.test.ts
+++ b/tests/updateGlobals.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { usePlannerStore, defaultGlobal } from '../src/state/store';
+import { FAMILY } from '../src/core/catalog';
+import { Module3D } from '../src/types';
+
+describe('updateGlobals legs handling', () => {
+  beforeEach(() => {
+    usePlannerStore.setState({
+    globals: JSON.parse(JSON.stringify(defaultGlobal)),
+    modules: [],
+    });
+  });
+
+  it('updates leg type and height for modules using global defaults', () => {
+    const store = usePlannerStore;
+    const baseModule = {
+      id: '1',
+      label: '',
+      family: FAMILY.BASE,
+      kind: 'base',
+      size: { w: 1, h: 0.8, d: 0.6 },
+      position: [0, 0, 0],
+    } as Module3D;
+    store.setState({ modules: [baseModule] });
+    store.getState().updateGlobals(FAMILY.BASE, {
+      legsType: 'Regulowane 12cm',
+      legsHeight: 120,
+    });
+    const mod = store.getState().modules[0];
+    expect(mod.adv?.legsType).toBe('Regulowane 12cm');
+    expect(mod.adv?.legs?.type).toBe('Regulowane 12cm');
+    expect(mod.adv?.legs?.height).toBe(120);
+  });
+
+  it('preserves custom leg settings while filling missing values', () => {
+    const store = usePlannerStore;
+    const modules: Module3D[] = [
+      {
+        id: '1',
+        label: '',
+        family: FAMILY.BASE,
+        kind: 'base',
+        size: { w: 1, h: 0.8, d: 0.6 },
+        position: [0, 0, 0],
+        adv: {
+          legsType: 'Custom',
+          legs: { type: 'Custom', height: 150 },
+        },
+      },
+      {
+        id: '2',
+        label: '',
+        family: FAMILY.BASE,
+        kind: 'base',
+        size: { w: 1, h: 0.8, d: 0.6 },
+        position: [0, 0, 0],
+        adv: {
+          legsType: 'Custom',
+          legs: { type: 'Custom' } as any,
+        },
+      },
+    ];
+    store.setState({ modules });
+    store.getState().updateGlobals(FAMILY.BASE, {
+      legsType: 'Regulowane 12cm',
+      legsHeight: 120,
+    });
+    const [modFull, modPartial] = store.getState().modules;
+    expect(modFull.adv?.legsType).toBe('Custom');
+    expect(modFull.adv?.legs?.type).toBe('Custom');
+    expect(modFull.adv?.legs?.height).toBe(150);
+
+    expect(modPartial.adv?.legsType).toBe('Custom');
+    expect(modPartial.adv?.legs?.type).toBe('Custom');
+    expect(modPartial.adv?.legs?.height).toBe(120);
+  });
+});
+


### PR DESCRIPTION
## Summary
- update modules' leg settings when global leg options change
- preserve custom leg overrides when applying global patches
- test global leg updates and override behavior

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b989c52860832290d0f3512e81e691