### PR TITLE
Lock sliding panel during wall drawing

### DIFF
--- a/src/ui/MainTabs.tsx
+++ b/src/ui/MainTabs.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { FAMILY, FAMILY_LABELS } from '../core/catalog';
 import type { Kind, Variant } from '../core/catalog';
 import TypePicker, { KindTabs, VariantList } from './panels/CatalogPicker';
@@ -74,6 +74,7 @@ export default function MainTabs({
   addCountertop,
   setAddCountertop,
 }: MainTabsProps) {
+  const [isDrawingWalls, setIsDrawingWalls] = useState(false);
   const toggleTab = (name: 'cab' | 'room' | 'costs' | 'cut' | 'global') => {
     setTab(tab === name ? null : name);
   };
@@ -102,6 +103,7 @@ export default function MainTabs({
         isOpen={tab !== null}
         onClose={() => setTab(null)}
         className={tab !== null ? 'open' : ''}
+        locked={isDrawingWalls}
       >
         {tab === 'cab' && (
           <>
@@ -183,7 +185,13 @@ export default function MainTabs({
           </>
         )}
 
-        {tab === 'room' && <RoomTab three={threeRef} />}
+        {tab === 'room' && (
+          <RoomTab
+            three={threeRef}
+            isDrawingWalls={isDrawingWalls}
+            setIsDrawingWalls={setIsDrawingWalls}
+          />
+        )}
         {tab === 'costs' && <CostsTab />}
         {tab === 'cut' && (
           <CutlistTab

--- a/src/ui/components/SlidingPanel.tsx
+++ b/src/ui/components/SlidingPanel.tsx
@@ -5,6 +5,7 @@ interface SlidingPanelProps {
   onClose: () => void;
   children: React.ReactNode;
   className?: string;
+  locked?: boolean;
 }
 
 export default function SlidingPanel({
@@ -12,11 +13,12 @@ export default function SlidingPanel({
   onClose,
   children,
   className = '',
+  locked = false,
 }: SlidingPanelProps) {
   const panelRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    if (!isOpen) return;
+    if (!isOpen || locked) return;
 
     const handleMouseDown = (e: MouseEvent) => {
       if (panelRef.current && !panelRef.current.contains(e.target as Node)) {
@@ -28,13 +30,15 @@ export default function SlidingPanel({
     return () => {
       document.removeEventListener('mousedown', handleMouseDown);
     };
-  }, [isOpen, onClose]);
+  }, [isOpen, onClose, locked]);
 
   return (
     <div ref={panelRef} className={`slidingPanel ${className}`}>
-      <button className="slidingPanelClose" onClick={onClose}>
-        ×
-      </button>
+      {!locked && (
+        <button className="slidingPanelClose" onClick={onClose}>
+          ×
+        </button>
+      )}
       {children}
     </div>
   );

--- a/src/ui/panels/RoomTab.tsx
+++ b/src/ui/panels/RoomTab.tsx
@@ -1,17 +1,22 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import * as THREE from 'three';
 import { useTranslation } from 'react-i18next';
 import { usePlannerStore } from '../../state/store';
 import RoomUploader from '../RoomUploader';
 
+interface RoomTabProps {
+  three: React.MutableRefObject<any>;
+  isDrawingWalls: boolean;
+  setIsDrawingWalls: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
 export default function RoomTab({
   three,
-}: {
-  three: React.MutableRefObject<any>;
-}) {
+  isDrawingWalls,
+  setIsDrawingWalls,
+}: RoomTabProps) {
   const store = usePlannerStore();
   const { t } = useTranslation();
-  const [isDrawingWalls, setIsDrawingWalls] = useState(false);
   const onHeightChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     store.setRoom({ height: Number((e.target as HTMLInputElement).value) || 0 });
   };


### PR DESCRIPTION
## Summary
- add optional `locked` prop to `SlidingPanel` that disables outside click close and hides close button
- keep main panel open while drawing walls by passing `isDrawingWalls` state to `SlidingPanel` and `RoomTab`
- toggle `isDrawingWalls` from `RoomTab` when starting and finishing wall drawing

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bc23bd1f9c832280a336f9becd78e9