### PR TITLE
feat: support arc walls

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -193,8 +193,26 @@ export interface Opening {
   kind: number;
 }
 
+export interface WallArc {
+  /** radius in millimetres */
+  radius: number;
+  /** central angle in degrees; positive is counter-clockwise */
+  angle: number;
+}
+
+export interface WallSegment {
+  id: string;
+  /** length in millimetres (for arcs this is the arc length) */
+  length: number;
+  /** direction of the segment start in degrees */
+  angle: number;
+  thickness: number;
+  /** optional arc definition */
+  arc?: WallArc;
+}
+
 export interface Room {
-  walls: { id: string; length: number; angle: number; thickness: number }[];
+  walls: WallSegment[];
   openings: Opening[];
   height: number;
   origin: { x: number; y: number };

--- a/src/viewer/wall.ts
+++ b/src/viewer/wall.ts
@@ -6,10 +6,27 @@ export function createWallGeometry(
   heightMm: number,
   thicknessMm: number,
   openings: Opening[],
+  arc?: { radius: number; angle: number },
 ): THREE.BufferGeometry {
-  const len = lengthMm / 1000;
   const h = heightMm / 1000;
   const t = thicknessMm / 1000;
+  if (arc) {
+    const r = arc.radius / 1000;
+    const sweep = (arc.angle * Math.PI) / 180;
+    const shape = new THREE.Shape();
+    shape.absarc(0, 0, r, 0, sweep, sweep < 0);
+    const inner = new THREE.Path();
+    inner.absarc(0, 0, r - t, sweep, 0, sweep < 0);
+    shape.holes.push(inner);
+    const geom = new THREE.ExtrudeGeometry(shape, {
+      depth: h,
+      bevelEnabled: false,
+    });
+    geom.rotateX(Math.PI / 2);
+    geom.translate(0, -t / 2, -h / 2);
+    return geom;
+  }
+  const len = lengthMm / 1000;
   const shape = new THREE.Shape();
   shape.moveTo(0, 0);
   shape.lineTo(len, 0);

--- a/tests/walls.test.ts
+++ b/tests/walls.test.ts
@@ -83,6 +83,29 @@ describe('getWallSegments', () => {
     expect(last.b.x).toBeCloseTo(segs[0].a.x, 3);
     expect(last.b.y).toBeCloseTo(segs[0].a.y, 3);
   });
+
+  it('handles arc segments', () => {
+    usePlannerStore.setState({
+      room: {
+        walls: [
+          {
+            id: 'a',
+            angle: 0,
+            thickness: 100,
+            arc: { radius: 1000, angle: 90 },
+            length: Math.PI * 1000 * 0.5,
+          },
+        ],
+        openings: [],
+        height: 2700,
+        origin: { x: 0, y: 0 },
+      },
+    });
+    const segs = getWallSegments();
+    expect(segs[0].arc?.radius).toBe(1000);
+    expect(segs[0].b.x).toBeCloseTo(1000, 3);
+    expect(segs[0].b.y).toBeCloseTo(1000, 3);
+  });
 });
 
 describe('updateWall', () => {


### PR DESCRIPTION
## Summary
- extend wall types with optional arc parameters
- compute segments and geometry for arc walls
- add rudimentary arc drawing mode and tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bea10dabd08322b065f1fd9849a86a