### PR TITLE
Expose defaultSquareAngle in planner store interface

### DIFF
--- a/src/viewer/WallDrawer.ts
+++ b/src/viewer/WallDrawer.ts
@@ -37,6 +37,7 @@ interface PlannerStore {
   snapLength: number;
   snapRightAngles: boolean;
   angleToPrev: number;
+  defaultSquareAngle: number;
   room: Room;
   setRoom: (patch: Partial<Room>) => void;
   autoCloseWalls: boolean;


### PR DESCRIPTION
## Summary
- add `defaultSquareAngle` to `PlannerStore` interface in `WallDrawer`
- confirm `usePlannerStore` continues to export `defaultSquareAngle` and `setDefaultSquareAngle`

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68beeeeeeca08322a9f5abf3aad29bf3