### PR TITLE
feat: add bottom wall length panel

### DIFF
--- a/src/scene/engine.ts
+++ b/src/scene/engine.ts
@@ -3,7 +3,14 @@ import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 import { usePlannerStore } from '../state/store';
 import WallDrawer from '../viewer/WallDrawer';
 import CabinetDragger from '../viewer/CabinetDragger';
-export function setupThree(container: HTMLElement) {
+export function setupThree(
+  container: HTMLElement,
+  callbacks?: {
+    onEnterTopDownMode?: () => void;
+    onExitTopDownMode?: () => void;
+    onLengthChange?: (len: number) => void;
+  },
+) {
   const scene = new THREE.Scene();
   scene.background = new THREE.Color(0xf3f4f6);
   const perspCamera = new THREE.PerspectiveCamera(
@@ -45,7 +52,13 @@ export function setupThree(container: HTMLElement) {
   scene.add(group);
   const controls = new OrbitControls(perspCamera, renderer.domElement);
   controls.enableDamping = true;
-  const wallDrawer = new WallDrawer(renderer, () => camera, scene, usePlannerStore);
+  const wallDrawer = new WallDrawer(
+    renderer,
+    () => camera,
+    scene,
+    usePlannerStore,
+    callbacks?.onLengthChange,
+  );
   const cabinetDragger = new CabinetDragger(
     renderer,
     () => camera,
@@ -104,12 +117,14 @@ export function setupThree(container: HTMLElement) {
         onResize();
         wallDrawer.enable();
         cabinetDragger.enable();
+        callbacks?.onEnterTopDownMode?.();
       },
     );
   };
   const exitTopDownMode = () => {
     wallDrawer.disable();
     cabinetDragger.disable();
+    callbacks?.onExitTopDownMode?.();
     perspCamera.position.copy(topPos);
     perspCamera.quaternion.copy(topQuat);
     camera = perspCamera;
@@ -140,5 +155,6 @@ export function setupThree(container: HTMLElement) {
     group,
     enterTopDownMode,
     exitTopDownMode,
+    applyWallLength: (len: number) => wallDrawer.applyLength(len),
   };
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -37,6 +37,8 @@
 .slidingPanelOverlay{position:fixed;inset:0;background:none;pointer-events:none}
 .slidingPanel{background:#fff;width:400px;max-width:100%;height:100%;box-shadow:2px 0 8px rgba(0,0,0,.2);padding:16px;overflow-y:auto;position:fixed;left:0;right:auto;top:0;transform:translateX(-100%);transition:transform .3s ease;z-index:50;pointer-events:auto}
 .slidingPanel.open{transform:translateX(0)}
+.slidingPanel.bottom{left:0;right:0;top:auto;bottom:0;width:100%;height:auto;transform:translateY(100%);box-shadow:0 -2px 8px rgba(0,0,0,.2)}
+.slidingPanel.bottom.open{transform:translateY(0)}
 .slidingPanelClose{position:absolute;top:8px;right:12px;border:none;background:none;font-size:20px;cursor:pointer}
 .configuratorHeader{position:sticky;top:0;z-index:10;background:var(--white)}
 details{border:1px solid var(--border);border-radius:8px;margin-top:8px}

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -39,6 +39,8 @@ export default function App() {
   const [boardW, setBoardW] = useState(2070);
   const [boardKerf, setBoardKerf] = useState(3);
   const [boardHasGrain, setBoardHasGrain] = useState(false);
+  const [isDrawingWalls, setIsDrawingWalls] = useState(false);
+  const [wallLength, setWallLength] = useState(0);
 
   const undo = store.undo;
   const redo = store.redo;
@@ -93,10 +95,18 @@ export default function App() {
           setBoardHasGrain={setBoardHasGrain}
           addCountertop={addCountertop}
           setAddCountertop={setAddCountertop}
+          isDrawingWalls={isDrawingWalls}
+          wallLength={wallLength}
+          setWallLength={setWallLength}
         />
       </div>
       <div className="canvasWrap">
-        <SceneViewer threeRef={threeRef} addCountertop={addCountertop} />
+        <SceneViewer
+          threeRef={threeRef}
+          addCountertop={addCountertop}
+          setIsDrawingWalls={setIsDrawingWalls}
+          setWallLength={setWallLength}
+        />
         <TopBar
           t={t}
           store={store}

--- a/src/ui/MainTabs.tsx
+++ b/src/ui/MainTabs.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { FAMILY, FAMILY_LABELS } from '../core/catalog';
 import type { Kind, Variant } from '../core/catalog';
 import TypePicker, { KindTabs, VariantList } from './panels/CatalogPicker';
@@ -43,6 +43,9 @@ interface MainTabsProps {
   setBoardHasGrain: (v: boolean) => void;
   addCountertop: boolean;
   setAddCountertop: (v: boolean) => void;
+  isDrawingWalls: boolean;
+  wallLength: number;
+  setWallLength: React.Dispatch<React.SetStateAction<number>>;
 }
 
 export default function MainTabs({
@@ -73,8 +76,10 @@ export default function MainTabs({
   setBoardHasGrain,
   addCountertop,
   setAddCountertop,
+  isDrawingWalls,
+  wallLength,
+  setWallLength,
 }: MainTabsProps) {
-  const [isDrawingWalls, setIsDrawingWalls] = useState(false);
   const toggleTab = (name: 'cab' | 'room' | 'costs' | 'cut' | 'global') => {
     setTab(tab === name ? null : name);
   };
@@ -189,7 +194,8 @@ export default function MainTabs({
           <RoomTab
             three={threeRef}
             isDrawingWalls={isDrawingWalls}
-            setIsDrawingWalls={setIsDrawingWalls}
+            wallLength={wallLength}
+            setWallLength={setWallLength}
           />
         )}
         {tab === 'costs' && <CostsTab />}

--- a/src/ui/SceneViewer.tsx
+++ b/src/ui/SceneViewer.tsx
@@ -18,6 +18,8 @@ interface ThreeContext {
 interface Props {
   threeRef: React.MutableRefObject<ThreeContext | null>;
   addCountertop: boolean;
+  setIsDrawingWalls: React.Dispatch<React.SetStateAction<boolean>>;
+  setWallLength: React.Dispatch<React.SetStateAction<number>>;
 }
 
 export const getLegHeight = (mod: Module3D, globals: Globals): number => {
@@ -28,7 +30,12 @@ export const getLegHeight = (mod: Module3D, globals: Globals): number => {
   return 0.1;
 };
 
-const SceneViewer: React.FC<Props> = ({ threeRef, addCountertop }) => {
+const SceneViewer: React.FC<Props> = ({
+  threeRef,
+  addCountertop,
+  setIsDrawingWalls,
+  setWallLength,
+}) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const store = usePlannerStore();
   const showEdges = store.role === 'stolarz';
@@ -36,8 +43,15 @@ const SceneViewer: React.FC<Props> = ({ threeRef, addCountertop }) => {
 
   useEffect(() => {
     if (!containerRef.current) return;
-    threeRef.current = setupThree(containerRef.current);
-  }, [threeRef]);
+    threeRef.current = setupThree(containerRef.current, {
+      onEnterTopDownMode: () => setIsDrawingWalls(true),
+      onExitTopDownMode: () => {
+        setIsDrawingWalls(false);
+        setWallLength(0);
+      },
+      onLengthChange: setWallLength,
+    });
+  }, [threeRef, setIsDrawingWalls, setWallLength]);
 
   const createCabinetMesh = (mod: Module3D, legHeight: number) => {
     const W = mod.size.w;

--- a/src/ui/panels/RoomTab.tsx
+++ b/src/ui/panels/RoomTab.tsx
@@ -3,17 +3,20 @@ import * as THREE from 'three';
 import { useTranslation } from 'react-i18next';
 import { usePlannerStore } from '../../state/store';
 import RoomUploader from '../RoomUploader';
+import SlidingPanel from '../components/SlidingPanel';
 
 interface RoomTabProps {
   three: React.MutableRefObject<any>;
   isDrawingWalls: boolean;
-  setIsDrawingWalls: React.Dispatch<React.SetStateAction<boolean>>;
+  wallLength: number;
+  setWallLength: React.Dispatch<React.SetStateAction<number>>;
 }
 
 export default function RoomTab({
   three,
   isDrawingWalls,
-  setIsDrawingWalls,
+  wallLength,
+  setWallLength,
 }: RoomTabProps) {
   const store = usePlannerStore();
   const { t } = useTranslation();
@@ -24,11 +27,9 @@ export default function RoomTab({
   const onAddDoor = () => store.addOpening({ kind: 1 });
   const onDrawWalls = () => {
     three.current?.enterTopDownMode?.();
-    setIsDrawingWalls(true);
   };
   const onFinishDrawing = () => {
     three.current?.exitTopDownMode?.();
-    setIsDrawingWalls(false);
   };
   useEffect(() => {
     const group = three.current?.group;
@@ -166,6 +167,26 @@ export default function RoomTab({
         </div>
       </div>
       <RoomUploader three={three} />
+      <SlidingPanel
+        isOpen={isDrawingWalls}
+        onClose={() => three.current?.exitTopDownMode?.()}
+        className={`bottom ${isDrawingWalls ? 'open' : ''}`}
+        locked
+      >
+        <div className="row">
+          <input
+            className="input"
+            type="number"
+            value={wallLength}
+            onChange={(e) => setWallLength(Number((e.target as HTMLInputElement).value) || 0)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                three.current?.applyWallLength?.(wallLength);
+              }
+            }}
+          />
+        </div>
+      </SlidingPanel>
     </>
   );
 }

--- a/tests/wallDrawer.e2e.test.ts
+++ b/tests/wallDrawer.e2e.test.ts
@@ -30,7 +30,7 @@ describe('WallDrawer click without drag', () => {
       }),
     } as any;
 
-    const drawer = new WallDrawer(renderer, getCamera, scene, store);
+    const drawer = new WallDrawer(renderer, getCamera, scene, store, () => {});
     (drawer as any).getPoint = () => new THREE.Vector3(0, 0, 0);
 
     const down = { clientX: 0, clientY: 0 } as PointerEvent;


### PR DESCRIPTION
## Summary
- show wall length input in bottom SlidingPanel when drawing walls
- drive wall drawer from React panel instead of DOM element
- open/close panel automatically when entering/exiting top-down mode

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bc89bd90048322b29fb9548dab3d63