### PR TITLE
Remove leftover wall system code

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,6 @@
   </head>
   <body>
     <div id="root"></div>
-    <div id="wall-labels" class="wall-labels"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -9,11 +9,6 @@
     "undo": "Undo",
     "redo": "Redo",
     "clear": "Clear",
-    "wallLabel": "Wall {{num}} ({{len}} mm)",
-    "autoWall": "Auto for wall",
-    "removeWall": "Remove wall",
-    "editWall": "Edit wall",
-    "moveWall": "Move wall",
     "view2D": "View 2D",
     "view3D": "View 3D",
     "auto": "Auto",
@@ -27,7 +22,6 @@
     },
     "tabs": {
       "cab": "Kitchen",
-      "room": "Room",
       "costs": "Costs",
       "cut": "Cutlist",
       "global": "Settings"
@@ -38,28 +32,6 @@
   },
   "catalog": {
     "choose": "Choose"
-  },
-  "room": {
-    "title": "Room — walls",
-    "height": "Room height (mm)",
-    "wallThickness": "Wall thickness (mm)",
-    "wallType": "Wall type",
-    "wallTypes": {
-      "nosna": "Load-bearing",
-      "dzialowa": "Partition"
-    },
-    "addWindow": "Add window",
-    "addDoor": "Add door",
-    "drawWalls": "Draw walls",
-    "finishDrawing": "Finish drawing",
-    "noWalls": "No walls",
-    "angleToPrev": "Angle to previous (°)",
-    "snapLength": "Length step (mm; hold Alt to disable snapping)",
-    "snapAngle": "Angle step (°) (hold Alt to disable snapping)",
-    "snapRightAngles": "Right angles",
-    "area": "Area (mm²)",
-    "perimeter": "Perimeter (mm)",
-    "invalidLength": "Length must be non-negative"
   },
   "global": {
     "title": "Global settings",

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -9,11 +9,6 @@
     "undo": "Cofnij",
     "redo": "Ponów",
     "clear": "Wyczyść",
-    "wallLabel": "Ściana {{num}} ({{len}} mm)",
-    "autoWall": "Auto pod ścianę",
-    "removeWall": "Usuń ścianę",
-    "editWall": "Edytuj ścianę",
-    "moveWall": "Przesuń ścianę",
     "view2D": "Widok 2D",
     "view3D": "Widok 3D",
     "auto": "Auto",
@@ -27,7 +22,6 @@
     },
     "tabs": {
       "cab": "Kuchnia",
-      "room": "Pomieszczenie",
       "costs": "Koszty",
       "cut": "Formatki",
       "global": "Ustawienia"
@@ -38,28 +32,6 @@
   },
   "catalog": {
     "choose": "Wybierz"
-  },
-  "room": {
-    "title": "Pomieszczenie — ściany",
-    "height": "Wysokość pomieszczenia (mm)",
-    "wallThickness": "Grubość ściany (mm)",
-    "wallType": "Typ ściany",
-    "wallTypes": {
-      "nosna": "Nośna",
-      "dzialowa": "Działowa"
-    },
-    "addWindow": "Dodaj okno",
-    "addDoor": "Dodaj drzwi",
-    "drawWalls": "Rysuj ściany",
-    "finishDrawing": "Zakończ rysowanie",
-    "noWalls": "Brak ścian",
-    "angleToPrev": "Kąt do poprzedniej (°)",
-    "snapLength": "Krok długości (mm; Alt tymczasowo wyłącza przyciąganie)",
-    "snapAngle": "Krok kąta (°) (Alt: chwilowe wyłączenie)",
-    "snapRightAngles": "Kąty proste",
-    "area": "Powierzchnia (mm²)",
-    "perimeter": "Obwód (mm)",
-    "invalidLength": "Długość nie może być ujemna"
   },
   "global": {
     "title": "Ustawienia ogólne",

--- a/src/types.ts
+++ b/src/types.ts
@@ -178,7 +178,6 @@ export interface Module3D {
   rotationY?: number;
   price?: Price;
   fittings?: Record<string, number>;
-  segIndex?: number | null;
   adv?: ModuleAdv;
   openStates?: boolean[];
 }

--- a/src/ui/useCabinetConfig.ts
+++ b/src/ui/useCabinetConfig.ts
@@ -55,7 +55,7 @@ export function useCabinetConfig(
     });
   }, [family, store.globals]);
 
-  const snapToWalls = (
+  const computePlacement = (
     mSize: { w: number; h: number; d: number },
     _fam: FAMILY,
   ) => {
@@ -66,7 +66,6 @@ export function useCabinetConfig(
         0,
       ] as [number, number, number],
       rot: 0,
-      segIndex: null as number | null,
     };
   };
 
@@ -89,8 +88,7 @@ export function useCabinetConfig(
       ];
       loops++;
     }
-    const { segIndex, ...rest } = tryMod as any;
-    return rest as Module3D;
+    return tryMod as Module3D;
   };
 
   const onAdd = (
@@ -138,7 +136,7 @@ export function useCabinetConfig(
       },
       { prices: store.prices, globals: store.globals },
     );
-    const snap = snapToWalls({ w, h, d }, family);
+    const placement = computePlacement({ w, h, d }, family);
     const advAugmented: ModuleAdv & {
       hinge?: string;
       drawerSlide?: string;
@@ -182,9 +180,8 @@ export function useCabinetConfig(
       family,
       kind: kind.key,
       size: { w, h, d },
-      position: snap.pos,
-      rotationY: snap.rot,
-      segIndex: snap.segIndex,
+      position: placement.pos,
+      rotationY: placement.rot,
       price,
       adv: advAugmented,
     };

--- a/src/utils/auto.ts
+++ b/src/utils/auto.ts
@@ -1,9 +1,3 @@
-export interface Segment {
-  a: { x: number; y: number };
-  b: { x: number; y: number };
-  length: number;
-  angle: number;
-}
 export function autoWidthsForRun(lengthMM:number, prefs:number[] = [600,800,400,500,300]){
   const result:number[] = []
   let remaining = Math.max(0, Math.floor(lengthMM))
@@ -18,24 +12,4 @@ export function autoWidthsForRun(lengthMM:number, prefs:number[] = [600,800,400,
     }
   }
   return result
-}
-export function placeAlongWall(widths:number[], seg:Segment, gapMM=5){
-  const placed:{ center:[number,number]; rot:number }[] = []
-  let cursor = 0
-  const dir = { x:(seg.b.x-seg.a.x)/seg.length, y:(seg.b.y-seg.a.y)/seg.length }
-  for (const w of widths){
-    const remaining = seg.length - cursor
-    if (remaining <= 0) break
-    let width = w
-    const exceeds = width + gapMM > remaining
-    if (exceeds && width > remaining) width = remaining
-    const centerMM = cursor + width/2
-    const cx = seg.a.x + dir.x*centerMM
-    const cy = seg.a.y + dir.y*centerMM
-    placed.push({ center:[cx, cy], rot: -seg.angle })
-    cursor += width
-    if (exceeds) break
-    cursor += gapMM
-  }
-  return placed
 }


### PR DESCRIPTION
## Summary
- drop unused wall-placement utility and `segIndex` references
- remove wall-specific translations and room tab strings
- clean up index placeholder for wall labels

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bfd0cec7908322bfc11b375df686f9