### PR TITLE
feat: support arc projection for wall segments

### DIFF
--- a/src/utils/walls.ts
+++ b/src/utils/walls.ts
@@ -56,6 +56,27 @@ export function getWallSegments(
   return segs
 }
 export function projectPointToSegment(px:number, py:number, seg:Segment){
+  if (seg.arc) {
+    const { cx, cy, radius, startAngle, sweep } = seg.arc
+    const dx = px - cx
+    const dy = py - cy
+    const start = startAngle
+    const end = startAngle + sweep
+    let ang = Math.atan2(dy, dx)
+    const norm = (a: number) => Math.atan2(Math.sin(a), Math.cos(a))
+    if (sweep >= 0) {
+      if (norm(ang - start) < 0) ang = start
+      else if (norm(ang - end) > 0) ang = end
+    } else {
+      if (norm(ang - start) > 0) ang = start
+      else if (norm(ang - end) < 0) ang = end
+    }
+    const x = cx + Math.cos(ang) * radius
+    const y = cy + Math.sin(ang) * radius
+    const t = sweep ? (ang - start) / sweep : 0
+    const dist = Math.hypot(px - x, py - y)
+    return { x, y, t, dist }
+  }
   const ax=seg.a.x, ay=seg.a.y, bx=seg.b.x, by=seg.b.y
   const abx=bx-ax, aby=by-ay
   const apx=px-ax, apy=py-ay

--- a/tests/walls.test.ts
+++ b/tests/walls.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, beforeEach, expect } from 'vitest';
-import { getWallSegments, getAreaAndPerimeter, Segment } from '../src/utils/walls';
+import {
+  getWallSegments,
+  getAreaAndPerimeter,
+  Segment,
+  projectPointToSegment,
+} from '../src/utils/walls';
 import { usePlannerStore, wallRanges } from '../src/state/store';
 import WallDrawer from '../src/viewer/WallDrawer';
 import * as THREE from 'three';
@@ -135,6 +140,33 @@ describe('getAreaAndPerimeter', () => {
     const { area, perimeter } = getAreaAndPerimeter(segs);
     expect(area).toBeCloseTo(Math.PI / 2, 3);
     expect(perimeter).toBeCloseTo(Math.PI + 2, 3);
+  });
+});
+
+describe('projectPointToSegment', () => {
+  const seg: Segment = {
+    a: { x: 1, y: 0 },
+    b: { x: 0, y: 1 },
+    angle: 0,
+    length: Math.PI / 2,
+    arc: { cx: 0, cy: 0, radius: 1, startAngle: 0, sweep: Math.PI / 2 },
+  };
+
+  it('projects point near middle of arc', () => {
+    const res = projectPointToSegment(0.7, 0.7, seg);
+    expect(res.x).toBeCloseTo(Math.SQRT1_2, 3);
+    expect(res.y).toBeCloseTo(Math.SQRT1_2, 3);
+    expect(res.t).toBeCloseTo(0.5, 3);
+    const expected = Math.hypot(0.7 - Math.SQRT1_2, 0.7 - Math.SQRT1_2);
+    expect(res.dist).toBeCloseTo(expected, 3);
+  });
+
+  it('clamps point outside arc sweep', () => {
+    const res = projectPointToSegment(1.2, 0, seg);
+    expect(res.x).toBeCloseTo(1, 3);
+    expect(res.y).toBeCloseTo(0, 3);
+    expect(res.t).toBeCloseTo(0, 3);
+    expect(res.dist).toBeCloseTo(0.2, 3);
   });
 });
 


### PR DESCRIPTION
## Summary
- compute closest point and offset on curved wall segments
- render openings and labels at correct positions on arcs
- test arc projection accuracy

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bf1a7348888322b959b6f65a940acd