### PR TITLE
Recalculate wall length on arc updates

### DIFF
--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import * as THREE from 'three';
 import { FAMILY } from '../core/catalog';
 import { Module3D, Room, Globals, Prices, Opening, Gaps, WallArc } from '../types';
 import { safeSetItem } from '../utils/storage';
@@ -459,6 +460,11 @@ export const usePlannerStore = create<Store>((set, get) => ({
       if (ang === 0) ang = 360;
       arc.angle = ang;
       validated.arc = arc;
+      if (patch.arc.radius !== undefined || patch.arc.angle !== undefined) {
+        validated.length = Math.abs(
+          arc.radius * THREE.MathUtils.degToRad(arc.angle),
+        );
+      }
     }
 
     if (Object.keys(validated).length === 0) return;

--- a/tests/walls.test.ts
+++ b/tests/walls.test.ts
@@ -240,6 +240,44 @@ describe('updateWall', () => {
     expect(wall.arc?.angle).toBe(90);
   });
 
+  it('recalculates length when arc radius changes', () => {
+    usePlannerStore.setState({
+      room: { walls: [], openings: [], height: 2700, origin: { x: 0, y: 0 } },
+    });
+    const store = usePlannerStore.getState();
+    const id = store.addWall({
+      length: Math.PI * 1000 * 0.5,
+      angle: 0,
+      thickness: 100,
+      arc: { radius: 1000, angle: 90 },
+    });
+    store.updateWall(id, { arc: { radius: 500 } });
+    const wall = usePlannerStore.getState().room.walls[0];
+    expect(wall.length).toBeCloseTo(
+      Math.abs(500 * THREE.MathUtils.degToRad(90)),
+      3,
+    );
+  });
+
+  it('recalculates length when arc angle changes', () => {
+    usePlannerStore.setState({
+      room: { walls: [], openings: [], height: 2700, origin: { x: 0, y: 0 } },
+    });
+    const store = usePlannerStore.getState();
+    const id = store.addWall({
+      length: Math.PI * 1000 * 0.5,
+      angle: 0,
+      thickness: 100,
+      arc: { radius: 1000, angle: 90 },
+    });
+    store.updateWall(id, { arc: { angle: 180 } });
+    const wall = usePlannerStore.getState().room.walls[0];
+    expect(wall.length).toBeCloseTo(
+      Math.abs(1000 * THREE.MathUtils.degToRad(180)),
+      3,
+    );
+  });
+
   it('rejects invalid arc parameters', () => {
     usePlannerStore.setState({
       room: { walls: [], openings: [], height: 2700, origin: { x: 0, y: 0 } },


### PR DESCRIPTION
## Summary
- recalc wall length when arc radius/angle changes using THREE.MathUtils
- add tests for length recomputation on radius and angle updates

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bf21dfb4c083229edadeb153958c53