### PR TITLE
Throttle camera updates via OrbitControls change event

### DIFF
--- a/src/scene/engine.ts
+++ b/src/scene/engine.ts
@@ -67,6 +67,7 @@ export function setupThree(
     usePlannerStore,
     callbacks?.onLengthChange,
     callbacks?.onAngleChange,
+    controls,
   );
   const cabinetDragger = new CabinetDragger(
     renderer,


### PR DESCRIPTION
## Summary
- Throttle label updates with requestAnimationFrame to reduce camera change workload
- Listen to OrbitControls `change` event instead of `pointermove`
- Clean up `OrbitControls` listener on disable

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bee5b398908322a3ee42925877a9aa