### PR TITLE
Show angle step when snapping right angles

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -54,7 +54,7 @@
     "noWalls": "No walls",
     "angleToPrev": "Angle to previous (°)",
     "snapLength": "Length step (mm)",
-    "snapAngle": "Angle step (°)",
+    "snapAngle": "Angle step (°) for right-angle mode",
     "noRightAngles": "No right angles",
     "autoClose": "Auto close",
     "invalidLength": "Length must be non-negative"

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -54,7 +54,7 @@
     "noWalls": "Brak ścian",
     "angleToPrev": "Kąt do poprzedniej (°)",
     "snapLength": "Krok długości (mm)",
-    "snapAngle": "Krok kąta (°)",
+    "snapAngle": "Krok kąta (°) w trybie kątów prostych",
     "noRightAngles": "Bez prostych kątów",
     "autoClose": "Automatyczne domknięcie",
     "invalidLength": "Długość nie może być ujemna"

--- a/src/ui/WallDrawPanel.tsx
+++ b/src/ui/WallDrawPanel.tsx
@@ -176,7 +176,7 @@ export default function WallDrawPanel({
             min={0}
           />
         </div>
-        {!store.snapRightAngles && (
+        {store.snapRightAngles && (
           <div>
             <div className="small">{t('room.snapAngle')}</div>
             <input


### PR DESCRIPTION
## Summary
- display Angle step control only in right-angle snapping mode
- clarify Angle step label in English and Polish translations

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be996014908322888560e7da913c87