### PR TITLE
Simplify Room tab UI

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -36,7 +36,11 @@
   },
   "room": {
     "title": "Room — walls",
+    "height": "Room height (mm)",
+    "addWindow": "Add window",
+    "addDoor": "Add door",
     "drawWalls": "Draw walls",
+    "finishDrawing": "Finish drawing",
     "noWalls": "No walls"
   },
   "global": {

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -36,7 +36,11 @@
   },
   "room": {
     "title": "Pomieszczenie — ściany",
+    "height": "Wysokość pomieszczenia (mm)",
+    "addWindow": "Dodaj okno",
+    "addDoor": "Dodaj drzwi",
     "drawWalls": "Rysuj ściany",
+    "finishDrawing": "Zakończ rysowanie",
     "noWalls": "Brak ścian"
   },
   "global": {

--- a/src/ui/panels/RoomTab.tsx
+++ b/src/ui/panels/RoomTab.tsx
@@ -12,6 +12,11 @@ export default function RoomTab({
   const store = usePlannerStore();
   const { t } = useTranslation();
   const [isDrawingWalls, setIsDrawingWalls] = useState(false);
+  const onHeightChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    store.setRoom({ height: Number((e.target as HTMLInputElement).value) || 0 });
+  };
+  const onAddWindow = () => store.addOpening({ kind: 0 });
+  const onAddDoor = () => store.addOpening({ kind: 1 });
   const onDrawWalls = () => {
     three.current?.enterTopDownMode?.();
     setIsDrawingWalls(true);
@@ -79,6 +84,25 @@ export default function RoomTab({
           </div>
         </div>
         <div className="bd">
+          <div className="row">
+            <div>
+              <div className="small">{t('room.height')}</div>
+              <input
+                className="input"
+                type="number"
+                value={store.room.height || 0}
+                onChange={onHeightChange}
+              />
+            </div>
+          </div>
+          <div className="row" style={{ marginTop: 8 }}>
+            <button className="btnGhost" onClick={onAddWindow}>
+              {t('room.addWindow')}
+            </button>
+            <button className="btnGhost" onClick={onAddDoor}>
+              {t('room.addDoor')}
+            </button>
+          </div>
           <div className="row" style={{ marginTop: 8 }}>
             <button
               className="btnGhost"
@@ -89,7 +113,7 @@ export default function RoomTab({
             </button>
             {isDrawingWalls && (
               <button className="btnGhost" onClick={onFinishDrawing}>
-                Zakończ rysowanie
+                {t('room.finishDrawing')}
               </button>
             )}
           </div>


### PR DESCRIPTION
## Summary
- simplify Room tab to include only room height input, window/door buttons, and wall drawing controls
- update translations for Room tab UI in English and Polish

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bc112549248322867245087a68b38f