### PR TITLE
feat: snap wall endpoints to edges

### DIFF
--- a/src/viewer/WallDrawer.ts
+++ b/src/viewer/WallDrawer.ts
@@ -539,7 +539,7 @@ export default class WallDrawer {
     return `${gx},${gy}`;
   }
 
-  private findClosestVertex(point: THREE.Vector3): THREE.Vector3 | null {
+  private findClosestPoint(point: THREE.Vector3): THREE.Vector3 | null {
     const segs = this.getSegments();
     let closest: THREE.Vector3 | null = null;
     let min = this.snapTolerance;
@@ -555,6 +555,17 @@ export default class WallDrawer {
       if (db < min) {
         min = db;
         closest = b;
+      }
+    }
+    if (closest) return closest;
+    const px = point.x * 1000;
+    const py = point.z * 1000;
+    for (const s of segs) {
+      const proj = projectPointToSegment(px, py, s);
+      const dist = proj.dist / 1000;
+      if (dist < min) {
+        min = dist;
+        closest = new THREE.Vector3(proj.x / 1000, 0, proj.y / 1000);
       }
     }
     return closest;
@@ -1068,7 +1079,7 @@ export default class WallDrawer {
       const endX = this.start.x + Math.cos(snappedAngle) * snappedLength;
       const endZ = this.start.z + Math.sin(snappedAngle) * snappedLength;
       let end = new THREE.Vector3(endX, 0, endZ);
-      const snap = this.findClosestVertex(end);
+      const snap = this.findClosestPoint(end);
       if (snap) {
         end = snap;
         const dxs = end.x - this.start.x;
@@ -1391,7 +1402,7 @@ export default class WallDrawer {
   private finalizeSegment(end: THREE.Vector3, manualLength?: number) {
     if (!this.start || !this.preview) return;
     const state = this.store.getState();
-    const snap = this.findClosestVertex(end);
+    const snap = this.findClosestPoint(end);
     let target = snap ? snap.clone() : end.clone();
     const origin = state.room.origin
       ? new THREE.Vector3(

--- a/tests/wallDrawer.e2e.test.ts
+++ b/tests/wallDrawer.e2e.test.ts
@@ -553,6 +553,62 @@ describe('WallDrawer vertex snapping to existing point', () => {
   });
 });
 
+describe('WallDrawer edge snapping to existing wall', () => {
+  it('snaps end of wall when cursor is near middle of existing wall', () => {
+    const canvas = document.createElement('canvas');
+    canvas.getBoundingClientRect = () => ({
+      left: 0,
+      top: 0,
+      width: 100,
+      height: 100,
+      right: 100,
+      bottom: 100,
+      x: 0,
+      y: 0,
+      toJSON() {},
+    });
+    const renderer = { domElement: canvas } as unknown as THREE.WebGLRenderer;
+    const camera = new THREE.PerspectiveCamera();
+    const getCamera = () => camera;
+    const scene = new THREE.Scene();
+    const addWall = vi.fn(() => 'id');
+    const state = {
+      addWall,
+      wallThickness: 100,
+      wallType: 'dzialowa',
+      snapAngle: 0,
+      snapLength: 0,
+      snapRightAngles: true,
+      angleToPrev: 0,
+      defaultSquareAngle: 0,
+      room: {
+        origin: { x: 0, y: 0 },
+        walls: [{ id: 'a', length: 1000, angle: 0, thickness: 100 }],
+      },
+      setRoom: vi.fn(),
+      autoCloseWalls: false,
+    };
+    const store: any = { getState: () => state };
+    const drawer = new WallDrawer(
+      renderer,
+      getCamera,
+      scene,
+      store,
+      () => {},
+      () => {},
+    );
+    (drawer as any).getPoint = () => new THREE.Vector3(0, 0, 1);
+    (drawer as any).onDown({ button: 0 } as PointerEvent);
+    (drawer as any).getPoint = () => new THREE.Vector3(0.5, 0, 0.002);
+    (drawer as any).onMove({} as PointerEvent);
+    (drawer as any).onUp({ button: 0 } as PointerEvent);
+    expect(addWall).toHaveBeenCalled();
+    const call = addWall.mock.calls[0][0];
+    expect(call.length).toBeCloseTo(1118, 0);
+    expect(call.angle).toBeCloseTo(296.565, 3);
+  });
+});
+
 describe('WallDrawer grid snapping', () => {
   it('snaps start and end points to grid when enabled', () => {
     const canvas = document.createElement('canvas');


### PR DESCRIPTION
## Summary
- allow drawing walls to snap to wall edges via `findClosestPoint`
- update wall drawing logic to use edge snapping
- add regression test for snapping to middle of existing wall

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bf2ece3e0c8322ace776db381a6516