### PR TITLE
Validate wall segment length

### DIFF
--- a/src/viewer/WallDrawer.ts
+++ b/src/viewer/WallDrawer.ts
@@ -151,6 +151,12 @@ export default class WallDrawer {
     if (!this.start || !this.preview || !this.lengthInput) return;
     const lengthMm = parseFloat(this.lengthInput.value);
     if (isNaN(lengthMm)) return;
+    if (lengthMm <= 0) {
+      this.lengthInput.setCustomValidity('Length must be greater than 0');
+      this.lengthInput.reportValidity();
+      return;
+    }
+    this.lengthInput.setCustomValidity('');
     const lengthM = lengthMm / 1000;
     const end = new THREE.Vector3(
       this.start.x + Math.cos(this.currentAngle) * lengthM,


### PR DESCRIPTION
## Summary
- prevent creating wall segments with zero or negative length in `WallDrawer`
- show a validation message when such value is entered

## Testing
- `npm test`
- manual check of function handling negative/zero length

------
https://chatgpt.com/codex/tasks/task_e_68bc7f912d108322b85da54e45c0dbf6