### PR TITLE
Use English leg category identifiers

### DIFF
--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -12,8 +12,8 @@ export const defaultGaps: Gaps = {
 
 export const legCategories: Record<string, string> = {
   'Nóżka kuchenna (standardowe)': 'standard',
-  'MULTI LEG (wzmocniona)': 'wzmocniona',
-  'Nóżka meblowa (ozdobna)': 'ozdobna',
+  'MULTI LEG (wzmocniona)': 'reinforced',
+  'Nóżka meblowa (ozdobna)': 'decorative',
 };
 
 export const defaultGlobal: Globals = {

--- a/src/ui/CabinetConfigurator.tsx
+++ b/src/ui/CabinetConfigurator.tsx
@@ -61,8 +61,8 @@ const CabinetConfigurator: React.FC<Props> = ({
   const legCategory = gLocal.legs?.category ?? legCategories[legType];
   const legCategoryToType: Record<string, 'standard' | 'reinforced' | 'decorative'> = {
     standard: 'standard',
-    wzmocniona: 'reinforced',
-    ozdobna: 'decorative',
+    reinforced: 'reinforced',
+    decorative: 'decorative',
   };
   const legsType = legCategoryToType[legCategory] ?? 'standard';
   const legsOffset = gLocal.legs?.legsOffset ?? g.legsOffset ?? 35;

--- a/src/ui/SceneViewer.tsx
+++ b/src/ui/SceneViewer.tsx
@@ -63,8 +63,8 @@ const SceneViewer: React.FC<Props> = ({ threeRef, addCountertop }) => {
       (adv.legs?.type ? legCategories[adv.legs.type] : undefined);
     const legCategoryToType: Record<string, 'standard' | 'reinforced' | 'decorative'> = {
       standard: 'standard',
-      wzmocniona: 'reinforced',
-      ozdobna: 'decorative',
+      reinforced: 'reinforced',
+      decorative: 'decorative',
     };
     const legsType = legCategory ? legCategoryToType[legCategory] : undefined;
     const group = buildCabinetMesh({

--- a/tests/updateGlobals.test.ts
+++ b/tests/updateGlobals.test.ts
@@ -24,14 +24,14 @@ describe('updateGlobals legs handling', () => {
     store.setState({ modules: [baseModule] });
     store.getState().updateGlobals(FAMILY.BASE, {
       legsType: 'MULTI LEG (wzmocniona)',
-      legsCategory: 'wzmocniona',
+      legsCategory: 'reinforced',
       legsHeight: 120,
     });
     const mod = store.getState().modules[0];
     expect(mod.adv?.legsType).toBe('MULTI LEG (wzmocniona)');
     expect(mod.adv?.legs?.type).toBe('MULTI LEG (wzmocniona)');
     expect(mod.adv?.legs?.height).toBe(120);
-    expect(mod.adv?.legs?.category).toBe('wzmocniona');
+    expect(mod.adv?.legs?.category).toBe('reinforced');
   });
 
   it('preserves custom leg settings while filling missing values', () => {
@@ -65,7 +65,7 @@ describe('updateGlobals legs handling', () => {
     store.setState({ modules });
     store.getState().updateGlobals(FAMILY.BASE, {
       legsType: 'MULTI LEG (wzmocniona)',
-      legsCategory: 'wzmocniona',
+      legsCategory: 'reinforced',
       legsHeight: 120,
     });
     const [modFull, modPartial] = store.getState().modules;


### PR DESCRIPTION
## Summary
- Map reinforced and decorative leg types to English category keys
- Adjust configurator, scene viewer, and tests for new category names

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9cb7e16b88322a8d8148132c2bd1a