### PR TITLE
Exit top-down mode when WallDrawPanel closes

### DIFF
--- a/src/ui/WallDrawPanel.tsx
+++ b/src/ui/WallDrawPanel.tsx
@@ -33,8 +33,12 @@ export default function WallDrawPanel({
       threeRef.current.onAngleChange = undefined;
     };
   }, [threeRef]);
+  React.useEffect(() => {
+    if (!isOpen) {
+      threeRef.current?.exitTopDownMode?.();
+    }
+  }, [isOpen, threeRef]);
   if (!isOpen) {
-    threeRef.current?.exitTopDownMode?.();
     return null;
   }
   return (


### PR DESCRIPTION
## Summary
- exit top-down mode whenever WallDrawPanel closes using isOpen effect
- keep panel content hidden when closed by returning null

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bd76041fec8322bb8c3b5a64732999