### PR TITLE
feat: add safe localStorage fallback

### DIFF
--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand';
 import { FAMILY } from '../core/catalog';
 import { Module3D, Room, Globals, Prices, Opening, Gaps } from '../types';
+import { safeSetItem } from '../utils/storage';
 
 export const defaultGaps: Gaps = {
   left: 2,
@@ -439,11 +440,7 @@ const persistSelector = (s: Store) => ({
 let persistTimeout = 0;
 usePlannerStore.subscribe(persistSelector, (slice) => {
   const save = () => {
-    try {
-      localStorage.setItem('kv7_state', JSON.stringify(slice));
-    } catch {
-      /* ignore */
-    }
+    safeSetItem('kv7_state', JSON.stringify(slice));
   };
   if ('requestIdleCallback' in window) {
     (window as any).requestIdleCallback(save);

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -7,6 +7,7 @@ import TopBar from './TopBar';
 import { createTranslator } from './i18n';
 import MainTabs from './MainTabs';
 import WallDrawPanel from './WallDrawPanel';
+import { safeSetItem } from '../utils/storage';
 
 export default function App() {
   const store = usePlannerStore();
@@ -18,10 +19,12 @@ export default function App() {
   const threeRef = useRef<any>({});
 
   const { t, i18n } = createTranslator();
-  const [lang, setLang] = useState(localStorage.getItem('lang') || i18n.language);
+  const [lang, setLang] = useState(
+    localStorage.getItem('lang') || i18n.language,
+  );
   useEffect(() => {
     i18n.changeLanguage(lang);
-    localStorage.setItem('lang', lang);
+    safeSetItem('lang', lang);
   }, [lang, i18n]);
 
   const {
@@ -35,7 +38,9 @@ export default function App() {
     initSidePanel,
   } = useCabinetConfig(family, kind, variant, selWall, setVariant);
 
-  const [tab, setTab] = useState<'cab' | 'room' | 'costs' | 'cut' | 'global' | null>(null);
+  const [tab, setTab] = useState<
+    'cab' | 'room' | 'costs' | 'cut' | 'global' | null
+  >(null);
   const [boardL, setBoardL] = useState(2800);
   const [boardW, setBoardW] = useState(2070);
   const [boardKerf, setBoardKerf] = useState(3);

--- a/src/ui/hooks/useLocalStorageState.ts
+++ b/src/ui/hooks/useLocalStorageState.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { safeSetItem } from '../../utils/storage';
 
 export default function useLocalStorageState<T>(key: string, initialValue: T) {
   const [value, setValue] = useState<T>(() => {
@@ -14,11 +15,7 @@ export default function useLocalStorageState<T>(key: string, initialValue: T) {
   });
 
   useEffect(() => {
-    try {
-      window.localStorage.setItem(key, JSON.stringify(value));
-    } catch {
-      /* ignore */
-    }
+    safeSetItem(key, JSON.stringify(value));
   }, [key, value]);
 
   return [value, setValue] as const;

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -1,0 +1,15 @@
+export function safeSetItem(key: string, value: string) {
+  try {
+    window.localStorage.setItem(key, value);
+  } catch (error) {
+    console.warn(`Failed to write to localStorage for key "${key}"`, error);
+    try {
+      window.sessionStorage.setItem(key, value);
+    } catch (sessionError) {
+      console.warn(
+        `Failed to write to sessionStorage for key "${key}"`,
+        sessionError,
+      );
+    }
+  }
+}

--- a/tests/useLocalStorageState.test.tsx
+++ b/tests/useLocalStorageState.test.tsx
@@ -1,54 +1,64 @@
 /** @vitest-environment jsdom */
-import { describe, it, expect } from 'vitest'
-import React, { act } from 'react'
-import ReactDOM from 'react-dom/client'
-import useLocalStorageState from '../src/ui/hooks/useLocalStorageState'
+import { describe, it, expect } from 'vitest';
+import React, { act } from 'react';
+import ReactDOM from 'react-dom/client';
+import useLocalStorageState from '../src/ui/hooks/useLocalStorageState';
 
 // React 18 requires this flag for act() in custom setups
-(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
 
-async function setup(key: string, initial: any){
-  const container = document.createElement('div')
-  let hookValue: any
-  let setHookValue: (v: any) => void = () => {}
+async function setup(key: string, initial: any) {
+  const container = document.createElement('div');
+  let hookValue: any;
+  let setHookValue: (v: any) => void = () => {};
 
-  function Test(){
-    const [v, setV] = useLocalStorageState(key, initial)
-    hookValue = v
-    setHookValue = setV
-    return <div>{String(v)}</div>
+  function Test() {
+    const [v, setV] = useLocalStorageState(key, initial);
+    hookValue = v;
+    setHookValue = setV;
+    return <div>{String(v)}</div>;
   }
 
-  const root = ReactDOM.createRoot(container)
+  const root = ReactDOM.createRoot(container);
   await act(async () => {
-    root.render(<Test />)
-  })
+    root.render(<Test />);
+  });
 
-  return { container, root, get value(){ return hookValue }, setValue: setHookValue }
+  return {
+    container,
+    root,
+    get value() {
+      return hookValue;
+    },
+    setValue: setHookValue,
+  };
 }
 
 describe('useLocalStorageState', () => {
   it('reads existing value from localStorage', async () => {
-    localStorage.setItem('test', JSON.stringify(5))
-    const { container, root } = await setup('test', 0)
-    expect(container.textContent).toBe('5')
+    try {
+      localStorage.setItem('test', JSON.stringify(5));
+    } catch (error) {
+      console.warn('Failed to set localStorage in test', error);
+    }
+    const { container, root } = await setup('test', 0);
+    expect(container.textContent).toBe('5');
     await act(async () => {
-      root.unmount()
-    })
-  })
+      root.unmount();
+    });
+  });
 
   it('saves updates to localStorage', async () => {
-    localStorage.clear()
-    const { container, setValue, root } = await setup('count', 1)
-    expect(localStorage.getItem('count')).toBe(JSON.stringify(1))
+    localStorage.clear();
+    const { container, setValue, root } = await setup('count', 1);
+    expect(localStorage.getItem('count')).toBe(JSON.stringify(1));
     await act(async () => {
-      setValue(7)
-    })
-    expect(localStorage.getItem('count')).toBe(JSON.stringify(7))
-    expect(container.textContent).toBe('7')
+      setValue(7);
+    });
+    expect(localStorage.getItem('count')).toBe(JSON.stringify(7));
+    expect(container.textContent).toBe('7');
     await act(async () => {
-      root.unmount()
-    })
-  })
-})
-
+      root.unmount();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add safeSetItem helper with sessionStorage fallback
- prevent crashes when writing to localStorage in App and store
- adjust useLocalStorageState and tests for safe storage access

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bd56f148c08322a736cb6103bb7686