### PR TITLE
feat: enable cabinet dragging in top-down view

### DIFF
--- a/src/scene/engine.ts
+++ b/src/scene/engine.ts
@@ -2,6 +2,7 @@ import * as THREE from 'three';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 import { usePlannerStore } from '../state/store';
 import WallDrawer from '../viewer/WallDrawer';
+import CabinetDragger from '../viewer/CabinetDragger';
 export function setupThree(container: HTMLElement) {
   const scene = new THREE.Scene();
   scene.background = new THREE.Color(0xf3f4f6);
@@ -45,6 +46,12 @@ export function setupThree(container: HTMLElement) {
   const controls = new OrbitControls(perspCamera, renderer.domElement);
   controls.enableDamping = true;
   const wallDrawer = new WallDrawer(renderer, () => camera, usePlannerStore);
+  const cabinetDragger = new CabinetDragger(
+    renderer,
+    () => camera,
+    group,
+    usePlannerStore,
+  );
   const orthoSize = 20;
   const onResize = () => {
     const w = container.clientWidth,
@@ -96,11 +103,13 @@ export function setupThree(container: HTMLElement) {
         controls.enableRotate = false;
         onResize();
         wallDrawer.enable();
+        cabinetDragger.enable();
       },
     );
   };
   const exitTopDownMode = () => {
     wallDrawer.disable();
+    cabinetDragger.disable();
     perspCamera.position.copy(topPos);
     perspCamera.quaternion.copy(topQuat);
     camera = perspCamera;

--- a/src/viewer/CabinetDragger.ts
+++ b/src/viewer/CabinetDragger.ts
@@ -1,0 +1,103 @@
+import * as THREE from 'three';
+import type { WebGLRenderer, Camera } from 'three';
+import type { UseBoundStore, StoreApi } from 'zustand';
+import { usePlannerStore } from '../state/store';
+import type { Module3D } from '../types';
+
+interface PlannerStore {
+  modules: Module3D[];
+  updateModule: (id: string, patch: Partial<Module3D>) => void;
+}
+
+export default class CabinetDragger {
+  private renderer: WebGLRenderer;
+  private getCamera: () => Camera;
+  private group: THREE.Group;
+  private store: UseBoundStore<StoreApi<PlannerStore>>;
+  private raycaster = new THREE.Raycaster();
+  private plane = new THREE.Plane(new THREE.Vector3(0, 0, 1), 0);
+  private draggingId: string | null = null;
+  private offset = new THREE.Vector3();
+
+  constructor(
+    renderer: WebGLRenderer,
+    getCamera: () => Camera,
+    group: THREE.Group,
+    store: typeof usePlannerStore,
+  ) {
+    this.renderer = renderer;
+    this.getCamera = getCamera;
+    this.group = group;
+    this.store = store;
+  }
+
+  enable() {
+    const dom = this.renderer.domElement;
+    dom.addEventListener('pointerdown', this.onDown);
+    dom.addEventListener('pointermove', this.onMove);
+    dom.addEventListener('pointerup', this.onUp);
+  }
+
+  disable() {
+    const dom = this.renderer.domElement;
+    dom.removeEventListener('pointerdown', this.onDown);
+    dom.removeEventListener('pointermove', this.onMove);
+    dom.removeEventListener('pointerup', this.onUp);
+    this.draggingId = null;
+  }
+
+  private getPoint(event: PointerEvent): THREE.Vector3 | null {
+    const rect = this.renderer.domElement.getBoundingClientRect();
+    const x = ((event.clientX - rect.left) / rect.width) * 2 - 1;
+    const y = -((event.clientY - rect.top) / rect.height) * 2 + 1;
+    const cam = this.getCamera();
+    this.raycaster.setFromCamera(new THREE.Vector2(x, y), cam);
+    const point = new THREE.Vector3();
+    this.raycaster.ray.intersectPlane(this.plane, point);
+    return point;
+  }
+
+  private onDown = (e: PointerEvent) => {
+    const rect = this.renderer.domElement.getBoundingClientRect();
+    const x = ((e.clientX - rect.left) / rect.width) * 2 - 1;
+    const y = -((e.clientY - rect.top) / rect.height) * 2 + 1;
+    const cam = this.getCamera();
+    this.raycaster.setFromCamera(new THREE.Vector2(x, y), cam);
+    const intersects = this.raycaster.intersectObjects(this.group.children, true);
+    if (intersects.length === 0) return;
+    let obj: THREE.Object3D | null = intersects[0].object;
+    while (obj && obj.parent !== this.group) {
+      obj = obj.parent;
+    }
+    if (!obj || obj.parent !== this.group) return;
+    if (obj.userData.kind !== 'cab') return;
+    const cabinets = this.group.children.filter((c) => c.userData.kind === 'cab');
+    const index = cabinets.indexOf(obj);
+    const mods = this.store.getState().modules;
+    const mod = mods[index];
+    if (!mod) return;
+    const point = this.getPoint(e);
+    if (!point) return;
+    this.draggingId = mod.id;
+    this.offset.set(mod.position[0], mod.position[1], 0).sub(point);
+  };
+
+  private onMove = (e: PointerEvent) => {
+    if (!this.draggingId) return;
+    const point = this.getPoint(e);
+    if (!point) return;
+    const mods = this.store.getState().modules;
+    const current = mods.find((m) => m.id === this.draggingId);
+    if (!current) return;
+    const newX = point.x + this.offset.x;
+    const newY = point.y + this.offset.y;
+    this.store.getState().updateModule(this.draggingId, {
+      position: [newX, newY, current.position[2]],
+    });
+  };
+
+  private onUp = () => {
+    this.draggingId = null;
+  };
+}
+


### PR DESCRIPTION
## Summary
- add CabinetDragger using XY raycasting to drag and reposition modules
- activate CabinetDragger when entering top-down mode and disable when leaving

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc0f1424988322a5852956639f636a