### PR TITLE
feat: add top-down wall drawing mode

### DIFF
--- a/src/scene/engine.ts
+++ b/src/scene/engine.ts
@@ -1,15 +1,21 @@
 import * as THREE from 'three';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
+import { usePlannerStore } from '../state/store';
+import WallDrawer from '../viewer/WallDrawer';
 export function setupThree(container: HTMLElement) {
   const scene = new THREE.Scene();
   scene.background = new THREE.Color(0xf3f4f6);
-  const camera = new THREE.PerspectiveCamera(
+  const perspCamera = new THREE.PerspectiveCamera(
     45,
     container.clientWidth / container.clientHeight,
     0.1,
     100,
   );
-  camera.position.set(4, 3, 6);
+  perspCamera.position.set(4, 3, 6);
+  const orthoCamera = new THREE.OrthographicCamera(-10, 10, 10, -10, 0.1, 100);
+  orthoCamera.position.set(0, 20, 0);
+  orthoCamera.lookAt(0, 0, 0);
+  let camera: THREE.Camera = perspCamera;
   const renderer = new THREE.WebGLRenderer({
     antialias: true,
     preserveDrawingBuffer: true,
@@ -22,7 +28,8 @@ export function setupThree(container: HTMLElement) {
   const dir = new THREE.DirectionalLight(0xffffff, 0.7);
   dir.position.set(6, 8, 4);
   scene.add(dir);
-  scene.add(new THREE.GridHelper(20, 40, 0xdddddd, 0xcccccc));
+  const grid = new THREE.GridHelper(20, 40, 0xdddddd, 0xcccccc);
+  scene.add(grid);
   const floor = new THREE.Mesh(
     new THREE.PlaneGeometry(40, 40),
     new THREE.MeshStandardMaterial({ color: 0xeeeeee, side: THREE.DoubleSide }),
@@ -31,16 +38,45 @@ export function setupThree(container: HTMLElement) {
   scene.add(floor);
   const group = new THREE.Group();
   scene.add(group);
-  const controls = new OrbitControls(camera, renderer.domElement);
+  const controls = new OrbitControls(perspCamera, renderer.domElement);
   controls.enableDamping = true;
+  const wallDrawer = new WallDrawer(renderer, () => camera, usePlannerStore);
+  const orthoSize = 20;
   const onResize = () => {
     const w = container.clientWidth,
       h = container.clientHeight;
     renderer.setSize(w, h);
-    camera.aspect = w / h;
-    camera.updateProjectionMatrix();
+    if (camera === perspCamera) {
+      perspCamera.aspect = w / h;
+      perspCamera.updateProjectionMatrix();
+    } else {
+      const aspect = w / h;
+      orthoCamera.left = (-orthoSize * aspect) / 2;
+      orthoCamera.right = (orthoSize * aspect) / 2;
+      orthoCamera.top = orthoSize / 2;
+      orthoCamera.bottom = -orthoSize / 2;
+      orthoCamera.updateProjectionMatrix();
+    }
   };
   window.addEventListener('resize', onResize);
+  const enterTopDownMode = () => {
+    camera = orthoCamera;
+    controls.object = camera as any;
+    controls.enableRotate = false;
+    group.visible = false;
+    floor.visible = false;
+    onResize();
+    wallDrawer.enable();
+  };
+  const exitTopDownMode = () => {
+    wallDrawer.disable();
+    camera = perspCamera;
+    controls.object = camera as any;
+    controls.enableRotate = true;
+    group.visible = true;
+    floor.visible = true;
+    onResize();
+  };
   const run = true;
   const loop = () => {
     if (!run) return;
@@ -49,5 +85,13 @@ export function setupThree(container: HTMLElement) {
     requestAnimationFrame(loop);
   };
   loop();
-  return { scene, camera, renderer, controls, group };
+  return {
+    scene,
+    camera,
+    renderer,
+    controls,
+    group,
+    enterTopDownMode,
+    exitTopDownMode,
+  };
 }

--- a/src/ui/panels/RoomTab.tsx
+++ b/src/ui/panels/RoomTab.tsx
@@ -3,7 +3,6 @@ import * as THREE from 'three';
 import { useTranslation } from 'react-i18next';
 import { usePlannerStore } from '../../state/store';
 import RoomUploader from '../RoomUploader';
-import WallDrawing2D from './WallDrawing2D';
 export default function RoomTab({
   three,
 }: {
@@ -15,7 +14,14 @@ export default function RoomTab({
   const [angle, setAngle] = useState(0);
   const [height, setHeight] = useState(store.room.height || 2700);
   const [isDrawingWalls, setIsDrawingWalls] = useState(false);
-  const onDrawWalls = () => setIsDrawingWalls((d) => !d);
+  const onDrawWalls = () => {
+    three.current?.enterTopDownMode?.();
+    setIsDrawingWalls(true);
+  };
+  const onFinishDrawing = () => {
+    three.current?.exitTopDownMode?.();
+    setIsDrawingWalls(false);
+  };
   useEffect(() => {
     store.setRoom({ height });
   }, [height]);
@@ -145,18 +151,22 @@ export default function RoomTab({
             <button className="btnGhost" onClick={addDoor}>
               {t('room.addDoor')}
             </button>
-            <button className="btnGhost" onClick={onDrawWalls}>
-              {isDrawingWalls
-                ? t('room.finishDrawing')
-                : t('room.drawWalls')}
+            <button
+              className="btnGhost"
+              onClick={onDrawWalls}
+              disabled={isDrawingWalls}
+            >
+              {t('room.drawWalls')}
             </button>
+            {isDrawingWalls && (
+              <button className="btnGhost" onClick={onFinishDrawing}>
+                {t('room.finishDrawing')}
+              </button>
+            )}
           </div>
         </div>
       </div>
       <RoomUploader three={three} />
-      {isDrawingWalls && (
-        <WallDrawing2D onFinish={() => setIsDrawingWalls(false)} />
-      )}
     </>
   );
 }

--- a/src/viewer/WallDrawer.ts
+++ b/src/viewer/WallDrawer.ts
@@ -1,0 +1,70 @@
+import * as THREE from 'three';
+import type { WebGLRenderer, Camera } from 'three';
+import type { UseBoundStore, StoreApi } from 'zustand';
+import { usePlannerStore } from '../state/store';
+
+interface PlannerStore {
+  addWall: (w: { length: number; angle: number }) => void;
+}
+
+export default class WallDrawer {
+  private renderer: WebGLRenderer;
+  private getCamera: () => Camera;
+  private store: UseBoundStore<StoreApi<PlannerStore>>;
+  private raycaster = new THREE.Raycaster();
+  private plane = new THREE.Plane(new THREE.Vector3(0, 1, 0), 0);
+  private start: THREE.Vector3 | null = null;
+
+  constructor(
+    renderer: WebGLRenderer,
+    getCamera: () => Camera,
+    store: typeof usePlannerStore,
+  ) {
+    this.renderer = renderer;
+    this.getCamera = getCamera;
+    this.store = store;
+  }
+
+  enable() {
+    const dom = this.renderer.domElement;
+    dom.addEventListener('pointerdown', this.onDown);
+    dom.addEventListener('pointerup', this.onUp);
+  }
+
+  disable() {
+    const dom = this.renderer.domElement;
+    dom.removeEventListener('pointerdown', this.onDown);
+    dom.removeEventListener('pointerup', this.onUp);
+    this.start = null;
+  }
+
+  private getPoint(event: PointerEvent): THREE.Vector3 | null {
+    const rect = this.renderer.domElement.getBoundingClientRect();
+    const x = ((event.clientX - rect.left) / rect.width) * 2 - 1;
+    const y = -((event.clientY - rect.top) / rect.height) * 2 + 1;
+    const cam = this.getCamera();
+    this.raycaster.setFromCamera(new THREE.Vector2(x, y), cam);
+    const point = new THREE.Vector3();
+    this.raycaster.ray.intersectPlane(this.plane, point);
+    return point;
+  }
+
+  private onDown = (e: PointerEvent) => {
+    this.start = this.getPoint(e);
+  };
+
+  private onUp = (e: PointerEvent) => {
+    if (!this.start) return;
+    const end = this.getPoint(e);
+    if (!end) {
+      this.start = null;
+      return;
+    }
+    const dx = end.x - this.start.x;
+    const dz = end.z - this.start.z;
+    const length = Math.sqrt(dx * dx + dz * dz) * 1000; // meters to mm
+    const angle = (Math.atan2(dz, dx) * 180) / Math.PI;
+    this.store.getState().addWall({ length, angle });
+    this.start = null;
+  };
+}


### PR DESCRIPTION
## Summary
- add orthographic camera and top-down mode toggling
- enable wall drawing with raycaster in WallDrawer
- update room UI with start/finish drawing controls

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bbfab782b48322aa10a9fe1e365dce