### PR TITLE
feat: enable wall editing mode

### DIFF
--- a/src/scene/engine.ts
+++ b/src/scene/engine.ts
@@ -170,5 +170,6 @@ export function setupThree(
       const safeLength = Math.min(len, 99999);
       wallDrawer.applyLength(safeLength);
     },
+    setWallMode: (mode: 'draw' | 'edit') => wallDrawer.setMode(mode),
   };
 }

--- a/src/ui/WallDrawPanel.tsx
+++ b/src/ui/WallDrawPanel.tsx
@@ -25,6 +25,7 @@ export default function WallDrawPanel({
   const [wallLength, setWallLength] = React.useState(0);
   const [wallAngle, setWallAngle] = React.useState(0);
   const [lengthError, setLengthError] = React.useState(false);
+  const [editMode, setEditMode] = React.useState(false);
   React.useEffect(() => {
     threeRef.current.onLengthChange = setWallLength;
     threeRef.current.onAngleChange = setWallAngle;
@@ -33,6 +34,9 @@ export default function WallDrawPanel({
       threeRef.current.onAngleChange = undefined;
     };
   }, [threeRef]);
+  React.useEffect(() => {
+    threeRef.current?.setWallMode?.(editMode ? 'edit' : 'draw');
+  }, [editMode, threeRef]);
   React.useEffect(() => {
     if (!isOpen) {
       threeRef.current?.exitTopDownMode?.();
@@ -61,6 +65,19 @@ export default function WallDrawPanel({
       >
         {isDrawing ? <FaCube /> : <FaRegSquare />}
       </button>
+      <label
+        className="small"
+        style={{ display: 'flex', gap: 8, alignItems: 'center' }}
+      >
+        <input
+          type="checkbox"
+          checked={editMode}
+          onChange={(e) =>
+            setEditMode((e.target as HTMLInputElement).checked)
+          }
+        />
+        {t('app.editWall')}
+      </label>
       <div style={{ display: 'flex', flexDirection: 'column' }}>
         <input
           className="input"

--- a/tests/wallDrawer.e2e.test.ts
+++ b/tests/wallDrawer.e2e.test.ts
@@ -148,3 +148,53 @@ describe('WallDrawer snapping', () => {
     expect(onLengthChange).toHaveBeenLastCalledWith(100);
   });
 });
+
+describe('WallDrawer edit mode', () => {
+  it('drags endpoint to change length and angle', () => {
+    const canvas = document.createElement('canvas');
+    canvas.getBoundingClientRect = () => ({
+      left: 0,
+      top: 0,
+      width: 100,
+      height: 100,
+      right: 100,
+      bottom: 100,
+      x: 0,
+      y: 0,
+      toJSON() {},
+    });
+    const renderer = { domElement: canvas } as unknown as THREE.WebGLRenderer;
+    const camera = new THREE.PerspectiveCamera();
+    const getCamera = () => camera;
+    const scene = new THREE.Scene();
+    const updateWall = vi.fn();
+    const state = {
+      updateWall,
+      wallThickness: 100,
+      wallType: 'dzialowa',
+      snapAngle: 0,
+      snapLength: 0,
+      snapRightAngles: true,
+      angleToPrev: 0,
+      room: {
+        origin: { x: 0, y: 0 },
+        walls: [{ id: 'a', length: 1000, angle: 0, thickness: 100 }],
+      },
+      setRoom: vi.fn(),
+    };
+    const store = { getState: () => state } as any;
+    const drawer = new WallDrawer(renderer, getCamera, scene, store, () => {}, () => {});
+    (drawer as any).setMode('edit');
+    // select endpoint at (1,0)
+    (drawer as any).getPoint = () => new THREE.Vector3(1, 0, 0);
+    (drawer as any).onDown({} as PointerEvent);
+    // drag to (0.5, 0.5)
+    (drawer as any).getPoint = () => new THREE.Vector3(0.5, 0, 0.5);
+    (drawer as any).onMove({} as PointerEvent);
+    (drawer as any).onUp({} as PointerEvent);
+    expect(updateWall).toHaveBeenCalled();
+    const patch = updateWall.mock.calls[0][1];
+    expect(patch.length).toBeCloseTo(707, 0);
+    expect(patch.angle).toBeCloseTo(45, 0);
+  });
+});


### PR DESCRIPTION
## Summary
- allow switching between drawing and editing walls
- update wall data on drag and expose mode toggle in UI panel
- add e2e test for wall vertex dragging

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bdb685f2bc832291838733917b7adb