### PR TITLE
Add activation button for wall drawing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,20 @@
 {
   "name": "kitchi",
-  "version": "8.0.1",
+  "version": "8.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kitchi",
-      "version": "8.0.1",
+      "version": "8.0.2",
+      "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "i18next": "^25.4.2",
         "jspdf": "^2.5.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-i18next": "^15.7.3",
+        "react-icons": "^5.5.0",
         "three": "^0.161.0",
         "zustand": "^4.5.2"
       },
@@ -3977,6 +3979,15 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
+      "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-refresh": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-i18next": "^15.7.3",
+    "react-icons": "^5.5.0",
     "three": "^0.161.0",
     "zustand": "^4.5.2"
   },

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -41,6 +41,7 @@ export default function App() {
   const [boardKerf, setBoardKerf] = useState(3);
   const [boardHasGrain, setBoardHasGrain] = useState(false);
   const [isDrawingWalls, setIsDrawingWalls] = useState(false);
+  const [wallPanelOpen, setWallPanelOpen] = useState(false);
   const [wallLength, setWallLength] = useState(0);
 
   const undo = store.undo;
@@ -97,7 +98,7 @@ export default function App() {
           addCountertop={addCountertop}
           setAddCountertop={setAddCountertop}
           isDrawingWalls={isDrawingWalls}
-          setIsDrawingWalls={setIsDrawingWalls}
+          setWallPanelOpen={setWallPanelOpen}
         />
       </div>
       <div className="canvasWrap">
@@ -109,9 +110,11 @@ export default function App() {
         />
         <WallDrawPanel
           threeRef={threeRef}
-          isDrawingWalls={isDrawingWalls}
+          isOpen={wallPanelOpen}
+          isDrawing={isDrawingWalls}
           wallLength={wallLength}
           setWallLength={setWallLength}
+          setIsOpen={setWallPanelOpen}
         />
         <TopBar
           t={t}

--- a/src/ui/MainTabs.tsx
+++ b/src/ui/MainTabs.tsx
@@ -44,7 +44,7 @@ interface MainTabsProps {
   addCountertop: boolean;
   setAddCountertop: (v: boolean) => void;
   isDrawingWalls: boolean;
-  setIsDrawingWalls: React.Dispatch<React.SetStateAction<boolean>>;
+  setWallPanelOpen: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 export default function MainTabs({
@@ -76,7 +76,7 @@ export default function MainTabs({
   addCountertop,
   setAddCountertop,
   isDrawingWalls,
-  setIsDrawingWalls,
+  setWallPanelOpen,
 }: MainTabsProps) {
   const toggleTab = (name: 'cab' | 'room' | 'costs' | 'cut' | 'global') => {
     setTab(tab === name ? null : name);
@@ -192,7 +192,7 @@ export default function MainTabs({
           <RoomTab
             three={threeRef}
             isDrawingWalls={isDrawingWalls}
-            setIsDrawingWalls={setIsDrawingWalls}
+            setWallPanelOpen={setWallPanelOpen}
           />
         )}
         {tab === 'costs' && <CostsTab />}

--- a/src/ui/WallDrawPanel.tsx
+++ b/src/ui/WallDrawPanel.tsx
@@ -1,34 +1,49 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
+import { FaPencilAlt } from 'react-icons/fa';
 import { usePlannerStore } from '../state/store';
 import SlidingPanel from './components/SlidingPanel';
 
 interface WallDrawPanelProps {
   threeRef: React.MutableRefObject<any>;
-  isDrawingWalls: boolean;
+  isOpen: boolean;
+  isDrawing: boolean;
   wallLength: number;
   setWallLength: React.Dispatch<React.SetStateAction<number>>;
+  setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 export default function WallDrawPanel({
   threeRef,
-  isDrawingWalls,
+  isOpen,
+  isDrawing,
   wallLength,
   setWallLength,
+  setIsOpen,
 }: WallDrawPanelProps) {
   const { t } = useTranslation();
   const store = usePlannerStore();
   return (
     <SlidingPanel
-      isOpen={isDrawingWalls}
-      onClose={() => threeRef.current?.exitTopDownMode?.()}
-      className={`bottom ${isDrawingWalls ? 'open' : ''}`}
-      locked
+      isOpen={isOpen}
+      onClose={() => {
+        threeRef.current?.exitTopDownMode?.();
+        setIsOpen(false);
+      }}
+      className={`bottom ${isOpen ? 'open' : ''}`}
+      locked={isDrawing}
     >
       <div
         className="row"
         style={{ display: 'flex', alignItems: 'center', gap: 8 }}
       >
+        <button
+          className="btnGhost"
+          onClick={() => threeRef.current?.enterTopDownMode?.()}
+          disabled={isDrawing}
+        >
+          <FaPencilAlt />
+        </button>
         <input
           className="input"
           type="number"
@@ -73,9 +88,7 @@ export default function WallDrawPanel({
             type="checkbox"
             checked={!store.snapRightAngles}
             onChange={(e) =>
-              store.setSnapRightAngles(
-                !(e.target as HTMLInputElement).checked,
-              )
+              store.setSnapRightAngles(!(e.target as HTMLInputElement).checked)
             }
           />
           {t('room.noRightAngles')}

--- a/src/ui/panels/RoomTab.tsx
+++ b/src/ui/panels/RoomTab.tsx
@@ -7,24 +7,25 @@ import RoomUploader from '../RoomUploader';
 interface RoomTabProps {
   three: React.MutableRefObject<any>;
   isDrawingWalls: boolean;
-  setIsDrawingWalls: React.Dispatch<React.SetStateAction<boolean>>;
+  setWallPanelOpen: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 export default function RoomTab({
   three,
   isDrawingWalls,
-  setIsDrawingWalls,
+  setWallPanelOpen,
 }: RoomTabProps) {
   const store = usePlannerStore();
   const { t } = useTranslation();
   const onHeightChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    store.setRoom({ height: Number((e.target as HTMLInputElement).value) || 0 });
+    store.setRoom({
+      height: Number((e.target as HTMLInputElement).value) || 0,
+    });
   };
   const onAddWindow = () => store.addOpening({ kind: 0 });
   const onAddDoor = () => store.addOpening({ kind: 1 });
   const onDrawWalls = () => {
-    setIsDrawingWalls(true);
-    three.current?.enterTopDownMode?.();
+    setWallPanelOpen(true);
   };
   useEffect(() => {
     const group = three.current?.group;
@@ -136,7 +137,8 @@ export default function RoomTab({
               <ul>
                 {store.room.walls.map((w, i) => (
                   <li key={i}>
-                    {t('app.wallLabel', { num: i + 1, len: w.length })} – {w.angle}° –
+                    {t('app.wallLabel', { num: i + 1, len: w.length })} –{' '}
+                    {w.angle}° –
                     <input
                       type="number"
                       value={w.thickness}


### PR DESCRIPTION
## Summary
- add `react-icons` dependency
- open wall drawing panel without starting drawing and add pencil button to activate drawing mode
- ensure room tab draw walls toggles panel visibility

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bcace966488322a9991bb7ed0b228c