### PR TITLE
Fix wall drawer pointer capture timing

### DIFF
--- a/src/viewer/WallDrawer.ts
+++ b/src/viewer/WallDrawer.ts
@@ -778,9 +778,11 @@ export default class WallDrawer {
   };
 
   private onDown = (e: PointerEvent) => {
-    this.renderer.domElement.setPointerCapture(e.pointerId);
     if (e.button !== 0) return;
     if (this.start) return;
+
+    this.renderer.domElement.setPointerCapture(e.pointerId);
+
     const point = this.getPoint(e);
     if (!point) return;
     this.dragStart = point.clone();


### PR DESCRIPTION
## Summary
- Delay pointer capture in WallDrawer until confirming a left-button event with no ongoing drag

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bf3f38bba4832298db7f8806f2c595