### PR TITLE
feat: add draw walls mode

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -42,6 +42,8 @@
     "addWall": "Add wall",
     "addWindow": "Add window",
     "addDoor": "Add door",
+    "drawWalls": "Draw walls",
+    "finishDrawing": "Finish drawing",
     "noWalls": "No walls"
   },
   "global": {

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -42,6 +42,8 @@
     "addWall": "Dodaj ścianę",
     "addWindow": "Dodaj okno",
     "addDoor": "Dodaj drzwi",
+    "drawWalls": "Rysuj ściany",
+    "finishDrawing": "Zakończ rysowanie",
     "noWalls": "Brak ścian"
   },
   "global": {

--- a/src/ui/panels/RoomTab.tsx
+++ b/src/ui/panels/RoomTab.tsx
@@ -13,6 +13,8 @@ export default function RoomTab({
   const [len, setLen] = useState(3000);
   const [angle, setAngle] = useState(0);
   const [height, setHeight] = useState(store.room.height || 2700);
+  const [isDrawingWalls, setIsDrawingWalls] = useState(false);
+  const onDrawWalls = () => setIsDrawingWalls((d) => !d);
   useEffect(() => {
     store.setRoom({ height });
   }, [height]);
@@ -141,6 +143,11 @@ export default function RoomTab({
             </button>
             <button className="btnGhost" onClick={addDoor}>
               {t('room.addDoor')}
+            </button>
+            <button className="btnGhost" onClick={onDrawWalls}>
+              {isDrawingWalls
+                ? t('room.finishDrawing')
+                : t('room.drawWalls')}
             </button>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- add i18n strings for starting and finishing wall drawing
- add button and state for toggling wall drawing mode

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bbf46fec288322b4e0a7ddd7f7242c