### PR TITLE
Add wall type and dynamic wall thickness controls

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -40,6 +40,11 @@
     "title": "Room — walls",
     "height": "Room height (mm)",
     "wallThickness": "Wall thickness (mm)",
+    "wallType": "Wall type",
+    "wallTypes": {
+      "nosna": "Load-bearing",
+      "dzialowa": "Partition"
+    },
     "addWindow": "Add window",
     "addDoor": "Add door",
     "drawWalls": "Draw walls",

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -40,6 +40,11 @@
     "title": "Pomieszczenie — ściany",
     "height": "Wysokość pomieszczenia (mm)",
     "wallThickness": "Grubość ściany (mm)",
+    "wallType": "Typ ściany",
+    "wallTypes": {
+      "nosna": "Nośna",
+      "dzialowa": "Działowa"
+    },
     "addWindow": "Dodaj okno",
     "addDoor": "Dodaj drzwi",
     "drawWalls": "Rysuj ściany",
@@ -104,15 +109,15 @@
     "back": "Plecy",
     "top": "Góra",
     "bottom": "Dół",
-      "carcassType": "Rodzaj korpusu",
-      "carcassTypes": {
-        "type1": "Typ 1",
-        "type2": "Typ 2",
-        "type3": "Typ 3",
-        "type4": "Typ 4",
-        "type5": "Typ 5",
-        "type6": "Typ 6"
-      },
+    "carcassType": "Rodzaj korpusu",
+    "carcassTypes": {
+      "type1": "Typ 1",
+      "type2": "Typ 2",
+      "type3": "Typ 3",
+      "type4": "Typ 4",
+      "type5": "Typ 5",
+      "type6": "Typ 6"
+    },
     "shelves": "Liczba półek",
     "gapsTitle": "Szczeliny i wysokości frontów (ustawiaj graficznie)",
     "backOptions": {

--- a/src/ui/WallDrawPanel.tsx
+++ b/src/ui/WallDrawPanel.tsx
@@ -4,6 +4,11 @@ import { FaPencilAlt } from 'react-icons/fa';
 import { usePlannerStore } from '../state/store';
 import SlidingPanel from './components/SlidingPanel';
 
+const ranges = {
+  nosna: { min: 150, max: 250 },
+  dzialowa: { min: 60, max: 120 },
+};
+
 interface WallDrawPanelProps {
   threeRef: React.MutableRefObject<any>;
   isOpen: boolean;
@@ -23,6 +28,7 @@ export default function WallDrawPanel({
 }: WallDrawPanelProps) {
   const { t } = useTranslation();
   const store = usePlannerStore();
+  const range = ranges[store.wallType];
   return (
     <SlidingPanel
       isOpen={isOpen}
@@ -78,6 +84,56 @@ export default function WallDrawPanel({
           />
         </div>
         <div>{Math.round(store.snappedAngleDeg)}°</div>
+      </div>
+      <div
+        className="row"
+        style={{ marginTop: 8, display: 'flex', gap: 8, alignItems: 'center' }}
+      >
+        <div>
+          <div className="small">{t('room.wallType')}</div>
+          <select
+            className="input"
+            value={store.wallType}
+            onChange={(e) =>
+              store.setWallType(
+                (e.target as HTMLSelectElement).value as 'nosna' | 'dzialowa',
+              )
+            }
+          >
+            <option value="nosna">{t('room.wallTypes.nosna')}</option>
+            <option value="dzialowa">{t('room.wallTypes.dzialowa')}</option>
+          </select>
+        </div>
+        <div style={{ flex: 1 }}>
+          <div className="small">{t('room.wallThickness')}</div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+            <input
+              type="range"
+              min={range.min}
+              max={range.max}
+              value={store.wallThickness}
+              onChange={(e) =>
+                store.setWallThickness(
+                  Number((e.target as HTMLInputElement).value) || 0,
+                )
+              }
+              style={{ flex: 1 }}
+            />
+            <input
+              className="input"
+              type="number"
+              min={range.min}
+              max={range.max}
+              value={store.wallThickness}
+              onChange={(e) =>
+                store.setWallThickness(
+                  Number((e.target as HTMLInputElement).value) || 0,
+                )
+              }
+              style={{ width: 60 }}
+            />
+          </div>
+        </div>
       </div>
       <div className="row" style={{ marginTop: 8 }}>
         <label

--- a/tests/wallDrawer.e2e.test.ts
+++ b/tests/wallDrawer.e2e.test.ts
@@ -25,6 +25,7 @@ describe('WallDrawer click without drag', () => {
       getState: () => ({
         addWall: vi.fn(),
         wallThickness: 100,
+        wallType: 'dzialowa',
         snapAngle: 0,
         snapLength: 0,
         snapRightAngles: true,


### PR DESCRIPTION
## Summary
- add wall type state and clamped thickness ranges
- add wall type selector and thickness slider to wall drawing panel
- persist wall type and update tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bcb3d42f848322bad8f6758625ce37