### PR TITLE
Add play mode tab and panel

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -24,7 +24,8 @@
       "cab": "Kitchen",
       "costs": "Costs",
       "cut": "Cutlist",
-      "global": "Settings"
+      "global": "Settings",
+      "play": "Play"
     },
     "cabinetType": "Cabinet type",
     "subcategories": "Subcategories ({{family}})",

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -24,7 +24,8 @@
       "cab": "Kuchnia",
       "costs": "Koszty",
       "cut": "Formatki",
-      "global": "Ustawienia"
+      "global": "Ustawienia",
+      "play": "Play"
     },
     "cabinetType": "Typ szafki",
     "subcategories": "Podkategorie ({{family}})",

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -35,7 +35,7 @@ export default function App() {
     initSidePanel,
   } = useCabinetConfig(family, kind, variant, setVariant);
 
-  const [tab, setTab] = useState<'cab' | 'costs' | 'cut' | 'global' | null>(null);
+  const [tab, setTab] = useState<'cab' | 'costs' | 'cut' | 'global' | 'play' | null>(null);
   const [boardL, setBoardL] = useState(2800);
   const [boardW, setBoardW] = useState(2070);
   const [boardKerf, setBoardKerf] = useState(3);
@@ -88,6 +88,7 @@ export default function App() {
           setBoardHasGrain={setBoardHasGrain}
           addCountertop={addCountertop}
           setAddCountertop={setAddCountertop}
+          threeRef={threeRef}
         />
       </div>
       <div className="canvasWrap">

--- a/src/ui/MainTabs.tsx
+++ b/src/ui/MainTabs.tsx
@@ -8,11 +8,12 @@ import CutlistTab from './panels/CutlistTab';
 import { CabinetConfig } from './types';
 import SlidingPanel from './components/SlidingPanel';
 import GlobalSettings from './panels/GlobalSettings';
+import PlayPanel from './panels/PlayPanel';
 
 interface MainTabsProps {
   t: (key: string, opts?: any) => string;
-  tab: 'cab' | 'costs' | 'cut' | 'global' | null;
-  setTab: (t: 'cab' | 'costs' | 'cut' | 'global' | null) => void;
+  tab: 'cab' | 'costs' | 'cut' | 'global' | 'play' | null;
+  setTab: (t: 'cab' | 'costs' | 'cut' | 'global' | 'play' | null) => void;
   family: FAMILY;
   setFamily: (f: FAMILY) => void;
   kind: Kind | null;
@@ -41,6 +42,7 @@ interface MainTabsProps {
   setBoardHasGrain: (v: boolean) => void;
   addCountertop: boolean;
   setAddCountertop: (v: boolean) => void;
+  threeRef: React.MutableRefObject<any>;
 }
 
 export default function MainTabs({
@@ -70,8 +72,9 @@ export default function MainTabs({
   setBoardHasGrain,
   addCountertop,
   setAddCountertop,
+  threeRef,
 }: MainTabsProps) {
-  const toggleTab = (name: 'cab' | 'costs' | 'cut' | 'global') => {
+  const toggleTab = (name: 'cab' | 'costs' | 'cut' | 'global' | 'play') => {
     setTab(tab === name ? null : name);
   };
 
@@ -89,6 +92,9 @@ export default function MainTabs({
         </button>
         <button className={`tabBtn ${tab === 'global' ? 'active' : ''}`} onClick={() => toggleTab('global')}>
           {t('app.tabs.global')}
+        </button>
+        <button className={`tabBtn ${tab === 'play' ? 'active' : ''}`} onClick={() => toggleTab('play')}>
+          {t('app.tabs.play')}
         </button>
       </div>
 
@@ -191,6 +197,7 @@ export default function MainTabs({
           />
         )}
         {tab === 'global' && <GlobalSettings />}
+        {tab === 'play' && <PlayPanel threeRef={threeRef} t={t} />}
       </SlidingPanel>
     </>
   );

--- a/src/ui/SceneViewer.tsx
+++ b/src/ui/SceneViewer.tsx
@@ -50,6 +50,7 @@ const SceneViewer: React.FC<Props> = ({ threeRef, addCountertop }) => {
   useEffect(() => {
     if (!containerRef.current) return;
     threeRef.current = setupThree(containerRef.current) as ThreeContext;
+    (threeRef.current as any).setPlayerMode = setPlayerMode;
     const pc = threeRef.current.playerControls;
     const onUnlock = () => setPlayerMode(false);
     pc.addEventListener('unlock', onUnlock);

--- a/src/ui/panels/PlayPanel.tsx
+++ b/src/ui/panels/PlayPanel.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+interface Props {
+  threeRef: React.MutableRefObject<any>;
+  t: (key: string, opts?: any) => string;
+}
+
+export default function PlayPanel({ threeRef, t }: Props) {
+  return (
+    <div className="section">
+      <div className="hd">
+        <div><div className="h1">{t('app.tabs.play')}</div></div>
+      </div>
+      <div className="bd" style={{ display: 'flex', gap: 8 }}>
+        <button className="btnGhost" onClick={() => threeRef.current?.setPlayerMode?.(true)}>
+          Enter play mode
+        </button>
+        <button className="btnGhost" onClick={() => threeRef.current?.setPlayerMode?.(false)}>
+          Exit play mode
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add Play tab to main interface with new PlayPanel for entering player mode
- expose player mode toggle from SceneViewer and update translations

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bfea5e4dbc8322a2203f904626287f