### PR TITLE
Prevent negative wall lengths in draw panel

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -53,7 +53,8 @@
     "finishDrawing": "Finish drawing",
     "noWalls": "No walls",
     "angleToPrev": "Angle to previous (°)",
-    "noRightAngles": "No right angles"
+    "noRightAngles": "No right angles",
+    "invalidLength": "Length must be non-negative"
   },
   "global": {
     "title": "Global settings",

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -53,7 +53,8 @@
     "finishDrawing": "Zakończ rysowanie",
     "noWalls": "Brak ścian",
     "angleToPrev": "Kąt do poprzedniej (°)",
-    "noRightAngles": "Bez prostych kątów"
+    "noRightAngles": "Bez prostych kątów",
+    "invalidLength": "Długość nie może być ujemna"
   },
   "global": {
     "title": "Ustawienia ogólne",

--- a/src/ui/WallDrawPanel.tsx
+++ b/src/ui/WallDrawPanel.tsx
@@ -24,6 +24,7 @@ export default function WallDrawPanel({
   const range = ranges[store.wallType];
   const [wallLength, setWallLength] = React.useState(0);
   const [wallAngle, setWallAngle] = React.useState(0);
+  const [lengthError, setLengthError] = React.useState(false);
   React.useEffect(() => {
     threeRef.current.onLengthChange = setWallLength;
     threeRef.current.onAngleChange = setWallAngle;
@@ -56,21 +57,35 @@ export default function WallDrawPanel({
       >
         {isDrawing ? <FaCube /> : <FaRegSquare />}
       </button>
-      <input
-        className="input"
-        type="number"
-        value={wallLength}
-        onChange={(e) =>
-          setWallLength(Number((e.target as HTMLInputElement).value) || 0)
-        }
-        onKeyDown={(e) => {
-          if (e.key === 'Enter') {
-            threeRef.current?.applyWallLength?.(wallLength);
-          }
-        }}
-        maxLength={5}
-        style={{ width: 70 }}
-      />
+      <div style={{ display: 'flex', flexDirection: 'column' }}>
+        <input
+          className="input"
+          type="number"
+          min={0}
+          value={wallLength}
+          onChange={(e) => {
+            const val = Number((e.target as HTMLInputElement).value);
+            if (val >= 0) {
+              setWallLength(val);
+              setLengthError(false);
+            } else {
+              setLengthError(true);
+            }
+          }}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              threeRef.current?.applyWallLength?.(wallLength);
+            }
+          }}
+          maxLength={5}
+          style={{ width: 70 }}
+        />
+        {lengthError && (
+          <div className="small" style={{ color: 'red' }}>
+            {t('room.invalidLength')}
+          </div>
+        )}
+      </div>
       <div>{Math.round(wallLength).toString().slice(0, 5)} mm</div>
       <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
         <div>


### PR DESCRIPTION
## Summary
- enforce non-negative values for wall length input and show a localized warning
- add translations for invalid wall length message

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bd5dcb356c832298e2e1e88aea7d61