### PR TITLE
Support openings in arc walls

### DIFF
--- a/src/viewer/wall.ts
+++ b/src/viewer/wall.ts
@@ -18,6 +18,27 @@ export function createWallGeometry(
     const inner = new THREE.Path();
     inner.absarc(0, 0, r - t, sweep, 0, sweep < 0);
     shape.holes.push(inner);
+    openings.forEach((o) => {
+      const offset = (o.offset || 0) / 1000;
+      const width = (o.width || 0) / 1000;
+      const start = offset / r;
+      const delta = width / r;
+      const path = new THREE.Path();
+      const outerStart = new THREE.Vector2(
+        r * Math.cos(start),
+        r * Math.sin(start),
+      );
+      path.moveTo(outerStart.x, outerStart.y);
+      path.absarc(0, 0, r, start, start + delta, !(sweep < 0));
+      path.lineTo(
+        (r - t) * Math.cos(start + delta),
+        (r - t) * Math.sin(start + delta),
+      );
+      path.absarc(0, 0, r - t, start + delta, start, sweep < 0);
+      path.lineTo(outerStart.x, outerStart.y);
+      path.closePath();
+      shape.holes.push(path);
+    });
     const geom = new THREE.ExtrudeGeometry(shape, {
       depth: h,
       bevelEnabled: false,

--- a/tests/openings.e2e.test.ts
+++ b/tests/openings.e2e.test.ts
@@ -117,6 +117,46 @@ describe('openings', () => {
     expect(rc2.intersectObject(mesh).length).toBeGreaterThan(0);
   });
 
+  it('creates geometry with hole for opening on arc wall', () => {
+    const opening = {
+      id: 'o1',
+      wallId: 'w1',
+      offset: 500,
+      width: 800,
+      height: 1000,
+      bottom: 0,
+      kind: 1,
+    };
+    const geom = createWallGeometry(0, 2700, 100, [opening], {
+      radius: 2000,
+      angle: 90,
+    });
+    const mesh = new THREE.Mesh(geom, new THREE.MeshBasicMaterial());
+    const r = 2000 / 1000;
+    const t = 100 / 1000;
+    const h = 2700 / 1000;
+    const start = (opening.offset / 1000) / r;
+    const delta = (opening.width / 1000) / r;
+    const theta = start + delta / 2;
+    const origin = new THREE.Vector3(
+      (r - t - 0.01) * Math.cos(theta),
+      -(h + t) / 2,
+      (r - t - 0.01) * Math.sin(theta) - h / 2,
+    );
+    const dir = new THREE.Vector3(Math.cos(theta), 0, Math.sin(theta));
+    const rc = new THREE.Raycaster(origin, dir);
+    expect(rc.intersectObject(mesh)).toHaveLength(0);
+    const outside = start + delta + 0.1;
+    const origin2 = new THREE.Vector3(
+      (r - t - 0.01) * Math.cos(outside),
+      -(h + t) / 2,
+      (r - t - 0.01) * Math.sin(outside) - h / 2,
+    );
+    const dir2 = new THREE.Vector3(Math.cos(outside), 0, Math.sin(outside));
+    const rc2 = new THREE.Raycaster(origin2, dir2);
+    expect(rc2.intersectObject(mesh).length).toBeGreaterThan(0);
+  });
+
   it('rejects opening with negative offset', () => {
     const { addOpening } = usePlannerStore.getState();
     expect(() =>


### PR DESCRIPTION
## Summary
- Allow arc wall geometries to subtract wedge-shaped holes for openings
- Add regression test ensuring openings create holes on arc walls

## Testing
- `npm test tests/openings.e2e.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bf4186d8c88322a704ef165115c1f4