### PR TITLE
Ensure wall removal clears related openings

### DIFF
--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -412,6 +412,7 @@ export const usePlannerStore = create<Store>((set, get) => ({
       room: {
         ...s.room,
         walls: s.room.walls.filter((w) => w.id !== id),
+        openings: s.room.openings.filter((o) => o.wallId !== id),
       },
       future: [],
     })),

--- a/tests/openings.e2e.test.ts
+++ b/tests/openings.e2e.test.ts
@@ -52,6 +52,41 @@ describe('openings', () => {
     expect(usePlannerStore.getState().room.openings).toHaveLength(0);
   });
 
+  it('removes openings of deleted wall', () => {
+    usePlannerStore.setState({
+      room: {
+        walls: [
+          { id: 'w1', length: 2000, angle: 0, thickness: 100 },
+          { id: 'w2', length: 2000, angle: 90, thickness: 100 },
+        ],
+        openings: [],
+        height: 2700,
+        origin: { x: 0, y: 0 },
+      },
+    });
+    const { addOpening, removeWall } = usePlannerStore.getState();
+    addOpening({
+      wallId: 'w1',
+      offset: 100,
+      width: 50,
+      height: 50,
+      bottom: 0,
+      kind: 0,
+    });
+    addOpening({
+      wallId: 'w2',
+      offset: 100,
+      width: 50,
+      height: 50,
+      bottom: 0,
+      kind: 0,
+    });
+    removeWall('w1');
+    const openings = usePlannerStore.getState().room.openings;
+    expect(openings).toHaveLength(1);
+    expect(openings[0].wallId).toBe('w2');
+  });
+
   it('creates geometry with hole for opening', () => {
     const wall = { id: 'w1', length: 2000, angle: 0, thickness: 100 };
     const opening = {


### PR DESCRIPTION
## Summary
- Remove wall-associated openings when deleting a wall
- Test that removing a wall deletes its openings

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bf1e17e1348322bf7aac9c63ea386f