### PR TITLE
Capture pointer during drag

### DIFF
--- a/src/viewer/CabinetDragger.ts
+++ b/src/viewer/CabinetDragger.ts
@@ -58,6 +58,7 @@ export default class CabinetDragger {
   }
 
   private onDown = (e: PointerEvent) => {
+    this.renderer.domElement.setPointerCapture(e.pointerId);
     const rect = this.renderer.domElement.getBoundingClientRect();
     const x = ((e.clientX - rect.left) / rect.width) * 2 - 1;
     const y = -((e.clientY - rect.top) / rect.height) * 2 + 1;
@@ -96,7 +97,8 @@ export default class CabinetDragger {
     });
   };
 
-  private onUp = () => {
+  private onUp = (e: PointerEvent) => {
+    this.renderer.domElement.releasePointerCapture(e.pointerId);
     this.draggingId = null;
   };
 }

--- a/src/viewer/WallDrawer.ts
+++ b/src/viewer/WallDrawer.ts
@@ -701,6 +701,7 @@ export default class WallDrawer {
   };
 
   private onDown = (e: PointerEvent) => {
+    this.renderer.domElement.setPointerCapture(e.pointerId);
     if (e.button !== 0) return;
     if (this.start) return;
     const point = this.getPoint(e);
@@ -1355,6 +1356,7 @@ export default class WallDrawer {
   }
 
   private onUp = (e: PointerEvent) => {
+    this.renderer.domElement.releasePointerCapture(e.pointerId);
     if (e.button !== 0) return;
     try {
       if (this.mode === 'opening') {

--- a/tests/cabinetDragger.pointerCapture.test.ts
+++ b/tests/cabinetDragger.pointerCapture.test.ts
@@ -1,0 +1,68 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import * as THREE from 'three';
+import CabinetDragger from '../src/viewer/CabinetDragger';
+import type { Module3D } from '../src/types';
+
+describe('CabinetDragger pointer capture', () => {
+  it('releases capture and resets state when pointerup occurs outside canvas', () => {
+    const canvas = document.createElement('canvas');
+    canvas.getBoundingClientRect = () => ({
+      left: 0,
+      top: 0,
+      width: 100,
+      height: 100,
+      right: 100,
+      bottom: 100,
+      x: 0,
+      y: 0,
+      toJSON() {},
+    });
+    canvas.setPointerCapture = vi.fn();
+    canvas.releasePointerCapture = vi.fn();
+
+    const renderer = { domElement: canvas } as unknown as THREE.WebGLRenderer;
+    const camera = new THREE.PerspectiveCamera();
+    const getCamera = () => camera;
+
+    const group = new THREE.Group();
+    const obj = new THREE.Object3D();
+    obj.userData.kind = 'cab';
+    group.add(obj);
+
+    const module = { id: '1', position: [0, 0, 0] } as Module3D;
+    const store = {
+      getState: () => ({
+        modules: [module],
+        updateModule: vi.fn(),
+      }),
+    } as any;
+
+    const dragger = new CabinetDragger(renderer, getCamera, group, store);
+
+    // Pretend the raycaster hits our object
+    (dragger as any).raycaster.intersectObjects = () => [{ object: obj }];
+    (dragger as any).getPoint = () => new THREE.Vector3(0, 0, 0);
+
+    const down = {
+      clientX: 0,
+      clientY: 0,
+      pointerId: 1,
+      button: 0,
+    } as PointerEvent;
+    (dragger as any).onDown(down);
+    expect(canvas.setPointerCapture).toHaveBeenCalledWith(1);
+    expect((dragger as any).draggingId).toBe('1');
+
+    const up = {
+      clientX: 200,
+      clientY: 200,
+      pointerId: 1,
+      button: 0,
+    } as PointerEvent;
+    (dragger as any).onUp(up);
+    expect(canvas.releasePointerCapture).toHaveBeenCalledWith(1);
+    expect((dragger as any).draggingId).toBeNull();
+  });
+});
+

--- a/tests/wallDrawer.e2e.test.ts
+++ b/tests/wallDrawer.e2e.test.ts
@@ -12,6 +12,8 @@ import { usePlannerStore } from '../src/state/store';
   strokeRect() {},
 });
 (HTMLCanvasElement.prototype as any).toDataURL = () => '';
+(HTMLCanvasElement.prototype as any).setPointerCapture = () => {};
+(HTMLCanvasElement.prototype as any).releasePointerCapture = () => {};
 
 describe('WallDrawer ignores non-left clicks', () => {
   it('does not start drawing on right or middle click', () => {

--- a/tests/wallDrawer.pointerCapture.test.ts
+++ b/tests/wallDrawer.pointerCapture.test.ts
@@ -1,0 +1,80 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import * as THREE from 'three';
+import WallDrawer from '../src/viewer/WallDrawer';
+
+describe('WallDrawer pointer capture', () => {
+  it('resets when pointerup happens outside the canvas', () => {
+    const canvas = document.createElement('canvas');
+    canvas.getBoundingClientRect = () => ({
+      left: 0,
+      top: 0,
+      width: 100,
+      height: 100,
+      right: 100,
+      bottom: 100,
+      x: 0,
+      y: 0,
+      toJSON() {},
+    });
+    canvas.setPointerCapture = vi.fn();
+    canvas.releasePointerCapture = vi.fn();
+
+    const renderer = { domElement: canvas } as unknown as THREE.WebGLRenderer;
+    const camera = new THREE.PerspectiveCamera();
+    const getCamera = () => camera;
+    const scene = new THREE.Scene();
+
+    const store = {
+      getState: () => ({
+        addWall: vi.fn(),
+        wallThickness: 100,
+        wallType: 'dzialowa',
+        snapAngle: 0,
+        snapLength: 0,
+        snapRightAngles: true,
+        angleToPrev: 0,
+        defaultSquareAngle: 0,
+        room: { walls: [] },
+        setRoom: vi.fn(),
+      }),
+    } as any;
+
+    const drawer = new WallDrawer(
+      renderer,
+      getCamera,
+      scene,
+      store,
+      () => {},
+      () => {},
+    );
+    (drawer as any).active = true;
+    (drawer as any).getPoint = vi.fn(() => new THREE.Vector3(0, 0, 0));
+    const down = {
+      clientX: 0,
+      clientY: 0,
+      pointerId: 1,
+      button: 0,
+    } as PointerEvent;
+    (drawer as any).onDown(down);
+    expect(canvas.setPointerCapture).toHaveBeenCalledWith(1);
+    expect((drawer as any).start).not.toBeNull();
+
+    // Simulate moving outside so getPoint returns null on up
+    (drawer as any).getPoint = vi.fn(() => null);
+    const disableSpy = vi.spyOn(drawer as any, 'disable');
+
+    const up = {
+      clientX: 200,
+      clientY: 200,
+      pointerId: 1,
+      button: 0,
+    } as PointerEvent;
+    (drawer as any).onUp(up);
+
+    expect(canvas.releasePointerCapture).toHaveBeenCalledWith(1);
+    expect(disableSpy).toHaveBeenCalled();
+    expect((drawer as any).start).toBeNull();
+  });
+});
+


### PR DESCRIPTION
## Summary
- Capture pointer on drag start and release on pointerup for cabinets and walls
- Add tests ensuring pointer capture releases and state resets when releasing outside canvas

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bf009dc0a483229b451df74f85dddf