### PR TITLE
Use tolerance for wall closure

### DIFF
--- a/src/utils/walls.ts
+++ b/src/utils/walls.ts
@@ -16,7 +16,7 @@ export function getWallSegments(startX?: number, startY?: number, close = false)
   }
   if (close && segs.length > 0){
     const last = segs[segs.length - 1].b
-    if (last.x !== start.x || last.y !== start.y){
+    if (Math.abs(last.x - start.x) > 1e-3 || Math.abs(last.y - start.y) > 1e-3){
       const dx = start.x - last.x, dy = start.y - last.y
       const len = Math.hypot(dx, dy)
       const ang = Math.atan2(dy, dx)

--- a/tests/walls.test.ts
+++ b/tests/walls.test.ts
@@ -63,6 +63,26 @@ describe('getWallSegments', () => {
     expect(last.b.x).toBeCloseTo(segs[0].a.x, 3);
     expect(last.b.y).toBeCloseTo(segs[0].a.y, 3);
   });
+
+  it('skips closing segment for negligible gap', () => {
+    usePlannerStore.setState({
+      room: {
+        walls: [
+          { id: 'a', length: 10, angle: 0, thickness: 100 },
+          { id: 'b', length: 10, angle: 120, thickness: 100 },
+          { id: 'c', length: 10, angle: 240, thickness: 100 },
+        ],
+        openings: [],
+        height: 2700,
+        origin: { x: 0, y: 0 },
+      },
+    });
+    const segs = getWallSegments(undefined, undefined, true);
+    expect(segs.length).toBe(3);
+    const last = segs[2];
+    expect(last.b.x).toBeCloseTo(segs[0].a.x, 3);
+    expect(last.b.y).toBeCloseTo(segs[0].a.y, 3);
+  });
 });
 
 describe('updateWall', () => {


### PR DESCRIPTION
## Summary
- avoid adding closing wall segment when gap is within 1e-3 tolerance
- add unit test for negligible floating-point gap

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be9b6e07688322b02f7647f670dbf4