### PR TITLE
Handle short clicks in wall drawing

### DIFF
--- a/src/viewer/WallDrawer.ts
+++ b/src/viewer/WallDrawer.ts
@@ -177,7 +177,11 @@ export default class WallDrawer {
     const dx = end.x - this.start.x;
     const dz = end.z - this.start.z;
     const lengthMm = Math.sqrt(dx * dx + dz * dz) * 1000; // meters to mm
-    if (lengthMm < 1) return;
+    if (lengthMm < 1) {
+      this.cleanupPreview();
+      this.start = null;
+      return;
+    }
     const angleDeg = (Math.atan2(dz, dx) * 180) / Math.PI;
     const { snapAngle, snapLength } = this.store.getState();
     const snappedAngle = snapAngle

--- a/tests/wallDrawer.e2e.test.ts
+++ b/tests/wallDrawer.e2e.test.ts
@@ -1,0 +1,46 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import * as THREE from 'three';
+import WallDrawer from '../src/viewer/WallDrawer';
+
+describe('WallDrawer click without drag', () => {
+  it('cleans up preview and resets state', () => {
+    const canvas = document.createElement('canvas');
+    canvas.getBoundingClientRect = () => ({
+      left: 0,
+      top: 0,
+      width: 100,
+      height: 100,
+      right: 100,
+      bottom: 100,
+      x: 0,
+      y: 0,
+      toJSON() {},
+    });
+    const renderer = { domElement: canvas } as unknown as THREE.WebGLRenderer;
+    const camera = new THREE.PerspectiveCamera();
+    const getCamera = () => camera;
+    const scene = new THREE.Scene();
+    const store = {
+      getState: () => ({
+        addWall: vi.fn(),
+        wallThickness: 100,
+        snapAngle: 0,
+        snapLength: 0,
+      }),
+    } as any;
+
+    const drawer = new WallDrawer(renderer, getCamera, scene, store);
+    (drawer as any).getPoint = () => new THREE.Vector3(0, 0, 0);
+
+    const down = { clientX: 0, clientY: 0 } as PointerEvent;
+    (drawer as any).onDown(down);
+    expect((drawer as any).preview).not.toBeNull();
+
+    const up = { clientX: 0, clientY: 0, detail: 1 } as PointerEvent;
+    (drawer as any).onUp(up);
+
+    expect((drawer as any).preview).toBeNull();
+    expect((drawer as any).start).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- reset preview and start point when a segment shorter than 1mm is finalized
- add e2e test to ensure a click without dragging leaves no locked preview

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bc80419a948322b4ce5fee1c0a73fe