### PR TITLE
Decouple wall drawing preview from global store

### DIFF
--- a/src/scene/engine.ts
+++ b/src/scene/engine.ts
@@ -9,6 +9,7 @@ export function setupThree(
     onEnterTopDownMode?: () => void;
     onExitTopDownMode?: () => void;
     onLengthChange?: (len: number) => void;
+    onAngleChange?: (angle: number) => void;
   },
 ) {
   const scene = new THREE.Scene();
@@ -65,6 +66,7 @@ export function setupThree(
     scene,
     usePlannerStore,
     callbacks?.onLengthChange,
+    callbacks?.onAngleChange,
   );
   const cabinetDragger = new CabinetDragger(
     renderer,

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -138,8 +138,6 @@ type Store = {
   snapLength: number;
   snapRightAngles: boolean;
   angleToPrev: number;
-  snappedLengthMm: number;
-  snappedAngleDeg: number;
   showFronts: boolean;
   setRole: (r: 'stolarz' | 'klient') => void;
   updateGlobals: (fam: FAMILY, patch: Partial<Globals[FAMILY]>) => void;
@@ -165,7 +163,6 @@ type Store = {
   setSnapLength: (v: number) => void;
   setSnapRightAngles: (v: boolean) => void;
   setAngleToPrev: (v: number) => void;
-  setDraftWall: (len: number, angle: number) => void;
 };
 
 export const usePlannerStore = create<Store>((set, get) => ({
@@ -196,8 +193,6 @@ export const usePlannerStore = create<Store>((set, get) => ({
   snapLength: persisted?.snapLength ?? 10,
   snapRightAngles: persisted?.snapRightAngles ?? true,
   angleToPrev: persisted?.angleToPrev ?? 0,
-  snappedLengthMm: 0,
-  snappedAngleDeg: 0,
   showFronts: true,
   setRole: (r) => set({ role: r }),
   updateGlobals: (fam, patch) =>
@@ -425,8 +420,6 @@ export const usePlannerStore = create<Store>((set, get) => ({
   setSnapLength: (v) => set({ snapLength: v }),
   setSnapRightAngles: (v) => set({ snapRightAngles: v, snapAngle: v ? 90 : 0 }),
   setAngleToPrev: (v) => set({ angleToPrev: clamp(v, 0, 360) }),
-  setDraftWall: (len, angle) =>
-    set({ snappedLengthMm: len, snappedAngleDeg: angle }),
 }));
 
 const persistSelector = (s: Store) => ({

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -42,7 +42,6 @@ export default function App() {
   const [boardHasGrain, setBoardHasGrain] = useState(false);
   const [isDrawingWalls, setIsDrawingWalls] = useState(false);
   const [wallPanelOpen, setWallPanelOpen] = useState(false);
-  const [wallLength, setWallLength] = useState(0);
 
   const undo = store.undo;
   const redo = store.redo;
@@ -106,14 +105,11 @@ export default function App() {
           threeRef={threeRef}
           addCountertop={addCountertop}
           setIsDrawingWalls={setIsDrawingWalls}
-          setWallLength={setWallLength}
         />
         <WallDrawPanel
           threeRef={threeRef}
           isOpen={wallPanelOpen}
           isDrawing={isDrawingWalls}
-          wallLength={wallLength}
-          setWallLength={setWallLength}
         />
         <TopBar
           t={t}

--- a/src/ui/SceneViewer.tsx
+++ b/src/ui/SceneViewer.tsx
@@ -13,13 +13,14 @@ interface ThreeContext {
   renderer: THREE.WebGLRenderer;
   controls: OrbitControls;
   group: THREE.Group;
+  onLengthChange?: (len: number) => void;
+  onAngleChange?: (angle: number) => void;
 }
 
 interface Props {
   threeRef: React.MutableRefObject<ThreeContext | null>;
   addCountertop: boolean;
   setIsDrawingWalls: React.Dispatch<React.SetStateAction<boolean>>;
-  setWallLength: React.Dispatch<React.SetStateAction<number>>;
 }
 
 export const getLegHeight = (mod: Module3D, globals: Globals): number => {
@@ -34,7 +35,6 @@ const SceneViewer: React.FC<Props> = ({
   threeRef,
   addCountertop,
   setIsDrawingWalls,
-  setWallLength,
 }) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const store = usePlannerStore();
@@ -47,11 +47,13 @@ const SceneViewer: React.FC<Props> = ({
       onEnterTopDownMode: () => setIsDrawingWalls(true),
       onExitTopDownMode: () => {
         setIsDrawingWalls(false);
-        setWallLength(0);
+        threeRef.current?.onLengthChange?.(0);
+        threeRef.current?.onAngleChange?.(0);
       },
-      onLengthChange: setWallLength,
+      onLengthChange: (len) => threeRef.current?.onLengthChange?.(len),
+      onAngleChange: (angle) => threeRef.current?.onAngleChange?.(angle),
     });
-  }, [threeRef, setIsDrawingWalls, setWallLength]);
+  }, [threeRef, setIsDrawingWalls]);
 
   const createCabinetMesh = (mod: Module3D, legHeight: number) => {
     const W = mod.size.w;

--- a/src/ui/WallDrawPanel.tsx
+++ b/src/ui/WallDrawPanel.tsx
@@ -12,20 +12,22 @@ interface WallDrawPanelProps {
   threeRef: React.MutableRefObject<any>;
   isOpen: boolean;
   isDrawing: boolean;
-  wallLength: number;
-  setWallLength: React.Dispatch<React.SetStateAction<number>>;
 }
 
 export default function WallDrawPanel({
   threeRef,
   isOpen,
   isDrawing,
-  wallLength,
-  setWallLength,
 }: WallDrawPanelProps) {
   const { t } = useTranslation();
   const store = usePlannerStore();
   const range = ranges[store.wallType];
+  const [wallLength, setWallLength] = React.useState(0);
+  const [wallAngle, setWallAngle] = React.useState(0);
+  React.useEffect(() => {
+    threeRef.current.onLengthChange = setWallLength;
+    threeRef.current.onAngleChange = setWallAngle;
+  }, [threeRef]);
   if (!isOpen) {
     threeRef.current?.exitTopDownMode?.();
     return null;
@@ -65,7 +67,7 @@ export default function WallDrawPanel({
         maxLength={5}
         style={{ width: 70 }}
       />
-      <div>{Math.round(store.snappedLengthMm).toString().slice(0, 5)} mm</div>
+      <div>{Math.round(wallLength).toString().slice(0, 5)} mm</div>
       <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
         <div>
           <div className="small">{t('room.angleToPrev')}</div>
@@ -86,7 +88,7 @@ export default function WallDrawPanel({
             maxLength={3}
           />
         </div>
-        <div>{Math.round(store.snappedAngleDeg)}°</div>
+        <div>{Math.round(wallAngle)}°</div>
       </div>
       <div>
         <div className="small">{t('room.wallType')}</div>

--- a/tests/wallDrawer.e2e.test.ts
+++ b/tests/wallDrawer.e2e.test.ts
@@ -32,11 +32,10 @@ describe('WallDrawer click without drag', () => {
         angleToPrev: 0,
         room: { walls: [] },
         setRoom: vi.fn(),
-        setDraftWall: vi.fn(),
       }),
     } as any;
 
-    const drawer = new WallDrawer(renderer, getCamera, scene, store, () => {});
+    const drawer = new WallDrawer(renderer, getCamera, scene, store, () => {}, () => {});
     (drawer as any).getPoint = () => new THREE.Vector3(0, 0, 0);
 
     const down = { clientX: 0, clientY: 0 } as PointerEvent;


### PR DESCRIPTION
## Summary
- Store wall-drawing length and angle locally in `WallDrawPanel` and update via callbacks
- Remove draft wall fields and action from planner store
- Drive `WallDrawer` updates through `onLengthChange`/`onAngleChange` callbacks

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bd53aa03bc8322bdf16644749800dc