### PR TITLE
Add grid snapping to wall drawer

### DIFF
--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -141,6 +141,8 @@ type Store = {
   angleToPrev: number;
   showFronts: boolean;
   autoCloseWalls: boolean;
+  gridSize: number;
+  snapToGrid: boolean;
   setRole: (r: 'stolarz' | 'klient') => void;
   updateGlobals: (fam: FAMILY, patch: Partial<Globals[FAMILY]>) => void;
   updatePrices: (patch: Partial<Prices>) => void;
@@ -168,6 +170,8 @@ type Store = {
   setSnapRightAngles: (v: boolean) => void;
   setAngleToPrev: (v: number) => void;
   setAutoCloseWalls: (v: boolean) => void;
+  setGridSize: (v: number) => void;
+  setSnapToGrid: (v: boolean) => void;
 };
 
 export const usePlannerStore = create<Store>((set, get) => ({
@@ -205,6 +209,8 @@ export const usePlannerStore = create<Store>((set, get) => ({
   snapRightAngles: persisted?.snapRightAngles ?? true,
   angleToPrev: persisted?.angleToPrev ?? 0,
   autoCloseWalls: persisted?.autoCloseWalls ?? true,
+  gridSize: persisted?.gridSize ?? 50,
+  snapToGrid: persisted?.snapToGrid ?? false,
   showFronts: true,
   setRole: (r) => set({ role: r }),
   updateGlobals: (fam, patch) =>
@@ -498,6 +504,8 @@ export const usePlannerStore = create<Store>((set, get) => ({
   setSnapRightAngles: (v) => set({ snapRightAngles: v, snapAngle: v ? 90 : 0 }),
   setAngleToPrev: (v) => set({ angleToPrev: clamp(v, 0, 360) }),
   setAutoCloseWalls: (v) => set({ autoCloseWalls: v }),
+  setGridSize: (v) => set({ gridSize: v }),
+  setSnapToGrid: (v) => set({ snapToGrid: v }),
 }));
 
 const persistSelector = (s: Store) => ({
@@ -513,6 +521,8 @@ const persistSelector = (s: Store) => ({
   snapRightAngles: s.snapRightAngles,
   angleToPrev: s.angleToPrev,
   autoCloseWalls: s.autoCloseWalls,
+  gridSize: s.gridSize,
+  snapToGrid: s.snapToGrid,
 });
 
 let persistTimeout = 0;

--- a/src/ui/WallDrawPanel.tsx
+++ b/src/ui/WallDrawPanel.tsx
@@ -178,27 +178,58 @@ export default function WallDrawPanel({
             min={0}
           />
         </div>
-        {store.snapRightAngles && (
-          <div>
-            <div className="small">{t('room.snapAngle')}</div>
-            <input
-              className="input"
-              type="number"
-              value={store.snapAngle}
-              onChange={(e) => {
-                const val = Number((e.target as HTMLInputElement).value);
-                if (!Number.isNaN(val) && val >= 0 && val <= 360) {
-                  store.setSnapAngle(val);
-                }
-              }}
-              style={{ width: 50 }}
-              min={0}
-              max={360}
-              maxLength={3}
-            />
-          </div>
-        )}
+      {store.snapRightAngles && (
+        <div>
+          <div className="small">{t('room.snapAngle')}</div>
+          <input
+            className="input"
+            type="number"
+            value={store.snapAngle}
+            onChange={(e) => {
+              const val = Number((e.target as HTMLInputElement).value);
+              if (!Number.isNaN(val) && val >= 0 && val <= 360) {
+                store.setSnapAngle(val);
+              }
+            }}
+            style={{ width: 50 }}
+            min={0}
+            max={360}
+            maxLength={3}
+          />
+        </div>
+      )}
       </div>
+      <label
+        className="small"
+        style={{ display: 'flex', gap: 8, alignItems: 'center' }}
+      >
+        <input
+          type="checkbox"
+          checked={store.snapToGrid}
+          onChange={(e) =>
+            store.setSnapToGrid((e.target as HTMLInputElement).checked)
+          }
+        />
+        {t('room.snapToGrid')}
+      </label>
+      {store.snapToGrid && (
+        <div>
+          <div className="small">{t('room.gridSize')}</div>
+          <input
+            className="input"
+            type="number"
+            value={store.gridSize}
+            onChange={(e) => {
+              const val = Number((e.target as HTMLInputElement).value);
+              if (!Number.isNaN(val) && val > 0) {
+                store.setGridSize(val);
+              }
+            }}
+            style={{ width: 60 }}
+            min={1}
+          />
+        </div>
+      )}
       <div>
         <div className="small">{t('room.wallType')}</div>
         <select


### PR DESCRIPTION
## Summary
- add `gridSize` and `snapToGrid` options to planner state
- allow configuring grid snapping in WallDrawPanel UI
- render configurable grid and snap wall points in WallDrawer
- test that walls snap to grid points when grid enabled

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68beaa6248c08322afb225a6dec3977d