### PR TITLE
feat: display live wall metrics in panel

### DIFF
--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -129,6 +129,8 @@ type Store = {
   snapLength: number;
   snapRightAngles: boolean;
   angleToPrev: number;
+  snappedLengthMm: number;
+  snappedAngleDeg: number;
   showFronts: boolean;
   setRole: (r: 'stolarz' | 'klient') => void;
   updateGlobals: (fam: FAMILY, patch: Partial<Globals[FAMILY]>) => void;
@@ -153,6 +155,7 @@ type Store = {
   setSnapLength: (v: number) => void;
   setSnapRightAngles: (v: boolean) => void;
   setAngleToPrev: (v: number) => void;
+  setDraftWall: (len: number, angle: number) => void;
 };
 
 export const usePlannerStore = create<Store>((set, get) => ({
@@ -178,6 +181,8 @@ export const usePlannerStore = create<Store>((set, get) => ({
   snapLength: persisted?.snapLength ?? 10,
   snapRightAngles: persisted?.snapRightAngles ?? true,
   angleToPrev: persisted?.angleToPrev ?? 0,
+  snappedLengthMm: 0,
+  snappedAngleDeg: 0,
   showFronts: true,
   setRole: (r) => set({ role: r }),
   updateGlobals: (fam, patch) =>
@@ -394,6 +399,7 @@ export const usePlannerStore = create<Store>((set, get) => ({
   setSnapRightAngles: (v) =>
     set({ snapRightAngles: v, snapAngle: v ? 90 : 0 }),
   setAngleToPrev: (v) => set({ angleToPrev: v }),
+  setDraftWall: (len, angle) => set({ snappedLengthMm: len, snappedAngleDeg: angle }),
 }));
 
 usePlannerStore.subscribe((state) => {

--- a/src/ui/panels/RoomTab.tsx
+++ b/src/ui/panels/RoomTab.tsx
@@ -173,20 +173,29 @@ export default function RoomTab({
         className={`bottom ${isDrawingWalls ? 'open' : ''}`}
         locked
       >
-        <div className="row">
+        <div
+          className="row"
+          style={{ display: 'flex', alignItems: 'center', gap: 8 }}
+        >
           <input
             className="input"
             type="number"
             value={wallLength}
-            onChange={(e) => setWallLength(Number((e.target as HTMLInputElement).value) || 0)}
+            onChange={(e) =>
+              setWallLength(Number((e.target as HTMLInputElement).value) || 0)
+            }
             onKeyDown={(e) => {
               if (e.key === 'Enter') {
                 three.current?.applyWallLength?.(wallLength);
               }
             }}
           />
+          <div>{Math.round(store.snappedLengthMm)} mm</div>
         </div>
-        <div className="row" style={{ marginTop: 8 }}>
+        <div
+          className="row"
+          style={{ marginTop: 8, display: 'flex', alignItems: 'center', gap: 8 }}
+        >
           <div>
             <div className="small">{t('room.angleToPrev')}</div>
             <input
@@ -201,6 +210,7 @@ export default function RoomTab({
               disabled={store.snapRightAngles}
             />
           </div>
+          <div>{Math.round(store.snappedAngleDeg)}°</div>
         </div>
         <div className="row" style={{ marginTop: 8 }}>
           <label

--- a/tests/wallDrawer.e2e.test.ts
+++ b/tests/wallDrawer.e2e.test.ts
@@ -31,6 +31,7 @@ describe('WallDrawer click without drag', () => {
         angleToPrev: 0,
         room: { walls: [] },
         setRoom: vi.fn(),
+        setDraftWall: vi.fn(),
       }),
     } as any;
 


### PR DESCRIPTION
## Summary
- track snapped wall length and angle in store during drawing
- show live measurements next to bottom panel inputs
- reset wall drafting state after segment finalized

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bc9c3d06f0832285ebe692b0560e5c