### PR TITLE
Toggle wall drawing with pencil button

### DIFF
--- a/src/ui/WallDrawPanel.tsx
+++ b/src/ui/WallDrawPanel.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { FaPencilAlt, FaCube, FaRegSquare } from 'react-icons/fa';
+import { FaPencilAlt } from 'react-icons/fa';
 import { usePlannerStore } from '../state/store';
 
 const ranges = {
@@ -48,22 +48,14 @@ export default function WallDrawPanel({
   return (
     <div className="bottombar row">
       <button
-        className="btnGhost"
-        onClick={() => threeRef.current?.enterTopDownMode?.()}
-        disabled={isDrawing}
-      >
-        <FaPencilAlt />
-      </button>
-      <button
-        className="btnGhost"
+        className={`btnGhost${isDrawing ? ' active' : ''}`}
         onClick={() =>
           isDrawing
             ? threeRef.current?.exitTopDownMode?.()
             : threeRef.current?.enterTopDownMode?.()
         }
-        title={isDrawing ? t('app.view3D') : t('app.view2D')}
       >
-        {isDrawing ? <FaCube /> : <FaRegSquare />}
+        <FaPencilAlt />
       </button>
       <label
         className="small"

--- a/tests/wallDrawPanel.test.tsx
+++ b/tests/wallDrawPanel.test.tsx
@@ -58,4 +58,41 @@ describe('WallDrawPanel callbacks', () => {
       root.unmount();
     });
   });
+
+  it('toggles drawing state when pencil is clicked', async () => {
+    const three: any = {};
+    const threeRef = { current: three } as React.MutableRefObject<any>;
+    const container = document.createElement('div');
+    const root = ReactDOM.createRoot(container);
+
+    const Wrapper = () => {
+      const [isDrawing, setIsDrawing] = React.useState(false);
+      three.enterTopDownMode = () => three.onEnterTopDownMode?.();
+      three.exitTopDownMode = () => three.onExitTopDownMode?.();
+      three.onEnterTopDownMode = () => setIsDrawing(true);
+      three.onExitTopDownMode = () => setIsDrawing(false);
+      return <WallDrawPanel threeRef={threeRef} isOpen isDrawing={isDrawing} />;
+    };
+
+    await act(async () => {
+      root.render(<Wrapper />);
+    });
+
+    const btn = container.querySelector('button') as HTMLButtonElement;
+    expect(btn.className.includes('active')).toBe(false);
+
+    await act(async () => {
+      btn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(btn.className.includes('active')).toBe(true);
+
+    await act(async () => {
+      btn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(btn.className.includes('active')).toBe(false);
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- make pencil button enter or exit top-down mode, highlighting when active
- remove redundant 2D/3D toggle button
- test wall drawing panel toggles drawing state on click

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdddb52d8483228dae27a9bc62bab6