### PR TITLE
feat: support multiple leg types in 3D cabinet preview

### DIFF
--- a/src/ui/CabinetConfigurator.tsx
+++ b/src/ui/CabinetConfigurator.tsx
@@ -59,6 +59,12 @@ const CabinetConfigurator: React.FC<Props> = ({
   const legsHeight = gLocal.legs?.height ?? globalLegsHeight;
   const legType = gLocal.legs?.type ?? g.legsType;
   const legCategory = gLocal.legs?.category ?? legCategories[legType];
+  const legCategoryToType: Record<string, 'standard' | 'reinforced' | 'decorative'> = {
+    standard: 'standard',
+    wzmocniona: 'reinforced',
+    ozdobna: 'decorative',
+  };
+  const legsType = legCategoryToType[legCategory] ?? 'standard';
   const legsOffset = gLocal.legs?.legsOffset ?? g.legsOffset ?? 35;
   const baseOptions = [60, 100, 150];
   const legsBase = baseOptions.find((b) => Math.abs(legsHeight - b) <= 25) ?? 100;
@@ -173,6 +179,7 @@ const CabinetConfigurator: React.FC<Props> = ({
               highlightPart={highlightPart}
               legHeight={gLocal.legs?.height || globalLegsHeight}
               legsOffset={legsOffset}
+              legsType={legsType}
             />
           </div>
           <div className="grid2" style={{ marginTop: 8 }}>

--- a/src/ui/SceneViewer.tsx
+++ b/src/ui/SceneViewer.tsx
@@ -4,7 +4,7 @@ import type { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js
 import { setupThree } from '../scene/engine';
 import { buildCabinetMesh } from '../scene/cabinetBuilder';
 import { FAMILY } from '../core/catalog';
-import { usePlannerStore } from '../state/store';
+import { usePlannerStore, legCategories } from '../state/store';
 import { Module3D, ModuleAdv, Globals } from '../types';
 
 interface ThreeContext {
@@ -58,6 +58,15 @@ const SceneViewer: React.FC<Props> = ({ threeRef, addCountertop }) => {
             | undefined);
     const legOffset =
       adv.legs?.legsOffset ?? store.globals[mod.family]?.legsOffset ?? 0;
+    const legCategory =
+      adv.legs?.category ??
+      (adv.legs?.type ? legCategories[adv.legs.type] : undefined);
+    const legCategoryToType: Record<string, 'standard' | 'reinforced' | 'decorative'> = {
+      standard: 'standard',
+      wzmocniona: 'reinforced',
+      ozdobna: 'decorative',
+    };
+    const legsType = legCategory ? legCategoryToType[legCategory] : undefined;
     const group = buildCabinetMesh({
       width: W,
       height: H,
@@ -72,6 +81,7 @@ const SceneViewer: React.FC<Props> = ({ threeRef, addCountertop }) => {
       bottomPanel: adv.bottomPanel,
       legHeight,
       legsOffset: legOffset / 1000,
+      legsType,
       showHandles: true,
       hinge,
       dividerPosition,

--- a/src/ui/components/Cabinet3D.tsx
+++ b/src/ui/components/Cabinet3D.tsx
@@ -33,6 +33,7 @@ export default function Cabinet3D({
   highlightPart = null,
   legHeight: legHeightMM = 0,
   legsOffset: legsOffsetMM = 0,
+  legsType = 'standard',
 }: {
   widthMM: number;
   heightMM: number;
@@ -63,6 +64,7 @@ export default function Cabinet3D({
   highlightPart?: 'top' | 'bottom' | 'shelf' | 'back' | 'leftSide' | 'rightSide' | null;
   legHeight?: number;
   legsOffset?: number;
+  legsType?: 'standard' | 'reinforced' | 'decorative';
 }) {
   const ref = useRef<HTMLDivElement>(null);
   const rendererRef = useRef<THREE.WebGLRenderer | null>(null);
@@ -144,6 +146,7 @@ export default function Cabinet3D({
       bottomPanel,
       legHeight,
       legsOffset: legOffset,
+      legsType,
       dividerPosition: drawersCount > 0 ? undefined : dividerPosition,
       showEdges,
       rightSideEdgeBanding,
@@ -233,6 +236,8 @@ export default function Cabinet3D({
     carcassType,
     showFronts,
     legHeightMM,
+    legsOffsetMM,
+    legsType,
   ]);
 
   useEffect(() => {
@@ -316,6 +321,8 @@ export default function Cabinet3D({
     carcassType,
     showFronts,
     legHeightMM,
+    legsOffsetMM,
+    legsType,
   ]);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- support a new `legsType` prop in `Cabinet3D` and forward to `buildCabinetMesh`
- map global leg category to internal type and pass to `Cabinet3D`
- derive leg category in scene viewer to build cabinet meshes correctly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9c985c17083229080ce05e050f6ed