### PR TITLE
Improve wall drawing direction and segment coverage

### DIFF
--- a/src/viewer/WallDrawer.ts
+++ b/src/viewer/WallDrawer.ts
@@ -167,8 +167,13 @@ export default class WallDrawer {
       const dx = point.x - this.start.x;
       const dz = point.z - this.start.z;
       length = dx * Math.cos(snappedAngle) + dz * Math.sin(snappedAngle);
-      if (length < 0) length = -length;
+      if (length < 0) {
+        length = -length;
+        snappedAngleDeg = (snappedAngleDeg + 180) % 360;
+        snappedAngle = (snappedAngle + Math.PI) % (Math.PI * 2);
+      }
     }
+    snappedAngleDeg = (snappedAngleDeg + 360) % 360;
     const lengthMm = length * 1000;
     const snappedLengthMm = snapLength
       ? Math.round(lengthMm / snapLength) * snapLength
@@ -188,7 +193,7 @@ export default class WallDrawer {
   };
 
   applyLength(lengthMm: number) {
-    if (!this.start || !this.preview) return;
+    if (!this.start || !this.preview || lengthMm <= 0) return;
     const lengthM = lengthMm / 1000;
     const end = new THREE.Vector3(
       this.start.x + Math.cos(this.currentAngle) * lengthM,
@@ -219,10 +224,16 @@ export default class WallDrawer {
     } else {
       const prev = state.room.walls[state.room.walls.length - 1];
       snappedAngleDeg = (prev ? prev.angle : 0) + state.angleToPrev;
-      const rad = (snappedAngleDeg * Math.PI) / 180;
-      const lenM = dx * Math.cos(rad) + dz * Math.sin(rad);
-      lengthMm = Math.abs(lenM) * 1000;
+      let rad = (snappedAngleDeg * Math.PI) / 180;
+      let lenM = dx * Math.cos(rad) + dz * Math.sin(rad);
+      if (lenM < 0) {
+        lenM = -lenM;
+        snappedAngleDeg = (snappedAngleDeg + 180) % 360;
+        rad = (snappedAngleDeg * Math.PI) / 180;
+      }
+      lengthMm = lenM * 1000;
     }
+    snappedAngleDeg = (snappedAngleDeg + 360) % 360;
     if (lengthMm < 1) {
       this.cleanupPreview();
       this.start = null;

--- a/tests/walls.test.ts
+++ b/tests/walls.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, beforeEach, expect } from 'vitest';
+import { getWallSegments } from '../src/utils/walls';
+import { usePlannerStore } from '../src/state/store';
+
+beforeEach(() => {
+  usePlannerStore.setState({
+    room: { walls: [], openings: [], height: 2700, origin: { x: 0, y: 0 } },
+  });
+});
+
+describe('getWallSegments', () => {
+  it('uses room origin when no start provided', () => {
+    usePlannerStore.setState({
+      room: {
+        walls: [{ length: 1000, angle: 0, thickness: 100 }],
+        openings: [],
+        height: 2700,
+        origin: { x: 1000, y: 2000 },
+      },
+    });
+    const segs = getWallSegments();
+    expect(segs[0].a.x).toBe(1000);
+    expect(segs[0].a.y).toBe(2000);
+  });
+
+  it('accepts custom starting point', () => {
+    usePlannerStore.setState({
+      room: {
+        walls: [{ length: 1000, angle: 0, thickness: 100 }],
+        openings: [],
+        height: 2700,
+        origin: { x: 0, y: 0 },
+      },
+    });
+    const segs = getWallSegments(50, 60);
+    expect(segs[0].a.x).toBe(50);
+    expect(segs[0].a.y).toBe(60);
+  });
+
+  it('adds closing segment when requested', () => {
+    usePlannerStore.setState({
+      room: {
+        walls: [
+          { length: 1000, angle: 0, thickness: 100 },
+          { length: 1000, angle: 90, thickness: 100 },
+          { length: 1000, angle: 180, thickness: 100 },
+        ],
+        openings: [],
+        height: 2700,
+        origin: { x: 0, y: 0 },
+      },
+    });
+    const segs = getWallSegments(undefined, undefined, true);
+    expect(segs.length).toBe(4);
+    const last = segs[3];
+    expect(last.b.x).toBeCloseTo(segs[0].a.x, 3);
+    expect(last.b.y).toBeCloseTo(segs[0].a.y, 3);
+  });
+});


### PR DESCRIPTION
## Summary
- normalize wall direction when drawing backwards and ignore non-positive lengths
- add tests for wall segments to cover room origin, custom start point and closing loops

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc57eec638832296997a353c259044