### PR TITLE
Disable automatic wall chaining by default

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -56,7 +56,7 @@
     "angleToPrev": "Angle to previous (°)",
     "snapLength": "Length step (mm; hold Alt to disable snapping)",
     "snapAngle": "Angle step (°) for right-angle mode (hold Alt to disable snapping)",
-    "autoClose": "Auto close",
+    "autoChain": "Auto-chain walls",
     "area": "Area (mm²)",
     "perimeter": "Perimeter (mm)",
     "invalidLength": "Length must be non-negative"

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -56,7 +56,7 @@
     "angleToPrev": "Kąt do poprzedniej (°)",
     "snapLength": "Krok długości (mm; Alt tymczasowo wyłącza przyciąganie)",
     "snapAngle": "Krok kąta (°) w trybie kątów prostych (Alt: chwilowe wyłączenie)",
-    "autoClose": "Automatyczne domknięcie",
+    "autoChain": "Automatyczne łączenie",
     "area": "Powierzchnia (mm²)",
     "perimeter": "Obwód (mm)",
     "invalidLength": "Długość nie może być ujemna"

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -225,7 +225,7 @@ export const usePlannerStore = create<Store>((set, get) => ({
   snapRightAngles: true,
   angleToPrev: persisted?.angleToPrev ?? 0,
   defaultSquareAngle: persisted?.defaultSquareAngle ?? 0,
-  autoCloseWalls: persisted?.autoCloseWalls ?? true,
+  autoCloseWalls: persisted?.autoCloseWalls ?? false,
   gridSize: persisted?.gridSize ?? 50,
   snapToGrid: persisted?.snapToGrid ?? false,
   measurementUnit: persisted?.measurementUnit || 'mm',

--- a/src/ui/WallDrawPanel.tsx
+++ b/src/ui/WallDrawPanel.tsx
@@ -364,7 +364,7 @@ export default function WallDrawPanel({
             store.setAutoCloseWalls((e.target as HTMLInputElement).checked)
           }
         />
-        {t('room.autoClose')}
+        {t('room.autoChain')}
       </label>
       <div>
         <div className="small">{t('room.area')}</div>

--- a/src/viewer/WallDrawer.ts
+++ b/src/viewer/WallDrawer.ts
@@ -1419,6 +1419,9 @@ export default class WallDrawer {
     if (lengthMm < 1) {
       this.cleanupPreview();
       this.start = null;
+      this.dragStart = null;
+      this.dragStartClient = null;
+      this.isDragging = false;
       return;
     }
     let snappedLength = state.snapLength
@@ -1437,6 +1440,9 @@ export default class WallDrawer {
     this.currentThickness = thickness / 1000;
     this.cleanupPreview();
     this.start = null;
+    this.dragStart = null;
+    this.dragStartClient = null;
+    this.isDragging = false;
     this.currentAngle = 0;
     this.updateLabels();
     if (autoClose) {

--- a/tests/wallDrawer.pointerCapture.test.ts
+++ b/tests/wallDrawer.pointerCapture.test.ts
@@ -78,3 +78,87 @@ describe('WallDrawer pointer capture', () => {
   });
 });
 
+describe('WallDrawer wall chaining', () => {
+  it('requires new mouse-down after creating a wall', () => {
+    (HTMLCanvasElement.prototype as any).getContext = () => ({
+      beginPath() {},
+      moveTo() {},
+      lineTo() {},
+      stroke() {},
+      strokeRect() {},
+    });
+    (HTMLCanvasElement.prototype as any).toDataURL = () => '';
+
+    const canvas = document.createElement('canvas');
+    canvas.getBoundingClientRect = () => ({
+      left: 0,
+      top: 0,
+      width: 100,
+      height: 100,
+      right: 100,
+      bottom: 100,
+      x: 0,
+      y: 0,
+      toJSON() {},
+    });
+    canvas.setPointerCapture = vi.fn();
+    canvas.releasePointerCapture = vi.fn();
+    const renderer = { domElement: canvas } as unknown as THREE.WebGLRenderer;
+    const camera = new THREE.PerspectiveCamera();
+    const getCamera = () => camera;
+    const scene = new THREE.Scene();
+
+    const addWall = vi.fn(() => 'id');
+    const store = {
+      getState: () => ({
+        addWall,
+        wallThickness: 100,
+        wallType: 'dzialowa',
+        snapAngle: 0,
+        snapLength: 0,
+        snapRightAngles: true,
+        angleToPrev: 0,
+        defaultSquareAngle: 0,
+        room: { origin: { x: 0, y: 0 }, walls: [] },
+        setRoom: vi.fn(),
+        autoCloseWalls: false,
+      }),
+      subscribe: () => () => {},
+    } as any;
+
+    const drawer = new WallDrawer(
+      renderer,
+      getCamera,
+      scene,
+      store,
+      () => {},
+      () => {},
+    );
+
+    (drawer as any).getPoint = vi.fn(() => new THREE.Vector3(0, 0, 0));
+    (drawer as any).onDown({
+      clientX: 0,
+      clientY: 0,
+      pointerId: 1,
+      button: 0,
+    } as PointerEvent);
+
+    (drawer as any).getPoint = vi.fn(() => new THREE.Vector3(1, 0, 0));
+    (drawer as any).onMove({ clientX: 10, clientY: 0 } as PointerEvent);
+    expect((drawer as any).preview).not.toBeNull();
+
+    (drawer as any).onUp({
+      clientX: 10,
+      clientY: 0,
+      pointerId: 1,
+      button: 0,
+    } as PointerEvent);
+    expect(addWall).toHaveBeenCalled();
+    expect((drawer as any).start).toBeNull();
+
+    (drawer as any).getPoint = vi.fn(() => new THREE.Vector3(2, 0, 0));
+    (drawer as any).onMove({ clientX: 20, clientY: 0 } as PointerEvent);
+    expect((drawer as any).preview).toBeNull();
+  });
+});
+


### PR DESCRIPTION
## Summary
- Stop auto-chaining walls unless explicitly enabled
- Reset drawing state after each wall to require a new mouse-down
- Provide wall panel toggle and localization for auto-chaining
- Add regression test verifying no automatic chaining

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf2cb2d43c8322a129e7597801069d