### PR TITLE
feat: update leg type labels

### DIFF
--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -11,9 +11,9 @@ export const defaultGaps: Gaps = {
 };
 
 export const legCategories: Record<string, string> = {
-  'Zwykła czarne': 'standard',
-  'Multi-legi': 'wzmocniona',
-  Metalowe: 'ozdobne',
+  'Nóżka kuchenna (standardowe)': 'standard',
+  'MULTI LEG (wzmocniona)': 'wzmocniona',
+  'Nóżka meblowa (ozdobna)': 'ozdobna',
 };
 
 export const defaultGlobal: Globals = {
@@ -23,7 +23,7 @@ export const defaultGlobal: Globals = {
     boardType: 'Płyta 18mm',
     frontType: 'Laminat',
     gaps: { ...defaultGaps },
-    legsType: 'Zwykła czarne',
+    legsType: 'Nóżka kuchenna (standardowe)',
     legsCategory: 'standard',
     legsHeight: 100,
     offsetWall: 30,
@@ -87,7 +87,11 @@ export const defaultPrices: Prices = {
   },
   edging: { 'ABS 1mm': 2.5, 'ABS 2mm': 3.2 },
   cut: 4.0,
-  legs: { 'Zwykła czarne': 6, 'Multi-legi': 9, Metalowe: 12 },
+  legs: {
+    'Nóżka kuchenna (standardowe)': 6,
+    'MULTI LEG (wzmocniona)': 9,
+    'Nóżka meblowa (ozdobna)': 12,
+  },
   hangers: { Standard: 10, Wzmocnione: 18 },
   hinges: { 'Blum ClipTop': 16, GTV: 9 },
   drawerSlide: { 'BLUM LEGRABOX': 68, 'BLUM TANDEMBOX': 48, GTV: 22 },

--- a/tests/pricing.test.ts
+++ b/tests/pricing.test.ts
@@ -126,7 +126,7 @@ describe('computeModuleCost', () => {
   })
 
   it('uses custom legs type pricing when specified', () => {
-    const adv = { ...advFor(FAMILY.BASE), legsType: 'Metalowe' }
+    const adv = { ...advFor(FAMILY.BASE), legsType: 'Nóżka meblowa (ozdobna)' }
     const price = computeModuleCost(
       {
         family: FAMILY.BASE,
@@ -138,7 +138,7 @@ describe('computeModuleCost', () => {
       { prices: defaultPrices, globals: defaultGlobal }
     )
     expect(price.parts.legs).toBe(
-      (defaultPrices.legs['Metalowe'] || 0) * price.counts.legs
+      (defaultPrices.legs['Nóżka meblowa (ozdobna)'] || 0) * price.counts.legs
     )
   })
 })

--- a/tests/updateGlobals.test.ts
+++ b/tests/updateGlobals.test.ts
@@ -23,13 +23,13 @@ describe('updateGlobals legs handling', () => {
     } as Module3D;
     store.setState({ modules: [baseModule] });
     store.getState().updateGlobals(FAMILY.BASE, {
-      legsType: 'Multi-legi',
+      legsType: 'MULTI LEG (wzmocniona)',
       legsCategory: 'wzmocniona',
       legsHeight: 120,
     });
     const mod = store.getState().modules[0];
-    expect(mod.adv?.legsType).toBe('Multi-legi');
-    expect(mod.adv?.legs?.type).toBe('Multi-legi');
+    expect(mod.adv?.legsType).toBe('MULTI LEG (wzmocniona)');
+    expect(mod.adv?.legs?.type).toBe('MULTI LEG (wzmocniona)');
     expect(mod.adv?.legs?.height).toBe(120);
     expect(mod.adv?.legs?.category).toBe('wzmocniona');
   });
@@ -64,7 +64,7 @@ describe('updateGlobals legs handling', () => {
     ];
     store.setState({ modules });
     store.getState().updateGlobals(FAMILY.BASE, {
-      legsType: 'Multi-legi',
+      legsType: 'MULTI LEG (wzmocniona)',
       legsCategory: 'wzmocniona',
       legsHeight: 120,
     });


### PR DESCRIPTION
## Summary
- rename leg category keys to new Polish labels
- update default global leg type and leg pricing keys
- adjust tests for new leg type names

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9ba231d088322a85610cfab71bed3