### PR TITLE
Handle pointerup events in wall drawer

### DIFF
--- a/src/viewer/WallDrawer.ts
+++ b/src/viewer/WallDrawer.ts
@@ -206,6 +206,7 @@ export default class WallDrawer {
     const dom = this.renderer.domElement;
     dom.addEventListener('pointerdown', this.onDown);
     dom.addEventListener('pointermove', this.onMove);
+    dom.addEventListener('pointerup', this.onUp);
     if (this.controls) {
       this.controls.addEventListener('change', this.onCameraChange);
     } else {
@@ -276,6 +277,7 @@ export default class WallDrawer {
     const dom = this.renderer.domElement;
     dom.removeEventListener('pointerdown', this.onDown);
     dom.removeEventListener('pointermove', this.onMove);
+    dom.removeEventListener('pointerup', this.onUp);
     if (this.controls) {
       this.controls.removeEventListener('change', this.onCameraChange);
     } else {


### PR DESCRIPTION
## Summary
- attach `pointerup` listener in `WallDrawer.enable` so releasing the mouse finalizes or cancels a segment
- remove `pointerup` listener in `WallDrawer.disable` to clean up properly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68befdde574483228f199342858283e8