### PR TITLE
Add active guard to WallDrawer

### DIFF
--- a/src/scene/engine.ts
+++ b/src/scene/engine.ts
@@ -114,6 +114,8 @@ export function setupThree(
     requestAnimationFrame(animate);
   };
   const enterTopDownMode = () => {
+    wallDrawer.disable();
+    cabinetDragger.disable();
     transition(
       perspCamera.position.clone(),
       perspCamera.quaternion.clone(),

--- a/src/viewer/WallDrawer.ts
+++ b/src/viewer/WallDrawer.ts
@@ -29,6 +29,7 @@ export default class WallDrawer {
   private currentAngle = 0; // radians
   private onLengthChange?: (len: number) => void;
   private onAngleChange?: (angle: number) => void;
+  private active = false;
 
   constructor(
     renderer: WebGLRenderer,
@@ -74,6 +75,7 @@ export default class WallDrawer {
   }
 
   enable() {
+    if (this.active) return;
     const dom = this.renderer.domElement;
     dom.addEventListener('pointerdown', this.onDown);
     dom.addEventListener('pointerup', this.onUp);
@@ -86,9 +88,11 @@ export default class WallDrawer {
         dom.style.cursor = this.updateCursor(t);
       },
     );
+    this.active = true;
   }
 
   disable() {
+    if (!this.active) return;
     const dom = this.renderer.domElement;
     dom.removeEventListener('pointerdown', this.onDown);
     dom.removeEventListener('pointerup', this.onUp);
@@ -99,6 +103,7 @@ export default class WallDrawer {
     dom.style.cursor = 'default';
     this.unsubscribe?.();
     this.unsubscribe = undefined;
+    this.active = false;
   }
 
   private cleanupPreview() {


### PR DESCRIPTION
## Summary
- prevent double-activation of WallDrawer by tracking an `active` flag
- disable tools before re-entering top-down mode to avoid stale instances

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bd559ef69883228b1291289683ccc6