### PR TITLE
Clamp module placement to segment length

### DIFF
--- a/src/utils/auto.ts
+++ b/src/utils/auto.ts
@@ -19,11 +19,18 @@ export function placeAlongWall(widths:number[], seg:Segment, gapMM=5){
   let cursor = 0
   const dir = { x:(seg.b.x-seg.a.x)/seg.length, y:(seg.b.y-seg.a.y)/seg.length }
   for (const w of widths){
-    const centerMM = cursor + w/2
+    const remaining = seg.length - cursor
+    if (remaining <= 0) break
+    let width = w
+    const exceeds = width + gapMM > remaining
+    if (exceeds && width > remaining) width = remaining
+    const centerMM = cursor + width/2
     const cx = seg.a.x + dir.x*centerMM
     const cy = seg.a.y + dir.y*centerMM
     placed.push({ center:[cx, cy], rot: -seg.angle })
-    cursor += w + gapMM
+    cursor += width
+    if (exceeds) break
+    cursor += gapMM
   }
   return placed
 }

--- a/tests/auto.test.ts
+++ b/tests/auto.test.ts
@@ -35,4 +35,19 @@ describe('placeAlongWall', () => {
     expect(placed[0].rot).toBeCloseTo(-Math.PI / 4)
     expect(placed[1].rot).toBeCloseTo(-Math.PI / 4)
   })
+
+  it('does not place modules beyond segment end', () => {
+    const seg: Segment = {
+      a: { x: 0, y: 0 },
+      b: { x: 2600, y: 0 },
+      angle: 0,
+      length: 2600,
+    }
+    const widths = [1000, 1000, 1000]
+    const placed = placeAlongWall(widths, seg, 5)
+    expect(placed.length).toBe(3)
+    const remaining = seg.length - (widths[0] + widths[1] + 5 * 2)
+    const lastCenter = placed[2].center[0]
+    expect(lastCenter + remaining / 2).toBeLessThanOrEqual(seg.length)
+  })
 })


### PR DESCRIPTION
## Summary
- prevent `placeAlongWall` from extending modules past the end of a wall by checking remaining length and trimming if necessary
- test that the algorithm stops or trims when the segment length is exceeded

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc82b3bd5883228f5f1a946a22ad0a