### PR TITLE
Add 2D/3D view toggle buttons to UI

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -13,6 +13,8 @@
     "autoWall": "Auto for wall",
     "removeWall": "Remove wall",
     "editWall": "Edit wall",
+    "view2D": "View 2D",
+    "view3D": "View 3D",
     "auto": "Auto",
     "material": {
       "title": "Material (sheet)",

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -13,6 +13,8 @@
     "autoWall": "Auto pod ścianę",
     "removeWall": "Usuń ścianę",
     "editWall": "Edytuj ścianę",
+    "view2D": "Widok 2D",
+    "view3D": "Widok 3D",
     "auto": "Auto",
     "material": {
       "title": "Materiał (arkusz)",

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -125,6 +125,8 @@ export default function App() {
           doAutoOnSelectedWall={doAutoOnSelectedWall}
           lang={lang}
           setLang={setLang}
+          threeRef={threeRef}
+          isTopDown={isDrawingWalls}
         />
       </div>
     </div>

--- a/src/ui/TopBar.tsx
+++ b/src/ui/TopBar.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { getWallSegments } from '../utils/walls';
 import type { Kind, Variant } from '../core/catalog';
+import { FaCube, FaRegSquare } from 'react-icons/fa';
 
 interface TopBarProps {
   t: (key: string, opts?: any) => string;
@@ -12,9 +13,11 @@ interface TopBarProps {
   doAutoOnSelectedWall: () => void;
   lang: string;
   setLang: (l: string) => void;
+  threeRef: React.MutableRefObject<any>;
+  isTopDown: boolean;
 }
 
-export default function TopBar({ t, store, setVariant, setKind, selWall, setSelWall, doAutoOnSelectedWall, lang, setLang }: TopBarProps) {
+export default function TopBar({ t, store, setVariant, setKind, selWall, setSelWall, doAutoOnSelectedWall, lang, setLang, threeRef, isTopDown }: TopBarProps) {
   const onRemoveWall = () => {
     store.removeWall(selWall);
     setSelWall(0);
@@ -67,6 +70,17 @@ export default function TopBar({ t, store, setVariant, setKind, selWall, setSelW
         disabled={store.room.walls.length === 0}
       >
         {t('app.editWall')}
+      </button>
+      <button
+        className="btnGhost"
+        onClick={() =>
+          isTopDown
+            ? threeRef.current?.exitTopDownMode?.()
+            : threeRef.current?.enterTopDownMode?.()
+        }
+        title={isTopDown ? t('app.view3D') : t('app.view2D')}
+      >
+        {isTopDown ? <FaCube /> : <FaRegSquare />}
       </button>
       <button className="btn" onClick={doAutoOnSelectedWall}>
         {t('app.autoWall')}

--- a/src/ui/WallDrawPanel.tsx
+++ b/src/ui/WallDrawPanel.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { FaPencilAlt } from 'react-icons/fa';
+import { FaPencilAlt, FaCube, FaRegSquare } from 'react-icons/fa';
 import { usePlannerStore } from '../state/store';
 
 const ranges = {
@@ -38,6 +38,17 @@ export default function WallDrawPanel({
         disabled={isDrawing}
       >
         <FaPencilAlt />
+      </button>
+      <button
+        className="btnGhost"
+        onClick={() =>
+          isDrawing
+            ? threeRef.current?.exitTopDownMode?.()
+            : threeRef.current?.enterTopDownMode?.()
+        }
+        title={isDrawing ? t('app.view3D') : t('app.view2D')}
+      >
+        {isDrawing ? <FaCube /> : <FaRegSquare />}
       </button>
       <input
         className="input"


### PR DESCRIPTION
## Summary
- Add 2D/3D view toggle button to wall drawing panel and top bar
- Pass three.js reference and state to top bar
- Localize new View 2D/View 3D tooltips

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bcc5122c808322a69df9773815d201