### PR TITLE
Add leg category and adjustable height controls

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -60,6 +60,8 @@
     "backPanel": "Back",
     "legs": "Legs",
     "legsHeight": "Leg height (mm)",
+    "legsAdjustment": "Adjustment (mm)",
+    "legsCategory": "Leg category",
     "offsetWall": "Offset from wall (mm)",
     "hanger": "Hangers",
     "gapsTitle": "Gaps (mm)",

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -60,6 +60,8 @@
     "backPanel": "Plecy",
     "legs": "Nóżki",
     "legsHeight": "Wysokość nóżek (mm)",
+    "legsAdjustment": "Regulacja (mm)",
+    "legsCategory": "Kategoria nóżek",
     "offsetWall": "Odsunięcie od ściany (mm)",
     "hanger": "Zawieszki",
     "gapsTitle": "Szczeliny (mm)",

--- a/src/ui/panels/GlobalSettings.tsx
+++ b/src/ui/panels/GlobalSettings.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { usePlannerStore } from '../../state/store'
+import { usePlannerStore, legCategories } from '../../state/store'
 import { FAMILY } from '../../core/catalog'
 
 const FamList = [FAMILY.BASE, FAMILY.WALL, FAMILY.PAWLACZ, FAMILY.TALL]
@@ -33,6 +33,11 @@ export default function GlobalSettings(){
     const g = store.globals[fam]
     const isOpen = openFam===fam
     const set = (patch:any)=>store.updateGlobals(fam, patch)
+    const legHeight = g.legsHeight ?? 0
+    const baseOptions = [150,100,60]
+    const legsBase = baseOptions.find(b=>Math.abs(legHeight - b) <= 25) ?? 100
+    const legsAdjustment = legHeight - legsBase
+    const legCategory = g.legsCategory ?? legCategories[g.legsType]
     return (
       <div className="section" style={{marginTop:8}}>
         <div className="hd" onClick={()=>setOpenFam(prev=> prev===fam ? null : fam)}>
@@ -77,8 +82,46 @@ export default function GlobalSettings(){
               ]}
             />
             {fam===FAMILY.BASE && (<>
-              <Field label={t('global.legs')} type="select" value={g.legsType} onChange={(v)=>set({legsType:v})} options={Object.keys(store.prices.legs)} />
-              <Field label={t('global.legsHeight')} value={g.legsHeight||0} onChange={(v)=>set({legsHeight:v})} />
+              <Field
+                label={t('global.legs')}
+                type="select"
+                value={g.legsType}
+                onChange={(v)=>set({legsType:v, legsCategory: legCategories[v]})}
+                options={Object.keys(store.prices.legs)}
+              />
+              <div>
+                <div className="small">{t('global.legsHeight')}</div>
+                <select
+                  className="input"
+                  value={legsBase}
+                  onChange={e=>{
+                    const base = parseInt((e.target as HTMLSelectElement).value,10)
+                    set({legsHeight: base + legsAdjustment})
+                  }}
+                >
+                  {baseOptions.map(v=> <option key={v} value={v}>{v}</option>)}
+                </select>
+              </div>
+              <div>
+                <div className="small">{t('global.legsAdjustment')}</div>
+                <input
+                  className="input"
+                  type="number"
+                  min={-25}
+                  max={25}
+                  value={legsAdjustment}
+                  onChange={e=>{
+                    let val = parseInt((e.target as HTMLInputElement).value,10)
+                    if (Number.isNaN(val)) val = 0
+                    val = Math.max(-25, Math.min(25, val))
+                    set({legsHeight: legsBase + val})
+                  }}
+                />
+              </div>
+              <div>
+                <div className="small">{t('global.legsCategory')}</div>
+                <input className="input" value={legCategory} readOnly />
+              </div>
               <Field label={t('global.offsetWall')} value={g.offsetWall||0} onChange={(v)=>set({offsetWall:v})} />
             </>)}
             {(fam===FAMILY.WALL || fam===FAMILY.PAWLACZ) && (<>

--- a/src/ui/useCabinetConfig.ts
+++ b/src/ui/useCabinetConfig.ts
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { FAMILY, Kind, Variant, KIND_SETS } from '../core/catalog';
 import { computeModuleCost } from '../core/pricing';
-import { usePlannerStore } from '../state/store';
+import { usePlannerStore, legCategories } from '../state/store';
 import { getWallSegments, projectPointToSegment } from '../utils/walls';
 import { autoWidthsForRun, placeAlongWall } from '../utils/auto';
 import { Module3D, ModuleAdv } from '../types';
@@ -48,7 +48,11 @@ export function useCabinetConfig(
       traverseEdgeBanding: {},
       backEdgeBanding: {},
       sidePanels: {},
-      legs: { type: g.legsType, height: g.legsHeight },
+      legs: {
+        type: g.legsType,
+        height: g.legsHeight,
+        category: legCategories[g.legsType],
+      },
       carcassType: g.carcassType,
     });
   }, [family, store.globals]);
@@ -180,7 +184,11 @@ export function useCabinetConfig(
     } = {
       ...g,
       legsType: selectedLegsType,
-      legs: { ...(g.legs || {}), ...(advLocal.legs || {}) },
+      legs: {
+        category: legCategories[selectedLegsType],
+        ...(g.legs || {}),
+        ...(advLocal.legs || {}),
+      },
     };
     if (!advAugmented.hinge) advAugmented.hinge = 'left';
     if (!advAugmented.drawerSlide) advAugmented.drawerSlide = 'BLUM LEGRABOX';
@@ -313,7 +321,12 @@ export function useCabinetConfig(
   const gLocal: CabinetConfig = (() => {
     const g = store.globals[family];
     const base = adv ? { ...adv } : ({ ...g } as CabinetConfig);
-    if (!base.legs) base.legs = { type: g.legsType, height: g.legsHeight };
+    if (!base.legs)
+      base.legs = {
+        type: g.legsType,
+        height: g.legsHeight,
+        category: legCategories[g.legsType],
+      };
     return base;
   })();
 
@@ -321,8 +334,23 @@ export function useCabinetConfig(
     setAdvState((prev) => {
       const g = store.globals[family];
       const base = prev
-        ? { ...prev, legs: prev.legs || { type: g.legsType, height: g.legsHeight } }
-        : ({ ...g, legs: { type: g.legsType, height: g.legsHeight } } as CabinetConfig);
+        ? {
+            ...prev,
+            legs:
+              prev.legs || {
+                type: g.legsType,
+                height: g.legsHeight,
+                category: legCategories[g.legsType],
+              },
+          }
+        : ({
+            ...g,
+            legs: {
+              type: g.legsType,
+              height: g.legsHeight,
+              category: legCategories[g.legsType],
+            },
+          } as CabinetConfig);
       return { ...base, ...patch };
     });
 


### PR DESCRIPTION
## Summary
- track leg category using `legCategories` when initializing cabinet config
- rework cabinet and global settings leg controls with discrete height options, ±25 mm adjustment, and category display
- add translation strings for leg adjustment and category

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b9947e0318832291de649dda0f5fbc