### PR TITLE
Prevent overlapping wall openings

### DIFF
--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -488,6 +488,16 @@ export const usePlannerStore = create<Store>((set, get) => ({
     ) {
       throw new Error('Invalid opening dimensions');
     }
+    if (
+      room.openings.some(
+        (o) =>
+          o.wallId === op.wallId &&
+          op.offset < o.offset + o.width &&
+          o.offset < op.offset + op.width,
+      )
+    ) {
+      throw new Error('Opening overlaps with existing opening');
+    }
     set((s) => ({
       past: [
         ...s.past,
@@ -520,6 +530,17 @@ export const usePlannerStore = create<Store>((set, get) => ({
       bottom + height > room.height
     ) {
       throw new Error('Invalid opening dimensions');
+    }
+    if (
+      room.openings.some(
+        (o) =>
+          o.wallId === wallId &&
+          o.id !== id &&
+          offset < o.offset + o.width &&
+          o.offset < offset + width,
+      )
+    ) {
+      throw new Error('Opening overlaps with existing opening');
     }
     set((s) => ({
       past: [

--- a/tests/openings.e2e.test.ts
+++ b/tests/openings.e2e.test.ts
@@ -141,4 +141,50 @@ describe('openings', () => {
     expect(() => updateOpening(id, { offset: -5 })).toThrow();
     expect(usePlannerStore.getState().room.openings[0].offset).toBe(100);
   });
+
+  it('rejects overlapping opening on add', () => {
+    const { addOpening } = usePlannerStore.getState();
+    addOpening({
+      wallId: 'w1',
+      offset: 100,
+      width: 50,
+      height: 50,
+      bottom: 0,
+      kind: 0,
+    });
+    expect(() =>
+      addOpening({
+        wallId: 'w1',
+        offset: 120,
+        width: 50,
+        height: 50,
+        bottom: 0,
+        kind: 0,
+      }),
+    ).toThrow();
+    expect(usePlannerStore.getState().room.openings).toHaveLength(1);
+  });
+
+  it('rejects overlapping opening on update', () => {
+    const { addOpening, updateOpening } = usePlannerStore.getState();
+    addOpening({
+      wallId: 'w1',
+      offset: 100,
+      width: 50,
+      height: 50,
+      bottom: 0,
+      kind: 0,
+    });
+    addOpening({
+      wallId: 'w1',
+      offset: 200,
+      width: 50,
+      height: 50,
+      bottom: 0,
+      kind: 0,
+    });
+    const id = usePlannerStore.getState().room.openings[0].id;
+    expect(() => updateOpening(id, { offset: 180 })).toThrow();
+    expect(usePlannerStore.getState().room.openings[0].offset).toBe(100);
+  });
 });


### PR DESCRIPTION
## Summary
- validate openings do not overlap when adding or updating
- cover overlapping add and update scenarios with new tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bf180e5514832280c90527234bfbff