### PR TITLE
feat: add legs category support

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -162,8 +162,9 @@ export interface ModuleAdv {
     right?: SidePanelSpec;
   };
   carcassType?: 'type1' | 'type2' | 'type3' | 'type4' | 'type5' | 'type6';
+  category?: string;
   legsType?: string;
-  legs?: { type: string; height: number };
+  legs?: { type: string; height: number; category?: string };
 }
 
 export interface Module3D {

--- a/src/ui/types.ts
+++ b/src/ui/types.ts
@@ -32,5 +32,5 @@ export interface CabinetConfig {
     right?: SidePanelSpec & { dropToFloor?: boolean };
   };
   hardware?: any;
-  legs?: { type: string; height: number };
+  legs?: { type: string; height: number; category?: string };
 }


### PR DESCRIPTION
## Summary
- allow setting leg categories in advanced module options and leg configs
- expose leg category in UI cabinet configuration

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b9930953948322966930440150a742