### PR TITLE
Validate wall length limits

### DIFF
--- a/src/scene/engine.ts
+++ b/src/scene/engine.ts
@@ -162,6 +162,9 @@ export function setupThree(
     group,
     enterTopDownMode,
     exitTopDownMode,
-    applyWallLength: (len: number) => wallDrawer.applyLength(len),
+    applyWallLength: (len: number) => {
+      const safeLength = Math.min(len, 99999);
+      wallDrawer.applyLength(safeLength);
+    },
   };
 }

--- a/src/ui/WallDrawPanel.tsx
+++ b/src/ui/WallDrawPanel.tsx
@@ -65,7 +65,7 @@ export default function WallDrawPanel({
         maxLength={5}
         style={{ width: 70 }}
       />
-      <div>{Math.round(store.snappedLengthMm)} mm</div>
+      <div>{Math.round(store.snappedLengthMm).toString().slice(0, 5)} mm</div>
       <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
         <div>
           <div className="small">{t('room.angleToPrev')}</div>


### PR DESCRIPTION
## Summary
- ensure wall length input is restricted to 5 characters
- clamp `applyWallLength` to a maximum of 99999
- show only first five digits of snapped length in preview

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bcc7af6aa48322b686a65ce1ed2cc5