### PR TITLE
Clamp wall angle input within 0–360 range

### DIFF
--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -424,7 +424,7 @@ export const usePlannerStore = create<Store>((set, get) => ({
   setSnapAngle: (v) => set({ snapAngle: v }),
   setSnapLength: (v) => set({ snapLength: v }),
   setSnapRightAngles: (v) => set({ snapRightAngles: v, snapAngle: v ? 90 : 0 }),
-  setAngleToPrev: (v) => set({ angleToPrev: v }),
+  setAngleToPrev: (v) => set({ angleToPrev: clamp(v, 0, 360) }),
   setDraftWall: (len, angle) =>
     set({ snappedLengthMm: len, snappedAngleDeg: angle }),
 }));

--- a/src/ui/WallDrawPanel.tsx
+++ b/src/ui/WallDrawPanel.tsx
@@ -62,15 +62,17 @@ export default function WallDrawPanel({
             className="input"
             type="number"
             value={store.angleToPrev}
-            onChange={(e) =>
-              store.setAngleToPrev(
-                Number((e.target as HTMLInputElement).value) || 0,
-              )
-            }
+            onChange={(e) => {
+              const val = Number((e.target as HTMLInputElement).value);
+              if (!Number.isNaN(val) && val >= 0 && val <= 360) {
+                store.setAngleToPrev(val);
+              }
+            }}
             disabled={store.snapRightAngles}
             style={{ width: 50 }}
             min={0}
             max={360}
+            maxLength={3}
           />
         </div>
         <div>{Math.round(store.snappedAngleDeg)}°</div>


### PR DESCRIPTION
## Summary
- Clamp `angleToPrev` updates to 0–360 in Zustand store
- Restrict wall angle input to three digits and discard out-of-range values

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bcc2ca61b48322ab601bba9ae3d49e