### PR TITLE
feat: allow custom start for wall segments

### DIFF
--- a/src/ui/TopBar.tsx
+++ b/src/ui/TopBar.tsx
@@ -48,7 +48,7 @@ export default function TopBar({ t, store, setVariant, setKind, selWall, setSelW
         value={selWall}
         onChange={e => setSelWall(Number((e.target as HTMLSelectElement).value) || 0)}
       >
-        {getWallSegments().map((s, i) => (
+        {getWallSegments(0, 0).map((s, i) => (
           <option key={i} value={i}>
             {t('app.wallLabel', { num: i + 1, len: Math.round(s.length) })}
           </option>

--- a/src/ui/useCabinetConfig.ts
+++ b/src/ui/useCabinetConfig.ts
@@ -62,7 +62,7 @@ export function useCabinetConfig(
     mSize: { w: number; h: number; d: number },
     fam: FAMILY,
   ) => {
-    const segs = getWallSegments();
+    const segs = getWallSegments(0, 0);
     if (segs.length === 0)
       return {
         pos: [
@@ -111,7 +111,7 @@ export function useCabinetConfig(
     const tryMod: Module3D = { ...mod };
     let loops = 0;
     const step = 0.02;
-    const segs = getWallSegments();
+    const segs = getWallSegments(0, 0);
     const seg = typeof mod.segIndex === 'number' ? segs[mod.segIndex] : null;
     const tangent = seg
       ? {
@@ -238,7 +238,7 @@ export function useCabinetConfig(
   };
 
   const doAutoOnSelectedWall = () => {
-    const segs = getWallSegments();
+    const segs = getWallSegments(0, 0);
     if (segs.length === 0) return alert(t('room.noWalls'));
     const seg = segs[0 + (selWall % segs.length)];
     const len = seg.length;

--- a/src/utils/walls.ts
+++ b/src/utils/walls.ts
@@ -1,9 +1,10 @@
 import { usePlannerStore } from '../state/store'
 export type Segment = { a:{x:number;y:number}; b:{x:number;y:number}; angle:number; length:number }
-export function getWallSegments(): Segment[] {
+export function getWallSegments(startX = 0, startY = 0, close = false): Segment[] {
   const room = usePlannerStore.getState().room
   const segs: Segment[] = []
-  let cursor = { x:0, y:0 }
+  let cursor = { x:startX, y:startY }
+  const start = { ...cursor }
   for (const w of room.walls){
     const ang = (w.angle||0) * Math.PI/180
     const dir = { x: Math.cos(ang), y: Math.sin(ang) }
@@ -11,6 +12,15 @@ export function getWallSegments(): Segment[] {
     const next = { x: cursor.x + dir.x*len, y: cursor.y + dir.y*len }
     segs.push({ a:{...cursor}, b:{...next}, angle:ang, length:len })
     cursor = next
+  }
+  if (close && segs.length > 0){
+    const last = segs[segs.length - 1].b
+    if (last.x !== start.x || last.y !== start.y){
+      const dx = start.x - last.x, dy = start.y - last.y
+      const len = Math.hypot(dx, dy)
+      const ang = Math.atan2(dy, dx)
+      segs.push({ a:{...last}, b:{...start}, angle:ang, length:len })
+    }
   }
   return segs
 }


### PR DESCRIPTION
## Summary
- allow specifying starting point for wall segments and optional closing segment
- update wall segment callers to pass new start parameters

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bc8183bf9083229a479215b5f8ffec