### PR TITLE
feat: add wall snap controls

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -53,6 +53,8 @@
     "finishDrawing": "Finish drawing",
     "noWalls": "No walls",
     "angleToPrev": "Angle to previous (°)",
+    "snapLength": "Length step (mm)",
+    "snapAngle": "Angle step (°)",
     "noRightAngles": "No right angles",
     "autoClose": "Auto close",
     "invalidLength": "Length must be non-negative"

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -53,6 +53,8 @@
     "finishDrawing": "Zakończ rysowanie",
     "noWalls": "Brak ścian",
     "angleToPrev": "Kąt do poprzedniej (°)",
+    "snapLength": "Krok długości (mm)",
+    "snapAngle": "Krok kąta (°)",
     "noRightAngles": "Bez prostych kątów",
     "autoClose": "Automatyczne domknięcie",
     "invalidLength": "Długość nie może być ujemna"

--- a/src/ui/WallDrawPanel.tsx
+++ b/src/ui/WallDrawPanel.tsx
@@ -113,6 +113,44 @@ export default function WallDrawPanel({
         </div>
         <div>{Math.round(wallAngle)}°</div>
       </div>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+        <div>
+          <div className="small">{t('room.snapLength')}</div>
+          <input
+            className="input"
+            type="number"
+            value={store.snapLength}
+            onChange={(e) => {
+              const val = Number((e.target as HTMLInputElement).value);
+              if (!Number.isNaN(val) && val >= 0) {
+                store.setSnapLength(val);
+              }
+            }}
+            style={{ width: 50 }}
+            min={0}
+          />
+        </div>
+        {!store.snapRightAngles && (
+          <div>
+            <div className="small">{t('room.snapAngle')}</div>
+            <input
+              className="input"
+              type="number"
+              value={store.snapAngle}
+              onChange={(e) => {
+                const val = Number((e.target as HTMLInputElement).value);
+                if (!Number.isNaN(val) && val >= 0 && val <= 360) {
+                  store.setSnapAngle(val);
+                }
+              }}
+              style={{ width: 50 }}
+              min={0}
+              max={360}
+              maxLength={3}
+            />
+          </div>
+        )}
+      </div>
       <div>
         <div className="small">{t('room.wallType')}</div>
         <select

--- a/tests/wallDrawer.e2e.test.ts
+++ b/tests/wallDrawer.e2e.test.ts
@@ -97,3 +97,54 @@ describe('WallDrawer.applyLength', () => {
     expect(addWall).not.toHaveBeenCalled();
   });
 });
+
+describe('WallDrawer snapping', () => {
+  it('snaps to configured angle and length', () => {
+    const canvas = document.createElement('canvas');
+    canvas.getBoundingClientRect = () => ({
+      left: 0,
+      top: 0,
+      width: 100,
+      height: 100,
+      right: 100,
+      bottom: 100,
+      x: 0,
+      y: 0,
+      toJSON() {},
+    });
+    const renderer = { domElement: canvas } as unknown as THREE.WebGLRenderer;
+    const camera = new THREE.PerspectiveCamera();
+    const getCamera = () => camera;
+    const scene = new THREE.Scene();
+    const onLengthChange = vi.fn();
+    const onAngleChange = vi.fn();
+    const state = {
+      addWall: vi.fn(),
+      wallThickness: 100,
+      wallType: 'dzialowa',
+      snapAngle: 30,
+      snapLength: 100,
+      snapRightAngles: true,
+      angleToPrev: 0,
+      room: { walls: [] },
+      setRoom: vi.fn(),
+    };
+    const store = { getState: () => state } as any;
+    const drawer = new WallDrawer(
+      renderer,
+      getCamera,
+      scene,
+      store,
+      onLengthChange,
+      onAngleChange,
+    );
+    (drawer as any).getPoint = () => new THREE.Vector3(0, 0, 0);
+    (drawer as any).onDown({} as PointerEvent);
+    const rad = (20 * Math.PI) / 180;
+    (drawer as any).getPoint = () =>
+      new THREE.Vector3(Math.cos(rad) * 0.12, 0, Math.sin(rad) * 0.12);
+    (drawer as any).onMove({} as PointerEvent);
+    expect(onAngleChange).toHaveBeenLastCalledWith(30);
+    expect(onLengthChange).toHaveBeenLastCalledWith(100);
+  });
+});

--- a/tests/walls.test.ts
+++ b/tests/walls.test.ts
@@ -5,7 +5,9 @@ import WallDrawer from '../src/viewer/WallDrawer';
 import * as THREE from 'three';
 import { webcrypto } from 'node:crypto';
 
-(globalThis as any).crypto = webcrypto as any;
+if (!(globalThis as any).crypto) {
+  (globalThis as any).crypto = webcrypto as any;
+}
 
 beforeEach(() => {
   usePlannerStore.setState({


### PR DESCRIPTION
## Summary
- allow configuring wall snap length and snap angle (angle field visible only when right-angle snapping is disabled)
- translate new controls to English and Polish
- cover wall drawer snapping behavior with an end-to-end test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bdb1d536448322b9bf4a70b83ba5ef