### PR TITLE
Restrict wall drawing to left-click only and streamline controls

### DIFF
--- a/tests/walls.test.ts
+++ b/tests/walls.test.ts
@@ -167,14 +167,21 @@ describe('WallDrawer auto close', () => {
       wd['preview'] = null;
     };
     const positions = { setXYZ: () => {}, needsUpdate: false } as any;
-    wd['preview'] = {
+    const makePreview = () => ({
       geometry: { attributes: { position: positions } },
       material: {},
-    } as any;
+    });
+    wd['preview'] = makePreview();
     wd['start'] = new THREE.Vector3(0, 0, 0);
     wd.finalizeSegment(new THREE.Vector3(1, 0, 0));
+    wd['preview'] = makePreview();
+    wd['start'] = new THREE.Vector3(1, 0, 0);
     wd.finalizeSegment(new THREE.Vector3(1, 0, 1));
+    wd['preview'] = makePreview();
+    wd['start'] = new THREE.Vector3(1, 0, 1);
     wd.finalizeSegment(new THREE.Vector3(0, 0, 1));
+    wd['preview'] = makePreview();
+    wd['start'] = new THREE.Vector3(0, 0, 1);
     wd.finalizeSegment(new THREE.Vector3(0.05, 0, 0.02));
     const segs = getWallSegments();
     expect(segs.length).toBe(4);


### PR DESCRIPTION
## Summary
- Ignore non-left clicks in wall drawing and drop double-click cancelation
- Remove right-button pointer-up listener and simplify keyboard handling
- Adjust tests for left-click behavior and drop Escape shortcut

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bec8b9353883228e31d1e7abc0d03d