### PR TITLE
Fix lateral movement direction in first-person controls

### DIFF
--- a/src/scene/engine.ts
+++ b/src/scene/engine.ts
@@ -122,7 +122,7 @@ export function setupThree(container: HTMLElement) {
       camera.getWorldDirection(forward);
       forward.y = 0;
       forward.normalize();
-      side.crossVectors(new THREE.Vector3(0, 1, 0), forward).normalize();
+      side.crossVectors(forward, new THREE.Vector3(0, 1, 0)).normalize();
       moveDir.set(0, 0, 0);
       if (move.forward) moveDir.add(forward);
       if (move.backward) moveDir.add(forward.clone().multiplyScalar(-1));


### PR DESCRIPTION
## Summary
- correct lateral side vector calculation so movement keys map correctly

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bfee0122a8832294d85da1fc2a158b