### PR TITLE
Fix wall drawing start point moving with cursor

### DIFF
--- a/src/viewer/WallDrawer.ts
+++ b/src/viewer/WallDrawer.ts
@@ -712,13 +712,13 @@ export default class WallDrawer {
     if (this.mode === 'draw') {
       if (this.arcMode) {
         if (!this.arcCenter) {
-          this.arcCenter = point;
+          this.arcCenter = point.clone();
           return;
         }
         this.finalizeArc(point);
         return;
       }
-      this.start = point;
+      this.start = point.clone();
       this.currentThickness = this.store.getState().wallThickness / 1000;
     } else if (this.mode === 'edit') {
       const segs = this.getSegments();

--- a/tests/wallDrawer.e2e.test.ts
+++ b/tests/wallDrawer.e2e.test.ts
@@ -273,6 +273,63 @@ describe('WallDrawer small movement treated as click', () => {
   });
 });
 
+describe('WallDrawer keeps first point fixed', () => {
+  it('does not move initial point when dragging', () => {
+    const canvas = document.createElement('canvas');
+    canvas.getBoundingClientRect = () => ({
+      left: 0,
+      top: 0,
+      width: 100,
+      height: 100,
+      right: 100,
+      bottom: 100,
+      x: 0,
+      y: 0,
+      toJSON() {},
+    });
+    const renderer = { domElement: canvas } as unknown as THREE.WebGLRenderer;
+    const camera = new THREE.PerspectiveCamera();
+    const getCamera = () => camera;
+    const scene = new THREE.Scene();
+    const store: any = {
+      getState: () => ({
+        addWall: vi.fn(),
+        wallThickness: 100,
+        wallType: 'dzialowa',
+        snapAngle: 0,
+        snapLength: 0,
+        snapRightAngles: true,
+        angleToPrev: 0,
+        defaultSquareAngle: 0,
+        room: { walls: [] },
+        setRoom: vi.fn(),
+      }),
+    };
+
+    const drawer = new WallDrawer(
+      renderer,
+      getCamera,
+      scene,
+      store,
+      () => {},
+      () => {},
+    );
+
+    const p = new THREE.Vector3(0, 0, 0);
+    (drawer as any).getPoint = () => p;
+    (drawer as any).onDown({ button: 0 } as PointerEvent);
+
+    (drawer as any).getPoint = () => {
+      p.set(1, 0, 0);
+      return p;
+    };
+    (drawer as any).onMove({ clientX: 10, clientY: 0 } as PointerEvent);
+
+    expect((drawer as any).start.x).toBeCloseTo(0, 3);
+    expect((drawer as any).start.z).toBeCloseTo(0, 3);
+  });
+});
+
 describe('WallDrawer segment selection', () => {
   it('finds correct segment for a given point', () => {
     const canvas = document.createElement('canvas');


### PR DESCRIPTION
## Summary
- Ensure wall drawing uses a cloned start point so the first click stays fixed
- Add regression test to verify the starting point doesn't move when dragging

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf03d2238c83229d040f2ff4c063a0