### PR TITLE
fix: remove keydown listener on cleanup

### DIFF
--- a/src/viewer/WallDrawer.ts
+++ b/src/viewer/WallDrawer.ts
@@ -54,6 +54,7 @@ export default class WallDrawer {
 
   private cleanupPreview() {
     if (this.lengthInput) {
+      this.lengthInput.removeEventListener('keydown', this.onInputKeyDown);
       this.lengthInput.remove();
       this.lengthInput = null;
     }


### PR DESCRIPTION
## Summary
- prevent keyboard event listener leaks by removing it from the wall length input before element cleanup

## Testing
- `npm test`
- `npx vitest run tests/wallDrawerToggle.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68bc7d8a24a8832294b2cf6a561678db