### PR TITLE
Refactor wall drawing controls into bottom toolbar

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -2,6 +2,7 @@
 .app{display:flex;flex-direction:column;height:100vh;width:100vw;color:var(--ink);position:relative}
 .canvasWrap{flex:1;position:relative;background:#F3F4F6}
 .topbar{position:absolute;top:12px;left:12px;z-index:10;display:flex;gap:8px;background:rgba(255,255,255,.85);border:1px solid var(--border);border-radius:10px;padding:8px;backdrop-filter:blur(6px)}
+.bottombar{position:absolute;bottom:12px;left:12px;z-index:10;display:flex;gap:8px;background:rgba(255,255,255,.85);border:1px solid var(--border);border-radius:10px;padding:8px;backdrop-filter:blur(6px)}
 .zoomControls{position:absolute;bottom:12px;right:12px;z-index:10;display:flex;flex-direction:column;gap:8px;background:rgba(255,255,255,.85);border:1px solid var(--border);border-radius:10px;padding:8px;backdrop-filter:blur(6px)}
 .h1{font-size:18px;font-weight:700}
 .small{font-size:12px;color:var(--muted)}

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -114,7 +114,6 @@ export default function App() {
           isDrawing={isDrawingWalls}
           wallLength={wallLength}
           setWallLength={setWallLength}
-          setIsOpen={setWallPanelOpen}
         />
         <TopBar
           t={t}

--- a/src/ui/WallDrawPanel.tsx
+++ b/src/ui/WallDrawPanel.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { FaPencilAlt } from 'react-icons/fa';
 import { usePlannerStore } from '../state/store';
-import SlidingPanel from './components/SlidingPanel';
 
 const ranges = {
   nosna: { min: 150, max: 250 },
@@ -15,7 +14,6 @@ interface WallDrawPanelProps {
   isDrawing: boolean;
   wallLength: number;
   setWallLength: React.Dispatch<React.SetStateAction<number>>;
-  setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 export default function WallDrawPanel({
@@ -24,51 +22,40 @@ export default function WallDrawPanel({
   isDrawing,
   wallLength,
   setWallLength,
-  setIsOpen,
 }: WallDrawPanelProps) {
   const { t } = useTranslation();
   const store = usePlannerStore();
   const range = ranges[store.wallType];
+  if (!isOpen) {
+    threeRef.current?.exitTopDownMode?.();
+    return null;
+  }
   return (
-    <SlidingPanel
-      isOpen={isOpen}
-      onClose={() => {
-        threeRef.current?.exitTopDownMode?.();
-        setIsOpen(false);
-      }}
-      className={`bottom ${isOpen ? 'open' : ''}`}
-      locked={isDrawing}
-    >
-      <div
-        className="row"
-        style={{ display: 'flex', alignItems: 'center', gap: 8 }}
+    <div className="bottombar row">
+      <button
+        className="btnGhost"
+        onClick={() => threeRef.current?.enterTopDownMode?.()}
+        disabled={isDrawing}
       >
-        <button
-          className="btnGhost"
-          onClick={() => threeRef.current?.enterTopDownMode?.()}
-          disabled={isDrawing}
-        >
-          <FaPencilAlt />
-        </button>
-        <input
-          className="input"
-          type="number"
-          value={wallLength}
-          onChange={(e) =>
-            setWallLength(Number((e.target as HTMLInputElement).value) || 0)
+        <FaPencilAlt />
+      </button>
+      <input
+        className="input"
+        type="number"
+        value={wallLength}
+        onChange={(e) =>
+          setWallLength(Number((e.target as HTMLInputElement).value) || 0)
+        }
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') {
+            threeRef.current?.applyWallLength?.(wallLength);
           }
-          onKeyDown={(e) => {
-            if (e.key === 'Enter') {
-              threeRef.current?.applyWallLength?.(wallLength);
-            }
-          }}
-        />
-        <div>{Math.round(store.snappedLengthMm)} mm</div>
-      </div>
-      <div
-        className="row"
-        style={{ marginTop: 8, display: 'flex', alignItems: 'center', gap: 8 }}
-      >
+        }}
+        maxLength={5}
+        style={{ width: 70 }}
+      />
+      <div>{Math.round(store.snappedLengthMm)} mm</div>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
         <div>
           <div className="small">{t('room.angleToPrev')}</div>
           <input
@@ -81,75 +68,71 @@ export default function WallDrawPanel({
               )
             }
             disabled={store.snapRightAngles}
+            style={{ width: 50 }}
+            min={0}
+            max={360}
           />
         </div>
         <div>{Math.round(store.snappedAngleDeg)}°</div>
       </div>
-      <div
-        className="row"
-        style={{ marginTop: 8, display: 'flex', gap: 8, alignItems: 'center' }}
-      >
-        <div>
-          <div className="small">{t('room.wallType')}</div>
-          <select
-            className="input"
-            value={store.wallType}
+      <div>
+        <div className="small">{t('room.wallType')}</div>
+        <select
+          className="input"
+          value={store.wallType}
+          onChange={(e) =>
+            store.setWallType(
+              (e.target as HTMLSelectElement).value as 'nosna' | 'dzialowa',
+            )
+          }
+        >
+          <option value="nosna">{t('room.wallTypes.nosna')}</option>
+          <option value="dzialowa">{t('room.wallTypes.dzialowa')}</option>
+        </select>
+      </div>
+      <div style={{ flex: 1 }}>
+        <div className="small">{t('room.wallThickness')}</div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <input
+            type="range"
+            min={range.min}
+            max={range.max}
+            value={store.wallThickness}
             onChange={(e) =>
-              store.setWallType(
-                (e.target as HTMLSelectElement).value as 'nosna' | 'dzialowa',
+              store.setWallThickness(
+                Number((e.target as HTMLInputElement).value) || 0,
               )
             }
-          >
-            <option value="nosna">{t('room.wallTypes.nosna')}</option>
-            <option value="dzialowa">{t('room.wallTypes.dzialowa')}</option>
-          </select>
-        </div>
-        <div style={{ flex: 1 }}>
-          <div className="small">{t('room.wallThickness')}</div>
-          <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-            <input
-              type="range"
-              min={range.min}
-              max={range.max}
-              value={store.wallThickness}
-              onChange={(e) =>
-                store.setWallThickness(
-                  Number((e.target as HTMLInputElement).value) || 0,
-                )
-              }
-              style={{ flex: 1 }}
-            />
-            <input
-              className="input"
-              type="number"
-              min={range.min}
-              max={range.max}
-              value={store.wallThickness}
-              onChange={(e) =>
-                store.setWallThickness(
-                  Number((e.target as HTMLInputElement).value) || 0,
-                )
-              }
-              style={{ width: 60 }}
-            />
-          </div>
-        </div>
-      </div>
-      <div className="row" style={{ marginTop: 8 }}>
-        <label
-          className="small"
-          style={{ display: 'flex', gap: 8, alignItems: 'center' }}
-        >
-          <input
-            type="checkbox"
-            checked={!store.snapRightAngles}
-            onChange={(e) =>
-              store.setSnapRightAngles(!(e.target as HTMLInputElement).checked)
-            }
+            style={{ flex: 1 }}
           />
-          {t('room.noRightAngles')}
-        </label>
+          <input
+            className="input"
+            type="number"
+            min={range.min}
+            max={range.max}
+            value={store.wallThickness}
+            onChange={(e) =>
+              store.setWallThickness(
+                Number((e.target as HTMLInputElement).value) || 0,
+              )
+            }
+            style={{ width: 60 }}
+          />
+        </div>
       </div>
-    </SlidingPanel>
+      <label
+        className="small"
+        style={{ display: 'flex', gap: 8, alignItems: 'center' }}
+      >
+        <input
+          type="checkbox"
+          checked={!store.snapRightAngles}
+          onChange={(e) =>
+            store.setSnapRightAngles(!(e.target as HTMLInputElement).checked)
+          }
+        />
+        {t('room.noRightAngles')}
+      </label>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- replace SlidingPanel with fixed bottom bar for wall drawing controls
- shorten wall length and angle inputs
- add reusable `bottombar` style

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bcc10b791c832289393664626f2aaf