### PR TITLE
Add wall area and perimeter calculation

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -58,6 +58,8 @@
     "snapAngle": "Angle step (°) for right-angle mode",
     "noRightAngles": "No right angles",
     "autoClose": "Auto close",
+    "area": "Area (mm²)",
+    "perimeter": "Perimeter (mm)",
     "invalidLength": "Length must be non-negative"
   },
   "global": {

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -58,6 +58,8 @@
     "snapAngle": "Krok kąta (°) w trybie kątów prostych",
     "noRightAngles": "Bez prostych kątów",
     "autoClose": "Automatyczne domknięcie",
+    "area": "Powierzchnia (mm²)",
+    "perimeter": "Obwód (mm)",
     "invalidLength": "Długość nie może być ujemna"
   },
   "global": {

--- a/src/ui/WallDrawPanel.tsx
+++ b/src/ui/WallDrawPanel.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { FaPencilAlt } from 'react-icons/fa';
 import { usePlannerStore } from '../state/store';
+import { getAreaAndPerimeter, getWallSegments } from '../utils/walls';
 
 const ranges = {
   nosna: { min: 150, max: 250 },
@@ -26,6 +27,10 @@ export default function WallDrawPanel({
   const [wallAngle, setWallAngle] = React.useState(0);
   const [lengthError, setLengthError] = React.useState(false);
   const [mode, setMode] = React.useState<'draw' | 'edit' | 'move'>('draw');
+  const { area, perimeter } = React.useMemo(() => {
+    const segs = getWallSegments(undefined, undefined, true);
+    return getAreaAndPerimeter(segs);
+  }, [store.room.walls]);
   React.useEffect(() => {
     threeRef.current.onLengthChange = setWallLength;
     threeRef.current.onAngleChange = setWallAngle;
@@ -301,6 +306,14 @@ export default function WallDrawPanel({
         />
         {t('room.autoClose')}
       </label>
+      <div>
+        <div className="small">{t('room.area')}</div>
+        <div>{Math.round(area)} mm²</div>
+      </div>
+      <div>
+        <div className="small">{t('room.perimeter')}</div>
+        <div>{Math.round(perimeter)} mm</div>
+      </div>
     </div>
   );
 }

--- a/src/utils/walls.ts
+++ b/src/utils/walls.ts
@@ -63,3 +63,13 @@ export function projectPointToSegment(px:number, py:number, seg:Segment){
   const dist=Math.hypot(dx,dy)
   return { x,y,t,dist }
 }
+
+export function getAreaAndPerimeter(segments: Segment[]) {
+  let area = 0
+  let perimeter = 0
+  for (const s of segments) {
+    area += s.a.x * s.b.y - s.b.x * s.a.y
+    perimeter += s.length
+  }
+  return { area: Math.abs(area) / 2, perimeter }
+}

--- a/tests/walls.test.ts
+++ b/tests/walls.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, beforeEach, expect } from 'vitest';
-import { getWallSegments } from '../src/utils/walls';
+import { getWallSegments, getAreaAndPerimeter, Segment } from '../src/utils/walls';
 import { usePlannerStore } from '../src/state/store';
 import WallDrawer from '../src/viewer/WallDrawer';
 import * as THREE from 'three';
@@ -105,6 +105,20 @@ describe('getWallSegments', () => {
     expect(segs[0].arc?.radius).toBe(1000);
     expect(segs[0].b.x).toBeCloseTo(1000, 3);
     expect(segs[0].b.y).toBeCloseTo(1000, 3);
+  });
+});
+
+describe('getAreaAndPerimeter', () => {
+  it('computes area and perimeter for square', () => {
+    const segs: Segment[] = [
+      { a: { x: 0, y: 0 }, b: { x: 10, y: 0 }, angle: 0, length: 10 },
+      { a: { x: 10, y: 0 }, b: { x: 10, y: 10 }, angle: Math.PI / 2, length: 10 },
+      { a: { x: 10, y: 10 }, b: { x: 0, y: 10 }, angle: Math.PI, length: 10 },
+      { a: { x: 0, y: 10 }, b: { x: 0, y: 0 }, angle: -Math.PI / 2, length: 10 },
+    ];
+    const { area, perimeter } = getAreaAndPerimeter(segs);
+    expect(area).toBeCloseTo(100, 3);
+    expect(perimeter).toBeCloseTo(40, 3);
   });
 });
 


### PR DESCRIPTION
## Summary
- add utility to compute polygon area and perimeter from wall segments
- show calculated area and perimeter in wall drawing panel
- test area and perimeter computation for closed polygons

## Testing
- `npm test -- tests/walls.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bead1b23f883228233f80612d06485