### PR TITLE
Include arc sector in area computation

### DIFF
--- a/src/utils/walls.ts
+++ b/src/utils/walls.ts
@@ -73,6 +73,9 @@ export function getAreaAndPerimeter(segments: Segment[]) {
   let perimeter = 0
   for (const s of segments) {
     area += s.a.x * s.b.y - s.b.x * s.a.y
+    if (s.arc) {
+      area += s.arc.radius * s.arc.radius * s.arc.sweep
+    }
     perimeter += s.length
   }
   return { area: Math.abs(area) / 2, perimeter }

--- a/tests/walls.test.ts
+++ b/tests/walls.test.ts
@@ -120,6 +120,22 @@ describe('getAreaAndPerimeter', () => {
     expect(area).toBeCloseTo(100, 3);
     expect(perimeter).toBeCloseTo(40, 3);
   });
+
+  it('computes area for room with curved wall', () => {
+    const room = {
+      walls: [
+        { id: 'a', angle: 90, thickness: 100, arc: { radius: 1, angle: -180 } },
+        { id: 'b', angle: 180, thickness: 100, length: 2 },
+      ],
+      openings: [],
+      height: 2700,
+      origin: { x: -1, y: 0 },
+    } as any;
+    const segs = getWallSegments(room);
+    const { area, perimeter } = getAreaAndPerimeter(segs);
+    expect(area).toBeCloseTo(Math.PI / 2, 3);
+    expect(perimeter).toBeCloseTo(Math.PI + 2, 3);
+  });
 });
 
 describe('updateWall', () => {


### PR DESCRIPTION
## Summary
- account for arc sectors when calculating room area
- test area and perimeter with a semicircular wall

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bf101b094483228d47a829c9b241c9