### PR TITLE
chore: remove wall and opening data

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -183,37 +183,7 @@ export interface Module3D {
   openStates?: boolean[];
 }
 
-export interface Opening {
-  id: string;
-  wallId: string;
-  offset: number;
-  width: number;
-  height: number;
-  bottom: number;
-  kind: number;
-}
-
-export interface WallArc {
-  /** radius in millimetres */
-  radius: number;
-  /** central angle in degrees; positive is counter-clockwise */
-  angle: number;
-}
-
-export interface WallSegment {
-  id: string;
-  /** length in millimetres (for arcs this is the arc length) */
-  length: number;
-  /** direction of the segment start in degrees */
-  angle: number;
-  thickness: number;
-  /** optional arc definition */
-  arc?: WallArc;
-}
-
 export interface Room {
-  walls: WallSegment[];
-  openings: Opening[];
   height: number;
   origin: { x: number; y: number };
 }

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -13,7 +13,6 @@ export default function App() {
   const [family, setFamily] = useState<FAMILY>(FAMILY.BASE);
   const [kind, setKind] = useState<Kind | null>(null);
   const [variant, setVariant] = useState<Variant | null>(null);
-    const [selWall, setSelWall] = useState(() => usePlannerStore.getState().room.walls[0]?.id || '');
   const [addCountertop, setAddCountertop] = useState(true);
   const threeRef = useRef<any>({});
 
@@ -32,10 +31,9 @@ export default function App() {
     gLocal,
     setAdv,
     onAdd,
-    doAutoOnSelectedWall,
     initBlenda,
     initSidePanel,
-    } = useCabinetConfig(family, kind, variant, selWall, setVariant);
+  } = useCabinetConfig(family, kind, variant, setVariant);
 
   const [tab, setTab] = useState<'cab' | 'costs' | 'cut' | 'global' | null>(null);
   const [boardL, setBoardL] = useState(2800);
