### PR TITLE
Sync wall length between panel and overlay

### DIFF
--- a/src/ui/WallDrawPanel.tsx
+++ b/src/ui/WallDrawPanel.tsx
@@ -42,6 +42,35 @@ export default function WallDrawPanel({
       threeRef.current?.exitTopDownMode?.();
     }
   }, [isOpen, threeRef]);
+  React.useEffect(() => {
+    if (!isOpen) return;
+    const overlay = document.querySelector(
+      'input.wall-overlay',
+    ) as HTMLInputElement | null;
+    if (!overlay) return;
+    overlay.value = `${wallLength}`;
+    const onInput = () => {
+      const val = Number(overlay.value);
+      if (!Number.isNaN(val)) {
+        setWallLength(val);
+      }
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Enter') {
+        const val = Number(overlay.value);
+        if (!Number.isNaN(val)) {
+          threeRef.current?.applyWallLength?.(val);
+          setWallLength(val);
+        }
+      }
+    };
+    overlay.addEventListener('input', onInput);
+    overlay.addEventListener('keydown', onKey);
+    return () => {
+      overlay.removeEventListener('input', onInput);
+      overlay.removeEventListener('keydown', onKey);
+    };
+  }, [wallLength, isOpen, threeRef]);
   if (!isOpen) {
     return null;
   }

--- a/tests/wallDrawPanel.test.tsx
+++ b/tests/wallDrawPanel.test.tsx
@@ -134,4 +134,54 @@ describe('WallDrawPanel callbacks', () => {
       root.unmount();
     });
   });
+
+  it('keeps panel and overlay values in sync', async () => {
+    const three: any = { applyWallLength: vi.fn() };
+    const threeRef = { current: three } as React.MutableRefObject<any>;
+    const container = document.createElement('div');
+    const root = ReactDOM.createRoot(container);
+    document.body.innerHTML = '';
+    const overlay = document.createElement('input');
+    overlay.className = 'wall-overlay';
+    document.body.appendChild(overlay);
+
+    await act(async () => {
+      root.render(<WallDrawPanel threeRef={threeRef} isOpen isDrawing />);
+    });
+
+    await act(async () => {
+      three.onLengthChange(123);
+    });
+    const panelInput = container.querySelector('input.input') as HTMLInputElement;
+    expect(panelInput.value).toBe('123');
+    expect(overlay.value).toBe('123');
+
+    await act(async () => {
+      three.onLengthChange(456);
+    });
+    expect(panelInput.value).toBe('456');
+    expect((document.querySelector('input.wall-overlay') as HTMLInputElement).value).toBe('456');
+
+    await act(async () => {
+      const ov = document.querySelector('input.wall-overlay') as HTMLInputElement;
+      ov.value = '789';
+      ov.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    expect(panelInput.value).toBe('789');
+
+    await act(async () => {
+      const ov = document.querySelector('input.wall-overlay') as HTMLInputElement;
+      ov.value = '900';
+      ov.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }),
+      );
+    });
+    expect(three.applyWallLength).toHaveBeenCalledWith(900);
+    expect(panelInput.value).toBe('900');
+
+    document.querySelector('input.wall-overlay')?.remove();
+    await act(async () => {
+      root.unmount();
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- keep overlay and panel wall-length fields synchronized
- apply overlay-edited lengths via `applyWallLength`
- test overlay and panel length consistency

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bde7a0b84c83228bf27d7b9562d1b9