### PR TITLE
feat: enable configurable angle snapping for walls

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -55,7 +55,7 @@
     "noWalls": "No walls",
     "angleToPrev": "Angle to previous (°)",
     "snapLength": "Length step (mm; hold Alt to disable snapping)",
-    "snapAngle": "Angle step (°) for right-angle mode (hold Alt to disable snapping)",
+    "snapAngle": "Angle step (°) (hold Alt to disable snapping)",
     "snapRightAngles": "Right angles",
     "area": "Area (mm²)",
     "perimeter": "Perimeter (mm)",

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -55,7 +55,7 @@
     "noWalls": "Brak ścian",
     "angleToPrev": "Kąt do poprzedniej (°)",
     "snapLength": "Krok długości (mm; Alt tymczasowo wyłącza przyciąganie)",
-    "snapAngle": "Krok kąta (°) w trybie kątów prostych (Alt: chwilowe wyłączenie)",
+    "snapAngle": "Krok kąta (°) (Alt: chwilowe wyłączenie)",
     "snapRightAngles": "Kąty proste",
     "area": "Powierzchnia (mm²)",
     "perimeter": "Obwód (mm)",

--- a/src/viewer/WallDrawer.ts
+++ b/src/viewer/WallDrawer.ts
@@ -131,7 +131,12 @@ export default class WallDrawer {
   private readonly segmentGridSize = 1000; // mm
 
   private applyAngleSnap(angle: number): number {
-    const { snapRightAngles } = this.store.getState();
+    const { snapAngle, snapRightAngles } = this.store.getState();
+    if (snapAngle > 0) {
+      const deg = THREE.MathUtils.radToDeg(angle);
+      const snapped = Math.round(deg / snapAngle) * snapAngle;
+      return THREE.MathUtils.degToRad(snapped);
+    }
     if (!snapRightAngles) return angle;
     const deg = THREE.MathUtils.radToDeg(angle);
     const snapped = Math.round(deg / 90) * 90;

--- a/tests/wallDrawPanel.test.tsx
+++ b/tests/wallDrawPanel.test.tsx
@@ -4,6 +4,7 @@ import React, { act } from 'react';
 import ReactDOM from 'react-dom/client';
 import WallDrawPanel from '../src/ui/WallDrawPanel';
 import i18n from '../src/i18n';
+import { usePlannerStore } from '../src/state/store';
 
 (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -206,6 +207,34 @@ describe('WallDrawPanel callbacks', () => {
     });
 
     expect(cb.checked).toBe(false);
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it('updates snap angle value', async () => {
+    usePlannerStore.setState({ snapAngle: 90, snapRightAngles: true });
+    const three: any = {};
+    const threeRef = { current: three } as React.MutableRefObject<any>;
+    const container = document.createElement('div');
+    const root = ReactDOM.createRoot(container);
+
+    await act(async () => {
+      root.render(<WallDrawPanel threeRef={threeRef} isOpen isDrawing={false} />);
+    });
+
+    const label = Array.from(container.querySelectorAll('div.small')).find(
+      (d) => d.textContent === i18n.t('room.snapAngle'),
+    ) as HTMLDivElement;
+    const input = label.parentElement!.querySelector('input') as HTMLInputElement;
+    expect(input.value).toBe('90');
+
+    await act(async () => {
+      input.value = '45';
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    expect(input.value).toBe('45');
 
     await act(async () => {
       root.unmount();

--- a/tests/wallDrawer.e2e.test.ts
+++ b/tests/wallDrawer.e2e.test.ts
@@ -519,7 +519,7 @@ describe('WallDrawer.applyLength', () => {
 });
 
 describe('WallDrawer snapping', () => {
-  it('uses actual angle and snaps to configured length', () => {
+  it('snaps to configured angle and length', () => {
     const canvas = document.createElement('canvas');
     canvas.getBoundingClientRect = () => ({
       left: 0,
@@ -565,7 +565,7 @@ describe('WallDrawer snapping', () => {
     (drawer as any).getPoint = () =>
       new THREE.Vector3(Math.cos(rad) * 0.12, 0, Math.sin(rad) * 0.12);
     (drawer as any).onMove({} as PointerEvent);
-    expect(onAngleChange.mock.calls.at(-1)?.[0]).toBeCloseTo(20);
+    expect(onAngleChange.mock.calls.at(-1)?.[0]).toBeCloseTo(30);
     expect(onLengthChange).toHaveBeenLastCalledWith(100);
   });
 });


### PR DESCRIPTION
## Summary
- allow walls to snap to arbitrary angle increments via `snapAngle`
- expose snap angle control in the drawing panel and update labels
- add tests for adjustable angle snapping and UI control

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bf47c959408322878e61c9986ecb9f