### PR TITLE
Use wall IDs instead of array indices

### DIFF
--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -151,9 +151,9 @@ type Store = {
   redo: () => void;
   setRoom: (patch: Partial<Room>) => void;
   addWall: (w: { length: number; angle: number; thickness: number }) => void;
-  removeWall: (index: number) => void;
+  removeWall: (id: string) => void;
   updateWall: (
-    index: number,
+    id: string,
     patch: Partial<{ length: number; angle: number; thickness: number }>,
   ) => void;
   addOpening: (op: Opening) => void;
@@ -179,6 +179,7 @@ export const usePlannerStore = create<Store>((set, get) => ({
         origin: persisted.room.origin || { x: 0, y: 0 },
         walls:
           persisted.room.walls?.map((w: any) => ({
+            id: w.id || crypto.randomUUID(),
             thickness: 100,
             ...w,
           })) || [],
@@ -356,25 +357,13 @@ export const usePlannerStore = create<Store>((set, get) => ({
           room: JSON.parse(JSON.stringify(s.room)),
         },
       ],
-      room: { ...s.room, walls: [...s.room.walls, w] },
-      future: [],
-    })),
-  removeWall: (index) =>
-    set((s) => ({
-      past: [
-        ...s.past,
-        {
-          modules: JSON.parse(JSON.stringify(s.modules)),
-          room: JSON.parse(JSON.stringify(s.room)),
-        },
-      ],
       room: {
         ...s.room,
-        walls: s.room.walls.filter((_, i) => i !== index),
+        walls: [...s.room.walls, { id: crypto.randomUUID(), ...w }],
       },
       future: [],
     })),
-  updateWall: (index, patch) =>
+  removeWall: (id) =>
     set((s) => ({
       past: [
         ...s.past,
@@ -385,8 +374,23 @@ export const usePlannerStore = create<Store>((set, get) => ({
       ],
       room: {
         ...s.room,
-        walls: s.room.walls.map((w, i) =>
-          i === index ? { ...w, ...patch } : w,
+        walls: s.room.walls.filter((w) => w.id !== id),
+      },
+      future: [],
+    })),
+  updateWall: (id, patch) =>
+    set((s) => ({
+      past: [
+        ...s.past,
+        {
+          modules: JSON.parse(JSON.stringify(s.modules)),
+          room: JSON.parse(JSON.stringify(s.room)),
+        },
+      ],
+      room: {
+        ...s.room,
+        walls: s.room.walls.map((w) =>
+          w.id === id ? { ...w, ...patch } : w,
         ),
       },
       future: [],

--- a/src/types.ts
+++ b/src/types.ts
@@ -186,7 +186,7 @@ export interface Module3D {
 export type Opening = Record<string, number>;
 
 export interface Room {
-  walls: { length: number; angle: number; thickness: number }[];
+  walls: { id: string; length: number; angle: number; thickness: number }[];
   openings: Opening[];
   height: number;
   origin: { x: number; y: number };

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -14,7 +14,7 @@ export default function App() {
   const [family, setFamily] = useState<FAMILY>(FAMILY.BASE);
   const [kind, setKind] = useState<Kind | null>(null);
   const [variant, setVariant] = useState<Variant | null>(null);
-  const [selWall, setSelWall] = useState(0);
+    const [selWall, setSelWall] = useState(() => usePlannerStore.getState().room.walls[0]?.id || '');
   const [addCountertop, setAddCountertop] = useState(true);
   const threeRef = useRef<any>({});
 
@@ -36,7 +36,7 @@ export default function App() {
     doAutoOnSelectedWall,
     initBlenda,
     initSidePanel,
-  } = useCabinetConfig(family, kind, variant, selWall, setVariant);
+    } = useCabinetConfig(family, kind, variant, selWall, setVariant);
 
   const [tab, setTab] = useState<
     'cab' | 'room' | 'costs' | 'cut' | 'global' | null
@@ -62,8 +62,11 @@ export default function App() {
         redo();
       } else if (e.key === 'Escape') {
         e.preventDefault();
-        removeWall(selWall);
-        setSelWall(0);
+          if (selWall) {
+            removeWall(selWall);
+            const first = usePlannerStore.getState().room.walls[0];
+            setSelWall(first ? first.id : '');
+          }
       }
     };
     window.addEventListener('keydown', handler);
@@ -121,8 +124,8 @@ export default function App() {
           store={store}
           setVariant={setVariant}
           setKind={setKind}
-          selWall={selWall}
-          setSelWall={setSelWall}
+            selWall={selWall}
+            setSelWall={setSelWall}
           doAutoOnSelectedWall={doAutoOnSelectedWall}
           lang={lang}
           setLang={setLang}

--- a/src/ui/TopBar.tsx
+++ b/src/ui/TopBar.tsx
@@ -2,15 +2,15 @@ import React from 'react';
 import { getWallSegments } from '../utils/walls';
 import type { Kind, Variant } from '../core/catalog';
 import { FaCube, FaRegSquare } from 'react-icons/fa';
-import { wallRanges } from '../state/store';
+import { wallRanges, usePlannerStore } from '../state/store';
 
 interface TopBarProps {
   t: (key: string, opts?: any) => string;
   store: any;
   setVariant: (v: Variant | null) => void;
   setKind: (k: Kind | null) => void;
-  selWall: number;
-  setSelWall: (n: number) => void;
+  selWall: string;
+  setSelWall: (n: string) => void;
   doAutoOnSelectedWall: () => void;
   lang: string;
   setLang: (l: string) => void;
@@ -21,10 +21,11 @@ interface TopBarProps {
 export default function TopBar({ t, store, setVariant, setKind, selWall, setSelWall, doAutoOnSelectedWall, lang, setLang, threeRef, isTopDown }: TopBarProps) {
   const onRemoveWall = () => {
     store.removeWall(selWall);
-    setSelWall(0);
+    const first = usePlannerStore.getState().room.walls[0];
+    setSelWall(first ? first.id : '');
   };
   const onEditWall = () => {
-    const w = store.room.walls[selWall];
+    const w = store.room.walls.find((ww: any) => ww.id === selWall);
     if (!w) return;
     const length = Number(prompt('Length (mm)', String(w.length))) || w.length;
     const angle = Number(prompt('Angle (deg)', String(w.angle))) || w.angle;
@@ -57,10 +58,10 @@ export default function TopBar({ t, store, setVariant, setKind, selWall, setSelW
       <select
         className="btnGhost"
         value={selWall}
-        onChange={e => setSelWall(Number((e.target as HTMLSelectElement).value) || 0)}
+        onChange={e => setSelWall((e.target as HTMLSelectElement).value)}
       >
         {getWallSegments().map((s, i) => (
-          <option key={i} value={i}>
+          <option key={store.room.walls[i]?.id} value={store.room.walls[i]?.id}>
             {t('app.wallLabel', { num: i + 1, len: Math.round(s.length) })}
           </option>
         ))}

--- a/src/ui/panels/RoomTab.tsx
+++ b/src/ui/panels/RoomTab.tsx
@@ -134,26 +134,25 @@ export default function RoomTab({
             {store.room.walls.length === 0 ? (
               <div>{t('room.noWalls')}</div>
             ) : (
-              <ul>
-                {store.room.walls.map((w, i) => (
-                  <li key={i}>
-                    {t('app.wallLabel', { num: i + 1, len: w.length })} –{' '}
-                    {w.angle}° –
-                    <input
-                      type="number"
-                      value={w.thickness}
-                      onChange={(e) =>
-                        store.updateWall(i, {
-                          thickness:
-                            Number((e.target as HTMLInputElement).value) || 0,
-                        })
-                      }
-                      style={{ width: 60, marginLeft: 4 }}
-                    />
-                    mm
-                  </li>
-                ))}
-              </ul>
+                <ul>
+                  {store.room.walls.map((w, i) => (
+                    <li key={w.id}>
+                      {t('app.wallLabel', { num: i + 1, len: w.length })} – {w.angle}° –
+                      <input
+                        type="number"
+                        value={w.thickness}
+                        onChange={(e) =>
+                          store.updateWall(w.id, {
+                            thickness:
+                              Number((e.target as HTMLInputElement).value) || 0,
+                          })
+                        }
+                        style={{ width: 60, marginLeft: 4 }}
+                      />
+                      mm
+                    </li>
+                  ))}
+                </ul>
             )}
           </div>
         </div>

--- a/src/ui/useCabinetConfig.ts
+++ b/src/ui/useCabinetConfig.ts
@@ -12,7 +12,7 @@ export function useCabinetConfig(
   family: FAMILY,
   kind: Kind | null,
   variant: Variant | null,
-  selWall: number,
+  selWall: string,
   setVariant: (v: Variant | null) => void,
 ) {
   const store = usePlannerStore();
@@ -240,7 +240,8 @@ export function useCabinetConfig(
   const doAutoOnSelectedWall = () => {
     const segs = getWallSegments();
     if (segs.length === 0) return alert(t('room.noWalls'));
-    const seg = segs[0 + (selWall % segs.length)];
+    const wallIndex = store.room.walls.findIndex(w => w.id === selWall);
+    const seg = segs[0 + ((wallIndex >= 0 ? wallIndex : 0) % segs.length)];
     const len = seg.length;
     const widths = autoWidthsForRun(len);
     const g = store.globals[family];
@@ -295,7 +296,7 @@ export function useCabinetConfig(
         size: { w, h, d },
         position: [pl.center[0] / 1000, h / 2, pl.center[1] / 1000],
         rotationY: pl.rot,
-        segIndex: selWall,
+        segIndex: wallIndex >= 0 ? wallIndex : 0,
         price,
         adv: {
           ...g,

--- a/tests/walls.test.ts
+++ b/tests/walls.test.ts
@@ -10,28 +10,28 @@ beforeEach(() => {
 
 describe('getWallSegments', () => {
   it('uses room origin when no start provided', () => {
-    usePlannerStore.setState({
-      room: {
-        walls: [{ length: 1000, angle: 0, thickness: 100 }],
-        openings: [],
-        height: 2700,
-        origin: { x: 1000, y: 2000 },
-      },
-    });
+      usePlannerStore.setState({
+        room: {
+          walls: [{ id: 'a', length: 1000, angle: 0, thickness: 100 }],
+          openings: [],
+          height: 2700,
+          origin: { x: 1000, y: 2000 },
+        },
+      });
     const segs = getWallSegments();
     expect(segs[0].a.x).toBe(1000);
     expect(segs[0].a.y).toBe(2000);
   });
 
   it('accepts custom starting point', () => {
-    usePlannerStore.setState({
-      room: {
-        walls: [{ length: 1000, angle: 0, thickness: 100 }],
-        openings: [],
-        height: 2700,
-        origin: { x: 0, y: 0 },
-      },
-    });
+      usePlannerStore.setState({
+        room: {
+          walls: [{ id: 'a', length: 1000, angle: 0, thickness: 100 }],
+          openings: [],
+          height: 2700,
+          origin: { x: 0, y: 0 },
+        },
+      });
     const segs = getWallSegments(50, 60);
     expect(segs[0].a.x).toBe(50);
     expect(segs[0].a.y).toBe(60);
@@ -40,11 +40,11 @@ describe('getWallSegments', () => {
   it('adds closing segment when requested', () => {
     usePlannerStore.setState({
       room: {
-        walls: [
-          { length: 1000, angle: 0, thickness: 100 },
-          { length: 1000, angle: 90, thickness: 100 },
-          { length: 1000, angle: 180, thickness: 100 },
-        ],
+          walls: [
+            { id: 'a', length: 1000, angle: 0, thickness: 100 },
+            { id: 'b', length: 1000, angle: 90, thickness: 100 },
+            { id: 'c', length: 1000, angle: 180, thickness: 100 },
+          ],
         openings: [],
         height: 2700,
         origin: { x: 0, y: 0 },
@@ -62,19 +62,19 @@ describe('updateWall', () => {
   it('updates thickness for selected wall', () => {
     usePlannerStore.setState({
       room: {
-        walls: [
-          { length: 1000, angle: 0, thickness: 100 },
-          { length: 1000, angle: 90, thickness: 100 },
-        ],
+          walls: [
+            { id: 'a', length: 1000, angle: 0, thickness: 100 },
+            { id: 'b', length: 1000, angle: 90, thickness: 100 },
+          ],
         openings: [],
         height: 2700,
         origin: { x: 0, y: 0 },
       },
     });
-    const store = usePlannerStore.getState();
-    store.updateWall(1, { thickness: 80 });
-    const walls = usePlannerStore.getState().room.walls;
-    expect(walls[1].thickness).toBe(80);
-    expect(walls[0].thickness).toBe(100);
+      const store = usePlannerStore.getState();
+      store.updateWall('b', { thickness: 80 });
+      const walls = usePlannerStore.getState().room.walls;
+      expect(walls[1].thickness).toBe(80);
+      expect(walls[0].thickness).toBe(100);
   });
 });


### PR DESCRIPTION
## Summary
- add `id` field to wall objects
- update store to generate IDs and manage walls by ID
- adjust UI components and tests to select walls via `id`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bda8b6aee48322b25ba402d8675050