### PR TITLE
Add wall openings support

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -183,7 +183,14 @@ export interface Module3D {
   openStates?: boolean[];
 }
 
-export type Opening = Record<string, number>;
+export interface Opening {
+  wallId: string;
+  offset: number;
+  width: number;
+  height: number;
+  bottom: number;
+  kind: number;
+}
 
 export interface Room {
   walls: { id: string; length: number; angle: number; thickness: number }[];

--- a/src/viewer/wall.ts
+++ b/src/viewer/wall.ts
@@ -1,0 +1,38 @@
+import * as THREE from 'three';
+import { Opening } from '../types';
+
+export function createWallGeometry(
+  lengthMm: number,
+  heightMm: number,
+  thicknessMm: number,
+  openings: Opening[],
+): THREE.BufferGeometry {
+  const len = lengthMm / 1000;
+  const h = heightMm / 1000;
+  const t = thicknessMm / 1000;
+  const shape = new THREE.Shape();
+  shape.moveTo(0, 0);
+  shape.lineTo(len, 0);
+  shape.lineTo(len, h);
+  shape.lineTo(0, h);
+  shape.lineTo(0, 0);
+  openings.forEach((o) => {
+    const ox = (o.offset || 0) / 1000;
+    const ob = (o.bottom || 0) / 1000;
+    const ow = (o.width || 0) / 1000;
+    const oh = (o.height || 0) / 1000;
+    const hole = new THREE.Path();
+    hole.moveTo(ox, ob);
+    hole.lineTo(ox + ow, ob);
+    hole.lineTo(ox + ow, ob + oh);
+    hole.lineTo(ox, ob + oh);
+    hole.lineTo(ox, ob);
+    shape.holes.push(hole);
+  });
+  const geom = new THREE.ExtrudeGeometry(shape, {
+    depth: t,
+    bevelEnabled: false,
+  });
+  geom.translate(-len / 2, -h / 2, -t / 2);
+  return geom;
+}

--- a/tests/openings.e2e.test.ts
+++ b/tests/openings.e2e.test.ts
@@ -1,0 +1,55 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach } from 'vitest';
+import * as THREE from 'three';
+import { usePlannerStore } from '../src/state/store';
+import { createWallGeometry } from '../src/viewer/wall';
+
+describe('openings', () => {
+  beforeEach(() => {
+    usePlannerStore.setState({
+      room: { walls: [], openings: [], height: 2700, origin: { x: 0, y: 0 } },
+    });
+  });
+
+  it('adds opening to store', () => {
+    const { addOpening } = usePlannerStore.getState();
+    addOpening({
+      wallId: 'w1',
+      offset: 100,
+      width: 50,
+      height: 50,
+      bottom: 0,
+      kind: 0,
+    });
+    expect(usePlannerStore.getState().room.openings).toHaveLength(1);
+  });
+
+  it('creates geometry with hole for opening', () => {
+    const wall = { id: 'w1', length: 2000, angle: 0, thickness: 100 };
+    const opening = {
+      wallId: 'w1',
+      offset: 500,
+      width: 800,
+      height: 1000,
+      bottom: 0,
+      kind: 1,
+    };
+    const geom = createWallGeometry(wall.length, 2700, wall.thickness, [opening]);
+    const mesh = new THREE.Mesh(geom, new THREE.MeshBasicMaterial());
+    const len = wall.length / 1000;
+    const h = 2700 / 1000;
+    const t = wall.thickness / 1000;
+    const holeX = (opening.offset / 1000 + opening.width / 1000 / 2) - len / 2;
+    const holeY = (opening.bottom / 1000 + opening.height / 1000 / 2) - h / 2;
+    const rc = new THREE.Raycaster(
+      new THREE.Vector3(holeX, holeY, t),
+      new THREE.Vector3(0, 0, -1),
+    );
+    expect(rc.intersectObject(mesh)).toHaveLength(0);
+    const rc2 = new THREE.Raycaster(
+      new THREE.Vector3(-len / 2 + 0.1, 0, t),
+      new THREE.Vector3(0, 0, -1),
+    );
+    expect(rc2.intersectObject(mesh).length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add form to create wall openings with position and size
- render walls with openings via extruded geometry
- test opening creation and wall cutouts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bdaa714e908322bacfb7e7e5151ec7