### PR TITLE
Add wall editing and removal with undo/redo support

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -11,6 +11,8 @@
     "clear": "Clear",
     "wallLabel": "Wall {{num}} ({{len}} mm)",
     "autoWall": "Auto for wall",
+    "removeWall": "Remove wall",
+    "editWall": "Edit wall",
     "auto": "Auto",
     "material": {
       "title": "Material (sheet)",

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -11,6 +11,8 @@
     "clear": "Wyczyść",
     "wallLabel": "Ściana {{num}} ({{len}} mm)",
     "autoWall": "Auto pod ścianę",
+    "removeWall": "Usuń ścianę",
+    "editWall": "Edytuj ścianę",
     "auto": "Auto",
     "material": {
       "title": "Materiał (arkusz)",

--- a/src/ui/TopBar.tsx
+++ b/src/ui/TopBar.tsx
@@ -15,6 +15,17 @@ interface TopBarProps {
 }
 
 export default function TopBar({ t, store, setVariant, setKind, selWall, setSelWall, doAutoOnSelectedWall, lang, setLang }: TopBarProps) {
+  const onRemoveWall = () => {
+    store.removeWall(selWall);
+    setSelWall(0);
+  };
+  const onEditWall = () => {
+    const w = store.room.walls[selWall];
+    if (!w) return;
+    const length = Number(prompt('Length (mm)', String(w.length))) || w.length;
+    const angle = Number(prompt('Angle (deg)', String(w.angle))) || w.angle;
+    store.updateWall(selWall, { length, angle });
+  };
   return (
     <div className="topbar row">
       <button className="btnGhost" onClick={() => store.setRole(store.role === 'stolarz' ? 'klient' : 'stolarz')}>
@@ -43,6 +54,20 @@ export default function TopBar({ t, store, setVariant, setKind, selWall, setSelW
           </option>
         ))}
       </select>
+      <button
+        className="btnGhost"
+        onClick={onRemoveWall}
+        disabled={store.room.walls.length === 0}
+      >
+        {t('app.removeWall')}
+      </button>
+      <button
+        className="btnGhost"
+        onClick={onEditWall}
+        disabled={store.room.walls.length === 0}
+      >
+        {t('app.editWall')}
+      </button>
       <button className="btn" onClick={doAutoOnSelectedWall}>
         {t('app.autoWall')}
       </button>

--- a/src/ui/panels/RoomTab.tsx
+++ b/src/ui/panels/RoomTab.tsx
@@ -74,7 +74,7 @@ export default function RoomTab({
       group.add(box);
       cursor = next;
     });
-  }, [store.room, three]);
+  }, [store.room.walls, store.room.height, three]);
   return (
     <>
       <div className="section">
@@ -115,6 +115,19 @@ export default function RoomTab({
               <button className="btnGhost" onClick={onFinishDrawing}>
                 {t('room.finishDrawing')}
               </button>
+            )}
+          </div>
+          <div className="row" style={{ marginTop: 8 }}>
+            {store.room.walls.length === 0 ? (
+              <div>{t('room.noWalls')}</div>
+            ) : (
+              <ul>
+                {store.room.walls.map((w, i) => (
+                  <li key={i}>
+                    {t('app.wallLabel', { num: i + 1, len: w.length })} – {w.angle}°
+                  </li>
+                ))}
+              </ul>
             )}
           </div>
         </div>


### PR DESCRIPTION
## Summary
- allow store to update or remove walls and track these changes in undo/redo history
- add TopBar controls for removing and editing a selected wall
- render current room walls in RoomTab and react to changes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc16076e208322b798cfde600e538f