### PR TITLE
Add first-person controls with player/editor mode toggle

### DIFF
--- a/src/scene/engine.ts
+++ b/src/scene/engine.ts
@@ -1,5 +1,6 @@
 import * as THREE from 'three';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
+import { PointerLockControls } from 'three/examples/jsm/controls/PointerLockControls.js';
 import { usePlannerStore } from '../state/store';
 import CabinetDragger from '../viewer/CabinetDragger';
 
@@ -44,8 +45,59 @@ export function setupThree(container: HTMLElement) {
   const controls = new OrbitControls(camera, renderer.domElement);
   controls.enableDamping = true;
 
-  const cabinetDragger = new CabinetDragger(renderer, () => camera, group, usePlannerStore);
+  const playerControls = new PointerLockControls(camera, renderer.domElement);
+
+  const cabinetDragger = new CabinetDragger(
+    renderer,
+    () => camera,
+    group,
+    usePlannerStore,
+  );
   cabinetDragger.enable?.();
+
+  const move = { forward: false, backward: false, left: false, right: false };
+  const onKeyDown = (e: KeyboardEvent) => {
+    switch (e.code) {
+      case 'ArrowUp':
+      case 'KeyW':
+        move.forward = true;
+        break;
+      case 'ArrowLeft':
+      case 'KeyA':
+        move.left = true;
+        break;
+      case 'ArrowDown':
+      case 'KeyS':
+        move.backward = true;
+        break;
+      case 'ArrowRight':
+      case 'KeyD':
+        move.right = true;
+        break;
+    }
+  };
+  const onKeyUp = (e: KeyboardEvent) => {
+    switch (e.code) {
+      case 'ArrowUp':
+      case 'KeyW':
+        move.forward = false;
+        break;
+      case 'ArrowLeft':
+      case 'KeyA':
+        move.left = false;
+        break;
+      case 'ArrowDown':
+      case 'KeyS':
+        move.backward = false;
+        break;
+      case 'ArrowRight':
+      case 'KeyD':
+        move.right = false;
+        break;
+    }
+  };
+  document.addEventListener('keydown', onKeyDown);
+  document.addEventListener('keyup', onKeyUp);
 
   const onResize = () => {
     const w = container.clientWidth,
@@ -57,9 +109,43 @@ export function setupThree(container: HTMLElement) {
   window.addEventListener('resize', onResize);
 
   const run = true;
+  const floorHalf = 5;
+  const speed = 0.1;
+  const forward = new THREE.Vector3();
+  const side = new THREE.Vector3();
+  const moveDir = new THREE.Vector3();
   const loop = () => {
     if (!run) return;
-    controls.update();
+    if (playerControls.isLocked) {
+      const oldPos = camera.position.clone();
+      forward.set(0, 0, 0);
+      camera.getWorldDirection(forward);
+      forward.y = 0;
+      forward.normalize();
+      side.crossVectors(new THREE.Vector3(0, 1, 0), forward).normalize();
+      moveDir.set(0, 0, 0);
+      if (move.forward) moveDir.add(forward);
+      if (move.backward) moveDir.add(forward.clone().multiplyScalar(-1));
+      if (move.left) moveDir.add(side.clone().multiplyScalar(-1));
+      if (move.right) moveDir.add(side);
+      if (moveDir.lengthSq() > 0) {
+        moveDir.normalize().multiplyScalar(speed);
+        const newPos = oldPos.clone().add(moveDir);
+        newPos.y = 1.6;
+        newPos.x = Math.max(-floorHalf, Math.min(floorHalf, newPos.x));
+        newPos.z = Math.max(-floorHalf, Math.min(floorHalf, newPos.z));
+        let blocked = false;
+        const box = new THREE.Box3();
+        group.children.forEach((child) => {
+          box.setFromObject(child);
+          if (box.containsPoint(newPos)) blocked = true;
+        });
+        if (!blocked) camera.position.copy(newPos);
+      }
+      camera.position.y = 1.6;
+    } else {
+      controls.update();
+    }
     renderer.render(scene, camera);
     requestAnimationFrame(loop);
   };
@@ -70,6 +156,8 @@ export function setupThree(container: HTMLElement) {
     camera,
     renderer,
     controls,
+    playerControls,
     group,
+    cabinetDragger,
   };
 }


### PR DESCRIPTION
## Summary
- integrate PointerLockControls for first-person navigation and keyboard movement
- add UI toggle in SceneViewer to switch between editor (Orbit) and player modes
- restrict movement to floor bounds and block collisions against scene objects

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bfddf950b48322b2b215b004d09e65