### PR TITLE
refactor: adjust screw height calculation

### DIFF
--- a/src/scene/cabinetBuilder.ts
+++ b/src/scene/cabinetBuilder.ts
@@ -1096,10 +1096,9 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
         const footRadius = 50 / 1000 / 2;
         const footHeight = 10 / 1000;
         const screwRadius = 10 / 1000 / 2;
+        // footHeight + screwHeight + shaftHeight + plateThickness = legHeight
         const screwHeight = Math.max(
-          footHeight > legHeight
-            ? 0
-            : legHeight - plateThickness - shaftHeight - footHeight,
+          legHeight - plateThickness - shaftHeight - footHeight,
           0,
         );
 


### PR DESCRIPTION
## Summary
- compute screw height directly from remaining leg height
- document that foot, screw, shaft and plate heights sum to legHeight

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b9f298bde88322aa9a6e12b4462b2a