@@ -45,7 +43,6 @@ export default function App() {
 
   const undo = store.undo;
   const redo = store.redo;
-  const removeWall = store.removeWall;
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       if ((e.ctrlKey || e.metaKey) && e.key === 'z') {
@@ -55,18 +52,11 @@ export default function App() {
       } else if ((e.ctrlKey || e.metaKey) && e.key === 'y') {
         e.preventDefault();
         redo();
-      } else if (e.key === 'Escape') {
-        e.preventDefault();
-          if (selWall) {
-            removeWall(selWall);
-            const first = usePlannerStore.getState().room.walls[0];
-            setSelWall(first ? first.id : '');
-          }
       }
     };
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
-  }, [undo, redo, removeWall, selWall]);
+  }, [undo, redo]);
 
   return (
     <div className="app">
@@ -110,9 +100,6 @@ export default function App() {
           store={store}
           setVariant={setVariant}
           setKind={setKind}
-            selWall={selWall}
-            setSelWall={setSelWall}
-          doAutoOnSelectedWall={doAutoOnSelectedWall}
           lang={lang}
           setLang={setLang}
         />

--- a/src/ui/TopBar.tsx
+++ b/src/ui/TopBar.tsx
@@ -1,39 +1,16 @@
 import React from 'react';
 import type { Kind, Variant } from '../core/catalog';
-import { wallRanges, usePlannerStore } from '../state/store';
 
 interface TopBarProps {
   t: (key: string, opts?: any) => string;
   store: any;
   setVariant: (v: Variant | null) => void;
   setKind: (k: Kind | null) => void;
-  selWall: string;
-  setSelWall: (n: string) => void;
-  doAutoOnSelectedWall: () => void;
   lang: string;
   setLang: (l: string) => void;
 }
 
-export default function TopBar({ t, store, setVariant, setKind, selWall, setSelWall, doAutoOnSelectedWall, lang, setLang }: TopBarProps) {
-  const onRemoveWall = () => {
-    store.removeWall(selWall);
-    const first = usePlannerStore.getState().room.walls[0];
-    setSelWall(first ? first.id : '');
-  };
-  const onEditWall = () => {
-    const w = store.room.walls.find((ww: any) => ww.id === selWall);
-    if (!w) return;
-    const length = Number(prompt('Length (mm)', String(w.length))) || w.length;
-    const angle = Number(prompt('Angle (deg)', String(w.angle))) || w.angle;
-    const thickness =
-      Number(prompt('Thickness (mm)', String(w.thickness))) || w.thickness;
-    const { min, max } = wallRanges[store.wallType];
-    if (thickness < min || thickness > max) {
-      alert(`Thickness must be between ${min} and ${max}mm`);
-      return;
-    }
-    store.updateWall(selWall, { length, angle, thickness });
-  };
+export default function TopBar({ t, store, setVariant, setKind, lang, setLang }: TopBarProps) {
   return (
     <div className="topbar row">
       <button className="btnGhost" onClick={() => store.setRole(store.role === 'stolarz' ? 'klient' : 'stolarz')}>
@@ -50,34 +27,6 @@ export default function TopBar({ t, store, setVariant, setKind, selWall, setSelW
       </button>
       <button className="btnGhost" onClick={() => store.clear()}>
         {t('app.clear')}
-      </button>
-      <select
-        className="btnGhost"
-        value={selWall}
-        onChange={e => setSelWall((e.target as HTMLSelectElement).value)}
-      >
-        {store.room.walls.map((w: any, i: number) => (
-          <option key={w.id} value={w.id}>
-            {t('app.wallLabel', { num: i + 1, len: Math.round(w.length) })}
-          </option>
-        ))}
-      </select>
-      <button
-        className="btnGhost"
-        onClick={onRemoveWall}
-        disabled={store.room.walls.length === 0}
-      >
-        {t('app.removeWall')}
-      </button>
-      <button
-        className="btnGhost"
-        onClick={onEditWall}
-        disabled={store.room.walls.length === 0}
-      >
-        {t('app.editWall')}
-      </button>
-      <button className="btn" onClick={doAutoOnSelectedWall}>
-        {t('app.autoWall')}
       </button>
       <select className="btnGhost" value={lang} onChange={e => setLang((e.target as HTMLSelectElement).value)}>
         <option value="pl">PL</option>

--- a/src/ui/useCabinetConfig.ts
+++ b/src/ui/useCabinetConfig.ts
@@ -3,7 +3,6 @@ import { useTranslation } from 'react-i18next';
 import { FAMILY, Kind, Variant, KIND_SETS } from '../core/catalog';
 import { computeModuleCost } from '../core/pricing';
 import { usePlannerStore, legCategories } from '../state/store';
-import { autoWidthsForRun } from '../utils/auto';
 import { Module3D, ModuleAdv } from '../types';
 import { CabinetConfig } from './types';
 
@@ -11,7 +10,6 @@ export function useCabinetConfig(
   family: FAMILY,
   kind: Kind | null,
   variant: Variant | null,
-  selWall: string,
   setVariant: (v: Variant | null) => void,
 ) {
   const store = usePlannerStore();
@@ -201,86 +199,6 @@ export function useCabinetConfig(
     setVariant(null);
   };
 
-  const doAutoOnSelectedWall = () => {
-    const wall = store.room.walls.find((w) => w.id === selWall);
-    if (!wall) return alert(t('room.noWalls'));
-    const len = wall.length || 0;
-    const widths = autoWidthsForRun(len);
-    const g = store.globals[family];
-    const h = g.height / 1000,
-      d = g.depth / 1000;
-    let cursor = 0;
-    widths.forEach((wmm, i) => {
-      const w = wmm / 1000;
-      const id = `auto_${Date.now()}_${i}_${Math.floor(Math.random() * 1e6)}`;
-      const price = computeModuleCost(
-        {
-          family,
-          kind: KIND_SETS[family][0]?.key || 'doors',
-          variant: 'doors',
-          width: wmm,
-          adv: {
-            height: g.height,
-            depth: g.depth,
-            boardType: g.boardType,
-            frontType: g.frontType,
-            frontFoldable: g.frontFoldable,
-            gaps: g.gaps,
-            backPanel: g.backPanel,
-            topPanel: g.topPanel,
-            bottomPanel: g.bottomPanel,
-            topPanelEdgeBanding: {},
-            bottomPanelEdgeBanding: {},
-            rightSideEdgeBanding: {
-              front: true,
-              back: true,
-            },
-            leftSideEdgeBanding: {
-              front: true,
-              back: true,
-            },
-            shelfEdgeBanding: {},
-            sidePanels: {},
-            carcassType: g.carcassType,
-            legsType: g.legsType,
-          },
-          doorsCount: 1,
-          drawersCount: 0,
-        },
-        { prices: store.prices, globals: store.globals },
-      );
-      let mod: Module3D = {
-        id,
-        label: t('app.auto'),
-        family,
-        kind: KIND_SETS[family][0]?.key || 'doors',
-        size: { w, h, d },
-        position: [cursor / 1000 + w / 2, h / 2, 0],
-        rotationY: 0,
-        segIndex: null,
-        price,
-        adv: {
-          ...g,
-          doorCount: 1,
-          topPanelEdgeBanding: {},
-          bottomPanelEdgeBanding: {},
-          rightSideEdgeBanding: {
-            front: true,
-            back: true,
-          },
-          leftSideEdgeBanding: {
-            front: true,
-            back: true,
-          },
-          shelfEdgeBanding: {},
-          sidePanels: {},
-        } as ModuleAdv,
-      };
-      mod = resolveCollisions(mod);
-      store.addModule(mod);
-      cursor += wmm + 5;
-    });
-  };
 
   const gLocal: CabinetConfig = (() => {
     const g = store.globals[family];
@@ -359,7 +277,6 @@ export function useCabinetConfig(
     setAdv,
     gLocal,
     onAdd,
-    doAutoOnSelectedWall,
     initSidePanel,
     initBlenda,
   };


### PR DESCRIPTION
## Summary
- drop wall and opening interfaces and fields
- simplify planner store by removing wall-related state and actions
- clean UI components of wall references

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bfd679906083229b9c389bb81639a8