### PR TITLE
Move wall drawing panel to app canvas

### DIFF
--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -6,6 +6,7 @@ import useCabinetConfig from './useCabinetConfig';
 import TopBar from './TopBar';
 import { createTranslator } from './i18n';
 import MainTabs from './MainTabs';
+import WallDrawPanel from './WallDrawPanel';
 
 export default function App() {
   const store = usePlannerStore();
@@ -96,8 +97,7 @@ export default function App() {
           addCountertop={addCountertop}
           setAddCountertop={setAddCountertop}
           isDrawingWalls={isDrawingWalls}
-          wallLength={wallLength}
-          setWallLength={setWallLength}
+          setIsDrawingWalls={setIsDrawingWalls}
         />
       </div>
       <div className="canvasWrap">
@@ -105,6 +105,12 @@ export default function App() {
           threeRef={threeRef}
           addCountertop={addCountertop}
           setIsDrawingWalls={setIsDrawingWalls}
+          setWallLength={setWallLength}
+        />
+        <WallDrawPanel
+          threeRef={threeRef}
+          isDrawingWalls={isDrawingWalls}
+          wallLength={wallLength}
           setWallLength={setWallLength}
         />
         <TopBar

--- a/src/ui/MainTabs.tsx
+++ b/src/ui/MainTabs.tsx
@@ -44,8 +44,7 @@ interface MainTabsProps {
   addCountertop: boolean;
   setAddCountertop: (v: boolean) => void;
   isDrawingWalls: boolean;
-  wallLength: number;
-  setWallLength: React.Dispatch<React.SetStateAction<number>>;
+  setIsDrawingWalls: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 export default function MainTabs({
@@ -77,8 +76,7 @@ export default function MainTabs({
   addCountertop,
   setAddCountertop,
   isDrawingWalls,
-  wallLength,
-  setWallLength,
+  setIsDrawingWalls,
 }: MainTabsProps) {
   const toggleTab = (name: 'cab' | 'room' | 'costs' | 'cut' | 'global') => {
     setTab(tab === name ? null : name);
@@ -194,8 +192,7 @@ export default function MainTabs({
           <RoomTab
             three={threeRef}
             isDrawingWalls={isDrawingWalls}
-            wallLength={wallLength}
-            setWallLength={setWallLength}
+            setIsDrawingWalls={setIsDrawingWalls}
           />
         )}
         {tab === 'costs' && <CostsTab />}

--- a/src/ui/WallDrawPanel.tsx
+++ b/src/ui/WallDrawPanel.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { usePlannerStore } from '../state/store';
+import SlidingPanel from './components/SlidingPanel';
+
+interface WallDrawPanelProps {
+  threeRef: React.MutableRefObject<any>;
+  isDrawingWalls: boolean;
+  wallLength: number;
+  setWallLength: React.Dispatch<React.SetStateAction<number>>;
+}
+
+export default function WallDrawPanel({
+  threeRef,
+  isDrawingWalls,
+  wallLength,
+  setWallLength,
+}: WallDrawPanelProps) {
+  const { t } = useTranslation();
+  const store = usePlannerStore();
+  return (
+    <SlidingPanel
+      isOpen={isDrawingWalls}
+      onClose={() => threeRef.current?.exitTopDownMode?.()}
+      className={`bottom ${isDrawingWalls ? 'open' : ''}`}
+      locked
+    >
+      <div
+        className="row"
+        style={{ display: 'flex', alignItems: 'center', gap: 8 }}
+      >
+        <input
+          className="input"
+          type="number"
+          value={wallLength}
+          onChange={(e) =>
+            setWallLength(Number((e.target as HTMLInputElement).value) || 0)
+          }
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              threeRef.current?.applyWallLength?.(wallLength);
+            }
+          }}
+        />
+        <div>{Math.round(store.snappedLengthMm)} mm</div>
+      </div>
+      <div
+        className="row"
+        style={{ marginTop: 8, display: 'flex', alignItems: 'center', gap: 8 }}
+      >
+        <div>
+          <div className="small">{t('room.angleToPrev')}</div>
+          <input
+            className="input"
+            type="number"
+            value={store.angleToPrev}
+            onChange={(e) =>
+              store.setAngleToPrev(
+                Number((e.target as HTMLInputElement).value) || 0,
+              )
+            }
+            disabled={store.snapRightAngles}
+          />
+        </div>
+        <div>{Math.round(store.snappedAngleDeg)}°</div>
+      </div>
+      <div className="row" style={{ marginTop: 8 }}>
+        <label
+          className="small"
+          style={{ display: 'flex', gap: 8, alignItems: 'center' }}
+        >
+          <input
+            type="checkbox"
+            checked={!store.snapRightAngles}
+            onChange={(e) =>
+              store.setSnapRightAngles(
+                !(e.target as HTMLInputElement).checked,
+              )
+            }
+          />
+          {t('room.noRightAngles')}
+        </label>
+      </div>
+    </SlidingPanel>
+  );
+}

--- a/src/ui/panels/RoomTab.tsx
+++ b/src/ui/panels/RoomTab.tsx
@@ -3,20 +3,17 @@ import * as THREE from 'three';
 import { useTranslation } from 'react-i18next';
 import { usePlannerStore } from '../../state/store';
 import RoomUploader from '../RoomUploader';
-import SlidingPanel from '../components/SlidingPanel';
 
 interface RoomTabProps {
   three: React.MutableRefObject<any>;
   isDrawingWalls: boolean;
-  wallLength: number;
-  setWallLength: React.Dispatch<React.SetStateAction<number>>;
+  setIsDrawingWalls: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 export default function RoomTab({
   three,
   isDrawingWalls,
-  wallLength,
-  setWallLength,
+  setIsDrawingWalls,
 }: RoomTabProps) {
   const store = usePlannerStore();
   const { t } = useTranslation();
@@ -26,10 +23,8 @@ export default function RoomTab({
   const onAddWindow = () => store.addOpening({ kind: 0 });
   const onAddDoor = () => store.addOpening({ kind: 1 });
   const onDrawWalls = () => {
+    setIsDrawingWalls(true);
     three.current?.enterTopDownMode?.();
-  };
-  const onFinishDrawing = () => {
-    three.current?.exitTopDownMode?.();
   };
   useEffect(() => {
     const group = three.current?.group;
@@ -133,11 +128,6 @@ export default function RoomTab({
             >
               {t('room.drawWalls')}
             </button>
-            {isDrawingWalls && (
-              <button className="btnGhost" onClick={onFinishDrawing}>
-                {t('room.finishDrawing')}
-              </button>
-            )}
           </div>
           <div className="row" style={{ marginTop: 8 }}>
             {store.room.walls.length === 0 ? (
@@ -167,69 +157,6 @@ export default function RoomTab({
         </div>
       </div>
       <RoomUploader three={three} />
-      <SlidingPanel
-        isOpen={isDrawingWalls}
-        onClose={() => three.current?.exitTopDownMode?.()}
-        className={`bottom ${isDrawingWalls ? 'open' : ''}`}
-        locked
-      >
-        <div
-          className="row"
-          style={{ display: 'flex', alignItems: 'center', gap: 8 }}
-        >
-          <input
-            className="input"
-            type="number"
-            value={wallLength}
-            onChange={(e) =>
-              setWallLength(Number((e.target as HTMLInputElement).value) || 0)
-            }
-            onKeyDown={(e) => {
-              if (e.key === 'Enter') {
-                three.current?.applyWallLength?.(wallLength);
-              }
-            }}
-          />
-          <div>{Math.round(store.snappedLengthMm)} mm</div>
-        </div>
-        <div
-          className="row"
-          style={{ marginTop: 8, display: 'flex', alignItems: 'center', gap: 8 }}
-        >
-          <div>
-            <div className="small">{t('room.angleToPrev')}</div>
-            <input
-              className="input"
-              type="number"
-              value={store.angleToPrev}
-              onChange={(e) =>
-                store.setAngleToPrev(
-                  Number((e.target as HTMLInputElement).value) || 0,
-                )
-              }
-              disabled={store.snapRightAngles}
-            />
-          </div>
-          <div>{Math.round(store.snappedAngleDeg)}°</div>
-        </div>
-        <div className="row" style={{ marginTop: 8 }}>
-          <label
-            className="small"
-            style={{ display: 'flex', gap: 8, alignItems: 'center' }}
-          >
-            <input
-              type="checkbox"
-              checked={!store.snapRightAngles}
-              onChange={(e) =>
-                store.setSnapRightAngles(
-                  !(e.target as HTMLInputElement).checked,
-                )
-              }
-            />
-            {t('room.noRightAngles')}
-          </label>
-        </div>
-      </SlidingPanel>
     </>
   );
 }


### PR DESCRIPTION
## Summary
- Remove RoomTab wall length/angle panel and expose only a “draw walls” button
- Add WallDrawPanel component for wall length and angle inputs
- Render WallDrawPanel below SceneViewer and wire up wall-drawing state

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bca9c12bec8322b55aca108e030d29