### PR TITLE
feat: allow editing wall thickness in top bar

### DIFF
--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -109,7 +109,7 @@ export const defaultPrices: Prices = {
   margin: 0.15,
 };
 
-const wallRanges = {
+export const wallRanges = {
   nosna: { min: 150, max: 250 },
   dzialowa: { min: 60, max: 120 },
 };

--- a/src/ui/TopBar.tsx
+++ b/src/ui/TopBar.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { getWallSegments } from '../utils/walls';
 import type { Kind, Variant } from '../core/catalog';
 import { FaCube, FaRegSquare } from 'react-icons/fa';
+import { wallRanges } from '../state/store';
 
 interface TopBarProps {
   t: (key: string, opts?: any) => string;
@@ -27,7 +28,14 @@ export default function TopBar({ t, store, setVariant, setKind, selWall, setSelW
     if (!w) return;
     const length = Number(prompt('Length (mm)', String(w.length))) || w.length;
     const angle = Number(prompt('Angle (deg)', String(w.angle))) || w.angle;
-    store.updateWall(selWall, { length, angle });
+    const thickness =
+      Number(prompt('Thickness (mm)', String(w.thickness))) || w.thickness;
+    const { min, max } = wallRanges[store.wallType];
+    if (thickness < min || thickness > max) {
+      alert(`Thickness must be between ${min} and ${max}mm`);
+      return;
+    }
+    store.updateWall(selWall, { length, angle, thickness });
   };
   return (
     <div className="topbar row">

--- a/tests/walls.test.ts
+++ b/tests/walls.test.ts
@@ -57,3 +57,24 @@ describe('getWallSegments', () => {
     expect(last.b.y).toBeCloseTo(segs[0].a.y, 3);
   });
 });
+
+describe('updateWall', () => {
+  it('updates thickness for selected wall', () => {
+    usePlannerStore.setState({
+      room: {
+        walls: [
+          { length: 1000, angle: 0, thickness: 100 },
+          { length: 1000, angle: 90, thickness: 100 },
+        ],
+        openings: [],
+        height: 2700,
+        origin: { x: 0, y: 0 },
+      },
+    });
+    const store = usePlannerStore.getState();
+    store.updateWall(1, { thickness: 80 });
+    const walls = usePlannerStore.getState().room.walls;
+    expect(walls[1].thickness).toBe(80);
+    expect(walls[0].thickness).toBe(100);
+  });
+});


### PR DESCRIPTION
## Summary
- allow TopBar to prompt for wall thickness and validate using wallRanges
- export wallRanges from state store
- test updating thickness on selected wall

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bda73202288322a595d30d9e15ed15