### PR TITLE
refactor: inject room into getWallSegments

### DIFF
--- a/src/ui/TopBar.tsx
+++ b/src/ui/TopBar.tsx
@@ -60,7 +60,7 @@ export default function TopBar({ t, store, setVariant, setKind, selWall, setSelW
         value={selWall}
         onChange={e => setSelWall((e.target as HTMLSelectElement).value)}
       >
-        {getWallSegments().map((s, i) => (
+        {getWallSegments(store.room).map((s, i) => (
           <option key={store.room.walls[i]?.id} value={store.room.walls[i]?.id}>
             {t('app.wallLabel', { num: i + 1, len: Math.round(s.length) })}
           </option>

--- a/src/ui/WallDrawPanel.tsx
+++ b/src/ui/WallDrawPanel.tsx
@@ -28,7 +28,7 @@ export default function WallDrawPanel({
   const [lengthError, setLengthError] = React.useState(false);
   const [mode, setMode] = React.useState<'draw' | 'edit' | 'move' | 'opening'>('draw');
   const { area, perimeter } = React.useMemo(() => {
-    const segs = getWallSegments(undefined, undefined, true);
+    const segs = getWallSegments(store.room, undefined, undefined, true);
     return getAreaAndPerimeter(segs);
   }, [store.room.walls]);
   React.useEffect(() => {

--- a/src/ui/useCabinetConfig.ts
+++ b/src/ui/useCabinetConfig.ts
@@ -62,7 +62,7 @@ export function useCabinetConfig(
     mSize: { w: number; h: number; d: number },
     fam: FAMILY,
   ) => {
-    const segs = getWallSegments();
+    const segs = getWallSegments(store.room);
     if (segs.length === 0)
       return {
         pos: [
@@ -111,7 +111,7 @@ export function useCabinetConfig(
     const tryMod: Module3D = { ...mod };
     let loops = 0;
     const step = 0.02;
-    const segs = getWallSegments();
+    const segs = getWallSegments(store.room);
     const seg = typeof mod.segIndex === 'number' ? segs[mod.segIndex] : null;
     const tangent = seg
       ? {
@@ -238,7 +238,7 @@ export function useCabinetConfig(
   };
 
   const doAutoOnSelectedWall = () => {
-    const segs = getWallSegments();
+    const segs = getWallSegments(store.room);
     if (segs.length === 0) return alert(t('room.noWalls'));
     const wallIndex = store.room.walls.findIndex(w => w.id === selWall);
     const seg = segs[0 + ((wallIndex >= 0 ? wallIndex : 0) % segs.length)];

--- a/src/utils/walls.ts
+++ b/src/utils/walls.ts
@@ -1,4 +1,4 @@
-import { usePlannerStore } from '../state/store'
+import type { Room } from '../types'
 export type Segment = {
   a:{x:number;y:number};
   b:{x:number;y:number};
@@ -6,8 +6,12 @@ export type Segment = {
   length:number;
   arc?:{ cx:number; cy:number; radius:number; startAngle:number; sweep:number };
 }
-export function getWallSegments(startX?: number, startY?: number, close = false): Segment[] {
-  const room = usePlannerStore.getState().room
+export function getWallSegments(
+  room: Room,
+  startX?: number,
+  startY?: number,
+  close = false,
+): Segment[] {
   const segs: Segment[] = []
   const origin = room.origin || { x:0, y:0 }
   let cursor = { x:startX ?? origin.x, y:startY ?? origin.y }

--- a/src/viewer/WallDrawer.ts
+++ b/src/viewer/WallDrawer.ts
@@ -431,11 +431,7 @@ export default class WallDrawer {
   }
 
   private getSegments() {
-    const orig = usePlannerStore.getState;
-    (usePlannerStore as any).getState = this.store.getState.bind(this.store);
-    const segs = getWallSegments();
-    (usePlannerStore as any).getState = orig;
-    return segs;
+    return getWallSegments(this.store.getState().room);
   }
 
   private findClosestVertex(point: THREE.Vector3): THREE.Vector3 | null {

--- a/tests/walls.test.ts
+++ b/tests/walls.test.ts
@@ -25,7 +25,7 @@ describe('getWallSegments', () => {
         origin: { x: 1000, y: 2000 },
       },
     });
-    const segs = getWallSegments();
+    const segs = getWallSegments(usePlannerStore.getState().room);
     expect(segs[0].a.x).toBe(1000);
     expect(segs[0].a.y).toBe(2000);
   });
@@ -39,7 +39,7 @@ describe('getWallSegments', () => {
         origin: { x: 0, y: 0 },
       },
     });
-    const segs = getWallSegments(50, 60);
+    const segs = getWallSegments(usePlannerStore.getState().room, 50, 60);
     expect(segs[0].a.x).toBe(50);
     expect(segs[0].a.y).toBe(60);
   });
@@ -57,7 +57,7 @@ describe('getWallSegments', () => {
         origin: { x: 0, y: 0 },
       },
     });
-    const segs = getWallSegments(undefined, undefined, true);
+    const segs = getWallSegments(usePlannerStore.getState().room, undefined, undefined, true);
     expect(segs.length).toBe(4);
     const last = segs[3];
     expect(last.b.x).toBeCloseTo(segs[0].a.x, 3);
@@ -77,7 +77,7 @@ describe('getWallSegments', () => {
         origin: { x: 0, y: 0 },
       },
     });
-    const segs = getWallSegments(undefined, undefined, true);
+    const segs = getWallSegments(usePlannerStore.getState().room, undefined, undefined, true);
     expect(segs.length).toBe(3);
     const last = segs[2];
     expect(last.b.x).toBeCloseTo(segs[0].a.x, 3);
@@ -101,7 +101,7 @@ describe('getWallSegments', () => {
         origin: { x: 0, y: 0 },
       },
     });
-    const segs = getWallSegments();
+    const segs = getWallSegments(usePlannerStore.getState().room);
     expect(segs[0].arc?.radius).toBe(1000);
     expect(segs[0].b.x).toBeCloseTo(1000, 3);
     expect(segs[0].b.y).toBeCloseTo(1000, 3);
@@ -183,7 +183,7 @@ describe('WallDrawer auto close', () => {
     wd['preview'] = makePreview();
     wd['start'] = new THREE.Vector3(0, 0, 1);
     wd.finalizeSegment(new THREE.Vector3(0.05, 0, 0.02));
-    const segs = getWallSegments();
+    const segs = getWallSegments(usePlannerStore.getState().room);
     expect(segs.length).toBe(4);
     const last = segs[3];
     expect(last.b.x).toBeCloseTo(segs[0].a.x, 3);


### PR DESCRIPTION
## Summary
- inject Room parameter into getWallSegments and remove usePlannerStore coupling
- simplify WallDrawer segment lookup using provided room
- update UI components and tests to use new getWallSegments API

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bee4baeaac8322b92dd6dc4e6316aa