### PR TITLE
Add configurable leg offset for cabinets

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -63,6 +63,7 @@
     "legsFloorHeight": "Height from floor",
     "legsAdjustment": "Adjustment (±25 mm)",
     "legsCategory": "Category",
+    "legsOffset": "Legs offset (mm)",
     "offsetWall": "Offset from wall (mm)",
     "hanger": "Hangers",
     "gapsTitle": "Gaps (mm)",
@@ -162,7 +163,8 @@
     "legsCategory": "Category",
     "legsBaseHeight": "Base height",
     "legsFloorHeight": "Height from floor",
-    "legsAdjustment": "Adjustment (±25 mm)"
+    "legsAdjustment": "Adjustment (±25 mm)",
+    "legsOffset": "Legs offset (mm)"
   },
   "forms": {
     "width": "Width",

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -63,6 +63,7 @@
     "legsFloorHeight": "Wysokość od podłogi",
     "legsAdjustment": "Regulacja (±25 mm)",
     "legsCategory": "Kategoria",
+    "legsOffset": "Odsunięcie nóg (mm)",
     "offsetWall": "Odsunięcie od ściany (mm)",
     "hanger": "Zawieszki",
     "gapsTitle": "Szczeliny (mm)",
@@ -162,7 +163,8 @@
     "legsCategory": "Kategoria",
     "legsBaseHeight": "Wysokość bazowa",
     "legsFloorHeight": "Wysokość od podłogi",
-    "legsAdjustment": "Regulacja (±25 mm)"
+    "legsAdjustment": "Regulacja (±25 mm)",
+    "legsOffset": "Odsunięcie nóg (mm)"
   },
   "forms": {
     "width": "Szerokość",

--- a/src/scene/cabinetBuilder.ts
+++ b/src/scene/cabinetBuilder.ts
@@ -43,6 +43,7 @@ export interface CabinetOptions {
   topPanel?: TopPanel;
   bottomPanel?: BottomPanel;
   legHeight?: number;
+  legsOffset?: number;
   showHandles?: boolean;
   boardThickness?: number;
   backThickness?: number;
@@ -83,6 +84,7 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
     topPanel = { type: 'full' } as TopPanel,
     bottomPanel = 'full' as BottomPanel,
     legHeight = 0,
+    legsOffset,
     showHandles = true,
     boardThickness: T = 0.018,
     backThickness: backT = 0.003,
@@ -124,6 +126,7 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
   const backColour = new THREE.Color(0xf0f0f0);
   const handleColour = new THREE.Color(0x333333);
   const footColour = new THREE.Color(0x444444);
+  const legOffset = typeof legsOffset === 'number' ? legsOffset : T;
 
   const carcMat = new THREE.MeshStandardMaterial({
     color: carcColour,
@@ -961,16 +964,16 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
       16,
     );
     const fl = new THREE.Mesh(footGeo, footMat);
-    fl.position.set(T + footRadius, footHeight / 2, -T);
+    fl.position.set(T + footRadius, footHeight / 2, -legOffset);
     group.add(fl);
     const fr = new THREE.Mesh(footGeo.clone(), footMat);
-    fr.position.set(W - T - footRadius, footHeight / 2, -T);
+    fr.position.set(W - T - footRadius, footHeight / 2, -legOffset);
     group.add(fr);
     const bl = new THREE.Mesh(footGeo.clone(), footMat);
-    bl.position.set(T + footRadius, footHeight / 2, -D + T);
+    bl.position.set(T + footRadius, footHeight / 2, -D + legOffset);
     group.add(bl);
     const br = new THREE.Mesh(footGeo.clone(), footMat);
-    br.position.set(W - T - footRadius, footHeight / 2, -D + T);
+    br.position.set(W - T - footRadius, footHeight / 2, -D + legOffset);
     group.add(br);
   }
   group.userData.frontGroups = frontGroups;

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -26,6 +26,7 @@ export const defaultGlobal: Globals = {
     legsType: 'Nóżka kuchenna (standardowe)',
     legsCategory: 'standard',
     legsHeight: 100,
+    legsOffset: 35,
     offsetWall: 30,
     shelves: 1,
     backPanel: 'full',
@@ -179,7 +180,8 @@ export const usePlannerStore = create<Store>((set, get) => ({
         if (
           patch.legsType !== undefined ||
           patch.legsHeight !== undefined ||
-          patch.legsCategory !== undefined
+          patch.legsCategory !== undefined ||
+          patch.legsOffset !== undefined
         ) {
           const legs = { ...(m.adv?.legs || {}) };
           const hadType = legs.type !== undefined;
@@ -193,6 +195,8 @@ export const usePlannerStore = create<Store>((set, get) => ({
             else if (patch.legsType !== undefined)
               legs.category = legCategories[patch.legsType];
           }
+          if (patch.legsOffset !== undefined && legs.legsOffset === undefined)
+            legs.legsOffset = patch.legsOffset;
           newAdv.legs = legs;
         }
         const newSize = { ...m.size };

--- a/src/types.ts
+++ b/src/types.ts
@@ -75,6 +75,7 @@ export interface GlobalsItem {
   gaps: Gaps;
   legsType?: string;
   legsHeight?: number;
+  legsOffset?: number;
   legsCategory?: string;
   hangerType?: string;
   offsetWall?: number;
@@ -164,7 +165,7 @@ export interface ModuleAdv {
   carcassType?: 'type1' | 'type2' | 'type3' | 'type4' | 'type5' | 'type6';
   category?: string;
   legsType?: string;
-  legs?: { type: string; height: number; category?: string };
+  legs?: { type: string; height: number; category?: string; legsOffset?: number };
 }
 
 export interface Module3D {

--- a/src/ui/CabinetConfigurator.tsx
+++ b/src/ui/CabinetConfigurator.tsx
@@ -59,6 +59,7 @@ const CabinetConfigurator: React.FC<Props> = ({
   const legsHeight = gLocal.legs?.height ?? globalLegsHeight;
   const legType = gLocal.legs?.type ?? g.legsType;
   const legCategory = gLocal.legs?.category ?? legCategories[legType];
+  const legsOffset = gLocal.legs?.legsOffset ?? g.legsOffset ?? 35;
   const baseOptions = [60, 100, 150];
   const legsBase = baseOptions.find((b) => Math.abs(legsHeight - b) <= 25) ?? 100;
   const legsAdjustment = legsHeight - legsBase;
@@ -171,6 +172,7 @@ const CabinetConfigurator: React.FC<Props> = ({
               showFronts={showFronts}
               highlightPart={highlightPart}
               legHeight={gLocal.legs?.height || globalLegsHeight}
+              legsOffset={legsOffset}
             />
           </div>
           <div className="grid2" style={{ marginTop: 8 }}>
@@ -1451,6 +1453,7 @@ const CabinetConfigurator: React.FC<Props> = ({
                         type,
                         height,
                         category: legCategories[type],
+                        legsOffset,
                       },
                     });
                   }}
@@ -1476,6 +1479,7 @@ const CabinetConfigurator: React.FC<Props> = ({
                         type,
                         height,
                         category: legCategories[type],
+                        legsOffset,
                       },
                     });
                     floorRef.current?.focus();
@@ -1508,6 +1512,7 @@ const CabinetConfigurator: React.FC<Props> = ({
                         type,
                         height,
                         category: legCategories[type],
+                        legsOffset,
                       },
                     });
                   }}
@@ -1532,6 +1537,7 @@ const CabinetConfigurator: React.FC<Props> = ({
                         type,
                         height,
                         category: legCategories[type],
+                        legsOffset,
                       },
                     });
                   }}
@@ -1540,6 +1546,28 @@ const CabinetConfigurator: React.FC<Props> = ({
               <div>
                 <div className="small">{t('configurator.legsCategory')}</div>
                 <input className="input" value={legCategory} readOnly />
+              </div>
+              <div>
+                <div className="small">{t('configurator.legsOffset')}</div>
+                <input
+                  className="input"
+                  type="number"
+                  value={legsOffset}
+                  onChange={(e) => {
+                    let val = parseInt((e.target as HTMLInputElement).value, 10);
+                    if (Number.isNaN(val)) val = 0;
+                    const type = gLocal.legs?.type ?? g.legsType;
+                    const height = gLocal.legs?.height ?? g.legsHeight ?? 0;
+                    setAdv({
+                      legs: {
+                        type,
+                        height,
+                        category: legCategories[type],
+                        legsOffset: val,
+                      },
+                    });
+                  }}
+                />
               </div>
             </div>
           </div>

--- a/src/ui/SceneViewer.tsx
+++ b/src/ui/SceneViewer.tsx
@@ -56,6 +56,8 @@ const SceneViewer: React.FC<Props> = ({ threeRef, addCountertop }) => {
             | 'right'
             | 'center'
             | undefined);
+    const legOffset =
+      adv.legs?.legsOffset ?? store.globals[mod.family]?.legsOffset ?? 0;
     const group = buildCabinetMesh({
       width: W,
       height: H,
@@ -69,6 +71,7 @@ const SceneViewer: React.FC<Props> = ({ threeRef, addCountertop }) => {
       topPanel: adv.topPanel,
       bottomPanel: adv.bottomPanel,
       legHeight,
+      legsOffset: legOffset / 1000,
       showHandles: true,
       hinge,
       dividerPosition,

--- a/src/ui/components/Cabinet3D.tsx
+++ b/src/ui/components/Cabinet3D.tsx
@@ -32,6 +32,7 @@ export default function Cabinet3D({
   showFronts = true,
   highlightPart = null,
   legHeight: legHeightMM = 0,
+  legsOffset: legsOffsetMM = 0,
 }: {
   widthMM: number;
   heightMM: number;
@@ -61,6 +62,7 @@ export default function Cabinet3D({
   showFronts?: boolean;
   highlightPart?: 'top' | 'bottom' | 'shelf' | 'back' | 'leftSide' | 'rightSide' | null;
   legHeight?: number;
+  legsOffset?: number;
 }) {
   const ref = useRef<HTMLDivElement>(null);
   const rendererRef = useRef<THREE.WebGLRenderer | null>(null);
@@ -126,6 +128,7 @@ export default function Cabinet3D({
       family === FAMILY.BASE || family === FAMILY.TALL
         ? legHeightMM / 1000
         : 0;
+    const legOffset = legsOffsetMM / 1000;
     const cabGroup = buildCabinetMesh({
       width: W,
       height: H,
@@ -140,6 +143,7 @@ export default function Cabinet3D({
       topPanel,
       bottomPanel,
       legHeight,
+      legsOffset: legOffset,
       dividerPosition: drawersCount > 0 ? undefined : dividerPosition,
       showEdges,
       rightSideEdgeBanding,

--- a/src/ui/panels/GlobalSettings.tsx
+++ b/src/ui/panels/GlobalSettings.tsx
@@ -142,6 +142,7 @@ export default function GlobalSettings(){
                 <div className="small">{t('global.legsCategory')}</div>
                 <input className="input" value={legCategory} readOnly />
               </div>
+              <Field label={t('global.legsOffset')} value={g.legsOffset ?? 35} onChange={(v)=>set({legsOffset:v})} />
               <Field label={t('global.offsetWall')} value={g.offsetWall||0} onChange={(v)=>set({offsetWall:v})} />
             </>)}
             {(fam===FAMILY.WALL || fam===FAMILY.PAWLACZ) && (<>

--- a/src/ui/types.ts
+++ b/src/ui/types.ts
@@ -32,5 +32,5 @@ export interface CabinetConfig {
     right?: SidePanelSpec & { dropToFloor?: boolean };
   };
   hardware?: any;
-  legs?: { type: string; height: number; category?: string };
+  legs?: { type: string; height: number; category?: string; legsOffset?: number };
 }

--- a/src/ui/useCabinetConfig.ts
+++ b/src/ui/useCabinetConfig.ts
@@ -52,6 +52,7 @@ export function useCabinetConfig(
         type: g.legsType,
         height: g.legsHeight,
         category: legCategories[g.legsType],
+        legsOffset: g.legsOffset,
       },
       carcassType: g.carcassType,
     });
@@ -186,7 +187,7 @@ export function useCabinetConfig(
       legsType: selectedLegsType,
       legs: {
         category: legCategories[selectedLegsType],
-        ...(g.legs || {}),
+        legsOffset: g.legsOffset,
         ...(advLocal.legs || {}),
       },
     };
@@ -326,6 +327,7 @@ export function useCabinetConfig(
         type: g.legsType,
         height: g.legsHeight,
         category: legCategories[g.legsType],
+        legsOffset: g.legsOffset,
       };
     return base;
   })();
@@ -341,6 +343,7 @@ export function useCabinetConfig(
                 type: g.legsType,
                 height: g.legsHeight,
                 category: legCategories[g.legsType],
+                legsOffset: g.legsOffset,
               },
           }
         : ({
@@ -349,6 +352,7 @@ export function useCabinetConfig(
               type: g.legsType,
               height: g.legsHeight,
               category: legCategories[g.legsType],
+              legsOffset: g.legsOffset,
             },
           } as CabinetConfig);
       return { ...base, ...patch };


### PR DESCRIPTION
## Summary
- support `legsOffset` in global and module settings
- allow configuring leg offset in settings panels
- offset cabinet legs in 3D builder based on provided value

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b9bde180688322865f5b1391f0b7d3