### PR TITLE
Add leg configuration translations

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -59,9 +59,9 @@
     "frontType": "Front type",
     "backPanel": "Back",
     "legs": "Legs",
-    "legsHeight": "Leg height (mm)",
-    "legsAdjustment": "Adjustment (mm)",
-    "legsCategory": "Leg category",
+    "legsBaseHeight": "Base height",
+    "legsAdjustment": "Adjustment (±25 mm)",
+    "legsCategory": "Category",
     "offsetWall": "Offset from wall (mm)",
     "hanger": "Hangers",
     "gapsTitle": "Gaps (mm)",
@@ -157,7 +157,10 @@
     "offsetDepth": "Offset (depth mm)",
     "offsetHeight": "Offset (height mm)",
     "traverseWidth": "Traverse width (mm)",
-    "hideCountertop": "Hide countertops"
+    "hideCountertop": "Hide countertops",
+    "legsCategory": "Category",
+    "legsBaseHeight": "Base height",
+    "legsAdjustment": "Adjustment (±25 mm)"
   },
   "forms": {
     "width": "Width",

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -59,9 +59,9 @@
     "frontType": "Rodzaj frontu",
     "backPanel": "Plecy",
     "legs": "Nóżki",
-    "legsHeight": "Wysokość nóżek (mm)",
-    "legsAdjustment": "Regulacja (mm)",
-    "legsCategory": "Kategoria nóżek",
+    "legsBaseHeight": "Wysokość bazowa",
+    "legsAdjustment": "Regulacja (±25 mm)",
+    "legsCategory": "Kategoria",
     "offsetWall": "Odsunięcie od ściany (mm)",
     "hanger": "Zawieszki",
     "gapsTitle": "Szczeliny (mm)",
@@ -157,7 +157,10 @@
     "offsetDepth": "Przesunięcie (głębokość, mm)",
     "offsetHeight": "Przesunięcie (wysokość, mm)",
     "traverseWidth": "Szerokość trawersu (mm)",
-    "hideCountertop": "Ukryj blaty"
+    "hideCountertop": "Ukryj blaty",
+    "legsCategory": "Kategoria",
+    "legsBaseHeight": "Wysokość bazowa",
+    "legsAdjustment": "Regulacja (±25 mm)"
   },
   "forms": {
     "width": "Szerokość",


### PR DESCRIPTION
## Summary
- add Category, Base height, and Adjustment (±25 mm) translation strings for legs settings in Polish and English

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b995e2b45083228718b0fbfe2b39c5