### PR TITLE
Update leg references and verify categories

### DIFF
--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -172,12 +172,23 @@ export const usePlannerStore = create<Store>((set, get) => ({
           newAdv.carcassType = patch.carcassType;
         if (patch.legsType !== undefined && newAdv.legsType === undefined)
           newAdv.legsType = patch.legsType;
-        if (patch.legsType !== undefined || patch.legsHeight !== undefined) {
+        if (
+          patch.legsType !== undefined ||
+          patch.legsHeight !== undefined ||
+          patch.legsCategory !== undefined
+        ) {
           const legs = { ...(m.adv?.legs || {}) };
+          const hadType = legs.type !== undefined;
           if (patch.legsType !== undefined && legs.type === undefined)
             legs.type = patch.legsType;
           if (patch.legsHeight !== undefined && legs.height === undefined)
             legs.height = patch.legsHeight;
+          if (!hadType && legs.category === undefined) {
+            if (patch.legsCategory !== undefined)
+              legs.category = patch.legsCategory;
+            else if (patch.legsType !== undefined)
+              legs.category = legCategories[patch.legsType];
+          }
           newAdv.legs = legs;
         }
         const newSize = { ...m.size };

--- a/tests/pricing.test.ts
+++ b/tests/pricing.test.ts
@@ -126,7 +126,7 @@ describe('computeModuleCost', () => {
   })
 
   it('uses custom legs type pricing when specified', () => {
-    const adv = { ...advFor(FAMILY.BASE), legsType: 'Metal 10cm' }
+    const adv = { ...advFor(FAMILY.BASE), legsType: 'Metalowe' }
     const price = computeModuleCost(
       {
         family: FAMILY.BASE,
@@ -138,7 +138,7 @@ describe('computeModuleCost', () => {
       { prices: defaultPrices, globals: defaultGlobal }
     )
     expect(price.parts.legs).toBe(
-      (defaultPrices.legs['Metal 10cm'] || 0) * price.counts.legs
+      (defaultPrices.legs['Metalowe'] || 0) * price.counts.legs
     )
   })
 })

--- a/tests/updateGlobals.test.ts
+++ b/tests/updateGlobals.test.ts
@@ -23,13 +23,15 @@ describe('updateGlobals legs handling', () => {
     } as Module3D;
     store.setState({ modules: [baseModule] });
     store.getState().updateGlobals(FAMILY.BASE, {
-      legsType: 'Regulowane 12cm',
+      legsType: 'Multi-legi',
+      legsCategory: 'wzmocniona',
       legsHeight: 120,
     });
     const mod = store.getState().modules[0];
-    expect(mod.adv?.legsType).toBe('Regulowane 12cm');
-    expect(mod.adv?.legs?.type).toBe('Regulowane 12cm');
+    expect(mod.adv?.legsType).toBe('Multi-legi');
+    expect(mod.adv?.legs?.type).toBe('Multi-legi');
     expect(mod.adv?.legs?.height).toBe(120);
+    expect(mod.adv?.legs?.category).toBe('wzmocniona');
   });
 
   it('preserves custom leg settings while filling missing values', () => {
@@ -62,17 +64,20 @@ describe('updateGlobals legs handling', () => {
     ];
     store.setState({ modules });
     store.getState().updateGlobals(FAMILY.BASE, {
-      legsType: 'Regulowane 12cm',
+      legsType: 'Multi-legi',
+      legsCategory: 'wzmocniona',
       legsHeight: 120,
     });
     const [modFull, modPartial] = store.getState().modules;
     expect(modFull.adv?.legsType).toBe('Custom');
     expect(modFull.adv?.legs?.type).toBe('Custom');
     expect(modFull.adv?.legs?.height).toBe(150);
+    expect(modFull.adv?.legs?.category).toBeUndefined();
 
     expect(modPartial.adv?.legsType).toBe('Custom');
     expect(modPartial.adv?.legs?.type).toBe('Custom');
     expect(modPartial.adv?.legs?.height).toBe(120);
+    expect(modPartial.adv?.legs?.category).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Summary
- replace old leg type names with "Multi-legi" and "Metalowe" in pricing and globals tests
- check leg categories when updating global leg settings
- propagate leg category when global leg type changes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9973ab99883228f953a49ca60e76d