### PR TITLE
feat: differentiate wall types visually

### DIFF
--- a/src/ui/panels/RoomTab.tsx
+++ b/src/ui/panels/RoomTab.tsx
@@ -3,7 +3,7 @@ import * as THREE from 'three';
 import { useTranslation } from 'react-i18next';
 import { usePlannerStore } from '../../state/store';
 import RoomUploader from '../RoomUploader';
-import { createWallGeometry } from '../../viewer/wall';
+import { createWallGeometry, createWallMaterial } from '../../viewer/wall';
 import { Opening } from '../../types';
 
 interface RoomTabProps {
@@ -76,8 +76,12 @@ export default function RoomTab({
       group.remove(m);
       (m as any).geometry?.dispose?.();
       if (Array.isArray((m as any).material)) {
-        (m as any).material.forEach((mm: any) => mm.dispose());
+        (m as any).material.forEach((mm: any) => {
+          mm.map?.dispose?.();
+          mm.dispose();
+        });
       } else {
+        (m as any).material?.map?.dispose?.();
         (m as any).material?.dispose?.();
       }
     });
@@ -112,17 +116,21 @@ export default function RoomTab({
         w.thickness || 0,
         store.room.openings.filter((o) => o.wallId === w.id),
       );
-      const box = new THREE.Mesh(
-        geom,
-        new THREE.MeshStandardMaterial({ color: 0xd1d5db }),
-      );
+      const mat = createWallMaterial(store.wallType);
+      const box = new THREE.Mesh(geom, mat);
       box.position.set(mid.x, h / 2000, mid.y);
       box.rotation.y = -ang;
       (box as any).userData.kind = 'room';
       group.add(box);
       cursor = next;
     });
-  }, [store.room.walls, store.room.height, store.room.openings, three]);
+  }, [
+    store.room.walls,
+    store.room.height,
+    store.room.openings,
+    store.wallType,
+    three,
+  ]);
   return (
     <>
       <div className="section">

--- a/src/viewer/wall.ts
+++ b/src/viewer/wall.ts
@@ -36,3 +36,36 @@ export function createWallGeometry(
   geom.translate(-len / 2, -h / 2, -t / 2);
   return geom;
 }
+
+export function createWallMaterial(
+  type: 'dzialowa' | 'nosna',
+): THREE.MeshStandardMaterial {
+  const size = 32;
+  const canvas = document.createElement('canvas');
+  canvas.width = canvas.height = size;
+  const ctx = canvas.getContext('2d');
+  if (ctx) {
+    ctx.fillStyle = '#d1d5db';
+    ctx.fillRect(0, 0, size, size);
+    ctx.strokeStyle = '#666';
+    ctx.lineWidth = 2;
+    for (let i = -size; i < size; i += 8) {
+      ctx.beginPath();
+      ctx.moveTo(i, 0);
+      ctx.lineTo(i + size, size);
+      ctx.stroke();
+    }
+    if (type === 'nosna') {
+      ctx.strokeStyle = '#000';
+      for (let y = 4; y < size; y += 8) {
+        ctx.beginPath();
+        ctx.arc(2, y, 4, -Math.PI / 2, Math.PI / 2);
+        ctx.stroke();
+      }
+    }
+  }
+  const texture = new THREE.CanvasTexture(canvas);
+  texture.wrapS = texture.wrapT = THREE.RepeatWrapping;
+  texture.repeat.set(4, 4);
+  return new THREE.MeshStandardMaterial({ map: texture });
+}


### PR DESCRIPTION
## Summary
- add canvas-based materials to render partition and load-bearing walls differently
- apply new wall materials when drawing room walls

## Testing
- `npm test`
- `npm run lint` *(fails: 'cursor' is never reassigned)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf71ed8608322bf0dabfe4cb828de