### PR TITLE
Reject negative opening dimensions

### DIFF
--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -486,6 +486,9 @@ export const usePlannerStore = create<Store>((set, get) => ({
     if (
       !wall ||
       op.offset < 0 ||
+      op.width <= 0 ||
+      op.height <= 0 ||
+      op.bottom < 0 ||
       op.offset + op.width > wall.length ||
       op.bottom + op.height > room.height
     ) {
@@ -529,6 +532,9 @@ export const usePlannerStore = create<Store>((set, get) => ({
     if (
       !wall ||
       offset < 0 ||
+      width <= 0 ||
+      height <= 0 ||
+      bottom < 0 ||
       offset + width > wall.length ||
       bottom + height > room.height
     ) {

--- a/tests/openings.e2e.test.ts
+++ b/tests/openings.e2e.test.ts
@@ -162,6 +162,51 @@ describe('openings', () => {
     expect(usePlannerStore.getState().room.openings).toHaveLength(0);
   });
 
+  it('rejects opening with negative width', () => {
+    const { addOpening } = usePlannerStore.getState();
+    expect(() =>
+      addOpening({
+        wallId: 'w1',
+        offset: 100,
+        width: -50,
+        height: 50,
+        bottom: 0,
+        kind: 0,
+      }),
+    ).toThrow();
+    expect(usePlannerStore.getState().room.openings).toHaveLength(0);
+  });
+
+  it('rejects opening with negative height', () => {
+    const { addOpening } = usePlannerStore.getState();
+    expect(() =>
+      addOpening({
+        wallId: 'w1',
+        offset: 100,
+        width: 50,
+        height: -50,
+        bottom: 0,
+        kind: 0,
+      }),
+    ).toThrow();
+    expect(usePlannerStore.getState().room.openings).toHaveLength(0);
+  });
+
+  it('rejects opening with negative bottom', () => {
+    const { addOpening } = usePlannerStore.getState();
+    expect(() =>
+      addOpening({
+        wallId: 'w1',
+        offset: 100,
+        width: 50,
+        height: 50,
+        bottom: -10,
+        kind: 0,
+      }),
+    ).toThrow();
+    expect(usePlannerStore.getState().room.openings).toHaveLength(0);
+  });
+
   it('rejects update that violates constraints', () => {
     const { addOpening, updateOpening } = usePlannerStore.getState();
     addOpening({
@@ -175,6 +220,24 @@ describe('openings', () => {
     const id = usePlannerStore.getState().room.openings[0].id;
     expect(() => updateOpening(id, { offset: -5 })).toThrow();
     expect(usePlannerStore.getState().room.openings[0].offset).toBe(100);
+  });
+
+  it('rejects update with negative dimensions', () => {
+    const { addOpening, updateOpening } = usePlannerStore.getState();
+    addOpening({
+      wallId: 'w1',
+      offset: 100,
+      width: 50,
+      height: 50,
+      bottom: 0,
+      kind: 0,
+    });
+    const id = usePlannerStore.getState().room.openings[0].id;
+    const before = { ...usePlannerStore.getState().room.openings[0] };
+    expect(() => updateOpening(id, { width: -10 })).toThrow();
+    expect(() => updateOpening(id, { height: -10 })).toThrow();
+    expect(() => updateOpening(id, { bottom: -10 })).toThrow();
+    expect(usePlannerStore.getState().room.openings[0]).toEqual(before);
   });
 
   it('rejects overlapping opening on add', () => {


### PR DESCRIPTION
## Summary
- prevent adding or updating openings with non-positive width or height and negative bottom values
- add tests ensuring negative dimensions are rejected on add or update

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf20bd6e0c83229e90bf89e13e3265