### PR TITLE
feat: allow configurable wall thickness

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -39,6 +39,7 @@
   "room": {
     "title": "Room — walls",
     "height": "Room height (mm)",
+    "wallThickness": "Wall thickness (mm)",
     "addWindow": "Add window",
     "addDoor": "Add door",
     "drawWalls": "Draw walls",

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -39,6 +39,7 @@
   "room": {
     "title": "Pomieszczenie — ściany",
     "height": "Wysokość pomieszczenia (mm)",
+    "wallThickness": "Grubość ściany (mm)",
     "addWindow": "Dodaj okno",
     "addDoor": "Dodaj drzwi",
     "drawWalls": "Rysuj ściany",

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -124,6 +124,7 @@ type Store = {
   past: { modules: Module3D[]; room: Room }[];
   future: { modules: Module3D[]; room: Room }[];
   room: Room;
+  wallThickness: number;
   showFronts: boolean;
   setRole: (r: 'stolarz' | 'klient') => void;
   updateGlobals: (fam: FAMILY, patch: Partial<Globals[FAMILY]>) => void;
@@ -135,14 +136,15 @@ type Store = {
   undo: () => void;
   redo: () => void;
   setRoom: (patch: Partial<Room>) => void;
-  addWall: (w: { length: number; angle: number }) => void;
+  addWall: (w: { length: number; angle: number; thickness: number }) => void;
   removeWall: (index: number) => void;
   updateWall: (
     index: number,
-    patch: Partial<{ length: number; angle: number }>,
+    patch: Partial<{ length: number; angle: number; thickness: number }>,
   ) => void;
   addOpening: (op: Opening) => void;
   setShowFronts: (v: boolean) => void;
+  setWallThickness: (v: number) => void;
 };
 
 export const usePlannerStore = create<Store>((set, get) => ({
@@ -152,7 +154,17 @@ export const usePlannerStore = create<Store>((set, get) => ({
   modules: persisted?.modules || [],
   past: [],
   future: [],
-  room: persisted?.room || { walls: [], openings: [], height: 2700 },
+  room: persisted?.room
+    ? {
+        ...persisted.room,
+        walls:
+          persisted.room.walls?.map((w: any) => ({
+            thickness: 100,
+            ...w,
+          })) || [],
+      }
+    : { walls: [], openings: [], height: 2700 },
+  wallThickness: persisted?.wallThickness || 100,
   showFronts: true,
   setRole: (r) => set({ role: r }),
   updateGlobals: (fam, patch) =>
@@ -363,6 +375,7 @@ export const usePlannerStore = create<Store>((set, get) => ({
       future: [],
     })),
   setShowFronts: (v) => set({ showFronts: v }),
+  setWallThickness: (v) => set({ wallThickness: v }),
 }));
 
 usePlannerStore.subscribe((state) => {
@@ -375,6 +388,7 @@ usePlannerStore.subscribe((state) => {
         prices: state.prices,
         modules: state.modules,
         room: state.room,
+        wallThickness: state.wallThickness,
       }),
     );
   } catch (e) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -186,7 +186,7 @@ export interface Module3D {
 export type Opening = Record<string, number>;
 
 export interface Room {
-  walls: { length: number; angle: number }[];
+  walls: { length: number; angle: number; thickness: number }[];
   openings: Opening[];
   height: number;
 }

--- a/src/ui/panels/RoomTab.tsx
+++ b/src/ui/panels/RoomTab.tsx
@@ -65,7 +65,7 @@ export default function RoomTab({
         (cursor.y + next.y) / 2,
       );
       const box = new THREE.Mesh(
-        new THREE.BoxGeometry(len, h, 0.1),
+        new THREE.BoxGeometry(len, h, (w.thickness || 0) / 1000),
         new THREE.MeshStandardMaterial({ color: 0xd1d5db }),
       );
       box.position.set(mid.x, h / 2, mid.y);
@@ -92,6 +92,21 @@ export default function RoomTab({
                 type="number"
                 value={store.room.height || 0}
                 onChange={onHeightChange}
+              />
+            </div>
+          </div>
+          <div className="row" style={{ marginTop: 8 }}>
+            <div>
+              <div className="small">{t('room.wallThickness')}</div>
+              <input
+                className="input"
+                type="number"
+                value={store.wallThickness}
+                onChange={(e) =>
+                  store.setWallThickness(
+                    Number((e.target as HTMLInputElement).value) || 0,
+                  )
+                }
               />
             </div>
           </div>
@@ -124,7 +139,19 @@ export default function RoomTab({
               <ul>
                 {store.room.walls.map((w, i) => (
                   <li key={i}>
-                    {t('app.wallLabel', { num: i + 1, len: w.length })} – {w.angle}°
+                    {t('app.wallLabel', { num: i + 1, len: w.length })} – {w.angle}° –
+                    <input
+                      type="number"
+                      value={w.thickness}
+                      onChange={(e) =>
+                        store.updateWall(i, {
+                          thickness:
+                            Number((e.target as HTMLInputElement).value) || 0,
+                        })
+                      }
+                      style={{ width: 60, marginLeft: 4 }}
+                    />
+                    mm
                   </li>
                 ))}
               </ul>

--- a/src/viewer/WallDrawer.ts
+++ b/src/viewer/WallDrawer.ts
@@ -4,7 +4,8 @@ import type { UseBoundStore, StoreApi } from 'zustand';
 import { usePlannerStore } from '../state/store';
 
 interface PlannerStore {
-  addWall: (w: { length: number; angle: number }) => void;
+  addWall: (w: { length: number; angle: number; thickness: number }) => void;
+  wallThickness: number;
 }
 
 export default class WallDrawer {
@@ -114,7 +115,8 @@ export default class WallDrawer {
     const dz = end.z - this.start.z;
     const length = Math.sqrt(dx * dx + dz * dz) * 1000; // meters to mm
     const angle = (Math.atan2(dz, dx) * 180) / Math.PI;
-    this.store.getState().addWall({ length, angle });
+    const thickness = this.store.getState().wallThickness;
+    this.store.getState().addWall({ length, angle, thickness });
     this.start = null;
     this.cleanupPreview();
   };


### PR DESCRIPTION
## Summary
- store wall thickness for each room wall
- expose thickness setting in RoomTab UI
- draw walls using stored thickness

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bc183ebd2883229e9842a7bda02027