### PR TITLE
Integrate 2D wall drawing overlay in room editor

### DIFF
--- a/src/ui/panels/RoomTab.tsx
+++ b/src/ui/panels/RoomTab.tsx
@@ -3,6 +3,7 @@ import * as THREE from 'three';
 import { useTranslation } from 'react-i18next';
 import { usePlannerStore } from '../../state/store';
 import RoomUploader from '../RoomUploader';
+import WallDrawing2D from './WallDrawing2D';
 export default function RoomTab({
   three,
 }: {
@@ -167,6 +168,7 @@ export default function RoomTab({
         </div>
       </div>
       <RoomUploader three={three} />
+      {isDrawingWalls && <WallDrawing2D onFinish={onFinishDrawing} />}
     </>
   );
 }


### PR DESCRIPTION
## Summary
- Show WallDrawing2D overlay when entering drawing mode in RoomTab
- Ensure overlay closes and camera resets when finishing wall drawing

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bc062274008322bd46d7c4385490b5