### PR TITLE
Fix wall material rendering and lint errors

### DIFF
--- a/src/viewer/WallDrawer.ts
+++ b/src/viewer/WallDrawer.ts
@@ -197,7 +197,7 @@ export default class WallDrawer {
     const origin = room.origin
       ? new THREE.Vector3(room.origin.x / 1000, 0, room.origin.y / 1000)
       : new THREE.Vector3();
-    let cursor = origin.clone();
+    const cursor = origin.clone();
     for (const w of walls) {
       let el = this.labels.get(w.id);
       if (!el || el instanceof HTMLInputElement) {
@@ -297,7 +297,7 @@ export default class WallDrawer {
       const origin = room.origin
         ? new THREE.Vector3(room.origin.x / 1000, 0, room.origin.y / 1000)
         : new THREE.Vector3();
-      let cursor = origin.clone();
+      const cursor = origin.clone();
       for (let i = 0; i < room.walls.length; i++) {
         const w = room.walls[i];
         const ang = (w.angle * Math.PI) / 180;
@@ -393,7 +393,7 @@ export default class WallDrawer {
       const { snapAngle, snapLength } = this.store.getState();
       const dx = point.x - this.start.x;
       const dz = point.z - this.start.z;
-      let length = Math.sqrt(dx * dx + dz * dz);
+      const length = Math.sqrt(dx * dx + dz * dz);
       let angle = Math.atan2(dz, dx);
       let angleDeg = (angle * 180) / Math.PI;
       if (snapAngle) {

--- a/src/viewer/wall.ts
+++ b/src/viewer/wall.ts
@@ -39,7 +39,7 @@ export function createWallGeometry(
 
 export function createWallMaterial(
   type: 'dzialowa' | 'nosna',
-): THREE.MeshStandardMaterial {
+): [THREE.MeshStandardMaterial, THREE.MeshStandardMaterial] {
   const size = 32;
   const canvas = document.createElement('canvas');
   canvas.width = canvas.height = size;
@@ -54,12 +54,10 @@ export function createWallMaterial(
       ctx.moveTo(i, 0);
       ctx.lineTo(i + size, size);
       ctx.stroke();
-    }
-    if (type === 'nosna') {
-      ctx.strokeStyle = '#000';
-      for (let y = 4; y < size; y += 8) {
+      if (type === 'nosna') {
         ctx.beginPath();
-        ctx.arc(2, y, 4, -Math.PI / 2, Math.PI / 2);
+        ctx.moveTo(i, size);
+        ctx.lineTo(i + size, 0);
         ctx.stroke();
       }
     }
@@ -67,5 +65,7 @@ export function createWallMaterial(
   const texture = new THREE.CanvasTexture(canvas);
   texture.wrapS = texture.wrapT = THREE.RepeatWrapping;
   texture.repeat.set(4, 4);
-  return new THREE.MeshStandardMaterial({ map: texture });
+  const topMaterial = new THREE.MeshStandardMaterial({ map: texture });
+  const sideMaterial = new THREE.MeshStandardMaterial({ color: '#d1d5db' });
+  return [sideMaterial, topMaterial];
 }

--- a/tests/wallDrawer.e2e.test.ts
+++ b/tests/wallDrawer.e2e.test.ts
@@ -242,7 +242,7 @@ describe('WallDrawer overlays', () => {
     const drawer = new WallDrawer(renderer, getCamera, scene, store, () => {}, () => {});
     (drawer as any).getPoint = () => new THREE.Vector3(0, 0, 0);
     (drawer as any).onDown({ clientX: 0, clientY: 0 } as PointerEvent);
-    let overlay = document.querySelector('input.wall-overlay') as HTMLInputElement;
+    const overlay = document.querySelector('input.wall-overlay') as HTMLInputElement;
     expect(overlay).not.toBeNull();
     // move to update overlay
     (drawer as any).getPoint = () => new THREE.Vector3(1, 0, 0);


### PR DESCRIPTION
## Summary
- draw single diagonals for partition walls and crosshatch load-bearing walls
- return separate side and top materials for wall meshes
- clean up lint warnings in wall drawer and tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be954df4508322b6c36d22734ebbef