### PR TITLE
Adjust leg position offset to align with cabinet edge

### DIFF
--- a/src/scene/cabinetBuilder.ts
+++ b/src/scene/cabinetBuilder.ts
@@ -999,7 +999,7 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
   // Feet (hardware)
   if (legHeight > 0) {
     const footHeight = legHeight;
-    const standardRadius = 0.02;
+    const standardRadius = 0.03;
     const baseSize = 0.08;
     const reinforcedCylRadius = 0.036 / 2;
     const decorativeSize = 0.04;
@@ -1010,10 +1010,10 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
           ? baseSize / 2
           : standardRadius;
     const positions: [number, number][] = [
-      [T + halfSize, -legOffset],
-      [W - T - halfSize, -legOffset],
-      [T + halfSize, -D + legOffset],
-      [W - T - halfSize, -D + legOffset],
+      [T + halfSize, -(legOffset + halfSize)],
+      [W - T - halfSize, -(legOffset + halfSize)],
+      [T + halfSize, -D + legOffset + halfSize],
+      [W - T - halfSize, -D + legOffset + halfSize],
     ];
     positions.forEach(([x, z]) => {
       let leg: THREE.Object3D;


### PR DESCRIPTION
## Summary
- Recompute leg positions so an offset of 0 places the leg's outer edge flush with the cabinet front/back
- Correct standard leg radius used for offset calculations

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9b8de15e08322bd63e161dd519125