### PR TITLE
feat: support arc updates for walls

### DIFF
--- a/tests/walls.test.ts
+++ b/tests/walls.test.ts
@@ -193,6 +193,58 @@ describe('updateWall', () => {
     expect(wall.thickness).toBe(max);
     expect(wall.angle).toBe(90);
   });
+
+  it('updates arc radius and angle', () => {
+    usePlannerStore.setState({
+      room: {
+        walls: [
+          {
+            id: 'a',
+            length: Math.PI * 1000 * 0.5,
+            angle: 0,
+            thickness: 100,
+            arc: { radius: 1000, angle: 90 },
+          },
+        ],
+        openings: [],
+        height: 2700,
+        origin: { x: 0, y: 0 },
+      },
+    });
+    const store = usePlannerStore.getState();
+    store.updateWall('a', { arc: { radius: 500 } });
+    let wall = usePlannerStore.getState().room.walls[0];
+    expect(wall.arc?.radius).toBe(500);
+    expect(wall.arc?.angle).toBe(90);
+    store.updateWall('a', { arc: { angle: 450 } });
+    wall = usePlannerStore.getState().room.walls[0];
+    expect(wall.arc?.angle).toBe(90);
+  });
+
+  it('rejects invalid arc parameters', () => {
+    usePlannerStore.setState({
+      room: {
+        walls: [
+          {
+            id: 'a',
+            length: Math.PI * 1000 * 0.5,
+            angle: 0,
+            thickness: 100,
+            arc: { radius: 1000, angle: 90 },
+          },
+        ],
+        openings: [],
+        height: 2700,
+        origin: { x: 0, y: 0 },
+      },
+    });
+    const store = usePlannerStore.getState();
+    expect(() => store.updateWall('a', { arc: { radius: -5 } })).toThrow();
+    expect(() => store.updateWall('a', { arc: { angle: 0 } })).toThrow();
+    const wall = usePlannerStore.getState().room.walls[0];
+    expect(wall.arc?.radius).toBe(1000);
+    expect(wall.arc?.angle).toBe(90);
+  });
 });
 
 describe('WallDrawer auto close', () => {


### PR DESCRIPTION
## Summary
- allow `updateWall` to patch and validate wall arcs
- ensure arc angles are normalized to `(-360°, 360°]`
- test updating wall arcs and invalid parameters

## Testing
- `npm test`
- `npm run lint` *(fails: 'snappedAngle' is never reassigned...)*

------
https://chatgpt.com/codex/tasks/task_e_68bf15d48360832287ab5edc5a13c675