### PR TITLE
Add configurable player movement parameters

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -191,6 +191,10 @@
     "mm": "mm",
     "cm": "cm"
   },
+  "play": {
+    "height": "Player height",
+    "speed": "Movement speed"
+  },
   "cutlist": {
     "validation": "Validation for sheet {{width}}×{{height}}",
     "sheets": "Sheets: {{sheets}}",

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -191,6 +191,10 @@
     "mm": "mm",
     "cm": "cm"
   },
+  "play": {
+    "height": "Wysokość człowieka",
+    "speed": "Prędkość poruszania"
+  },
   "cutlist": {
     "validation": "Walidacja formatu {{width}}×{{height}}",
     "sheets": "Arkusze: {{sheets}}",

--- a/src/scene/engine.ts
+++ b/src/scene/engine.ts
@@ -65,8 +65,9 @@ export function setupThree(container: HTMLElement) {
   };
   let velocityY = 0;
   const gravity = 0.01;
-  const standHeight = 1.6;
-  const crouchHeight = 1.0;
+  let playerHeight = usePlannerStore.getState().playerHeight;
+  let crouchHeight = playerHeight - 0.6;
+  let playerSpeed = usePlannerStore.getState().playerSpeed;
   const onKeyDown = (e: KeyboardEvent) => {
     switch (e.code) {
       case 'ArrowUp':
@@ -87,11 +88,12 @@ export function setupThree(container: HTMLElement) {
         break;
       case 'Space':
         move.jump = true;
-        if (camera.position.y <= (move.crouch ? crouchHeight : standHeight) + 0.01) velocityY = 0.2;
+        if (camera.position.y <= (move.crouch ? crouchHeight : playerHeight) + 0.01)
+          velocityY = 0.2;
         break;
       case 'ControlLeft':
         move.crouch = true;
-        if (camera.position.y <= standHeight + 0.01) camera.position.y = crouchHeight;
+        if (camera.position.y <= playerHeight + 0.01) camera.position.y = crouchHeight;
         break;
     }
   };
@@ -118,7 +120,7 @@ export function setupThree(container: HTMLElement) {
         break;
       case 'ControlLeft':
         move.crouch = false;
-        camera.position.y = Math.max(camera.position.y, standHeight);
+        camera.position.y = Math.max(camera.position.y, playerHeight);
         break;
     }
   };
@@ -136,7 +138,6 @@ export function setupThree(container: HTMLElement) {
 
   const run = true;
   const floorHalf = 5;
-  const speed = 0.1;
   const forward = new THREE.Vector3();
   const side = new THREE.Vector3();
   const moveDir = new THREE.Vector3();
@@ -155,9 +156,9 @@ export function setupThree(container: HTMLElement) {
       if (move.left) moveDir.add(side.clone().multiplyScalar(-1));
       if (move.right) moveDir.add(side);
       if (moveDir.lengthSq() > 0) {
-        moveDir.normalize().multiplyScalar(speed);
+        moveDir.normalize().multiplyScalar(playerSpeed);
         const collisionPos = oldPos.clone().add(moveDir);
-        collisionPos.y = standHeight;
+        collisionPos.y = playerHeight;
         collisionPos.x = Math.max(-floorHalf, Math.min(floorHalf, collisionPos.x));
         collisionPos.z = Math.max(-floorHalf, Math.min(floorHalf, collisionPos.z));
         let blocked = false;
@@ -172,7 +173,7 @@ export function setupThree(container: HTMLElement) {
         }
       }
       camera.position.y += velocityY;
-      const minY = move.crouch ? crouchHeight : standHeight;
+      const minY = move.crouch ? crouchHeight : playerHeight;
       if (camera.position.y <= minY) {
         camera.position.y = minY;
         velocityY = 0;
@@ -187,6 +188,14 @@ export function setupThree(container: HTMLElement) {
   };
   loop();
 
+  const setPlayerParams = ({ height, speed }: { height?: number; speed?: number }) => {
+    if (typeof height === 'number') {
+      playerHeight = height;
+      crouchHeight = height - 0.6;
+    }
+    if (typeof speed === 'number') playerSpeed = speed;
+  };
+
   return {
     scene,
     camera,
@@ -195,5 +204,6 @@ export function setupThree(container: HTMLElement) {
     playerControls,
     group,
     cabinetDragger,
+    setPlayerParams,
   };
 }

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -147,6 +147,8 @@ type Store = {
   gridSize: number;
   snapToGrid: boolean;
   measurementUnit: 'mm' | 'cm';
+  playerHeight: number;
+  playerSpeed: number;
   setRole: (r: 'stolarz' | 'klient') => void;
   updateGlobals: (fam: FAMILY, patch: Partial<Globals[FAMILY]>) => void;
   updatePrices: (patch: Partial<Prices>) => void;
@@ -169,6 +171,8 @@ type Store = {
   setGridSize: (v: number) => void;
   setSnapToGrid: (v: boolean) => void;
   setMeasurementUnit: (u: 'mm' | 'cm') => void;
+  setPlayerHeight: (v: number) => void;
+  setPlayerSpeed: (v: number) => void;
 };
 
 export const usePlannerStore = create<Store>((set, get) => ({
@@ -193,6 +197,8 @@ export const usePlannerStore = create<Store>((set, get) => ({
   gridSize: persisted?.gridSize ?? 50,
   snapToGrid: persisted?.snapToGrid ?? false,
   measurementUnit: persisted?.measurementUnit || 'mm',
+  playerHeight: persisted?.playerHeight ?? 1.6,
+  playerSpeed: persisted?.playerSpeed ?? 0.1,
   showFronts: true,
   setRole: (r) => set({ role: r }),
   updateGlobals: (fam, patch) =>
@@ -404,6 +410,8 @@ export const usePlannerStore = create<Store>((set, get) => ({
   setGridSize: (v) => set({ gridSize: v }),
   setSnapToGrid: (v) => set({ snapToGrid: v }),
   setMeasurementUnit: (v) => set({ measurementUnit: v }),
+  setPlayerHeight: (v) => set({ playerHeight: v }),
+  setPlayerSpeed: (v) => set({ playerSpeed: v }),
 }));
 
 const persistSelector = (s: Store) => ({
@@ -420,6 +428,8 @@ const persistSelector = (s: Store) => ({
   gridSize: s.gridSize,
   snapToGrid: s.snapToGrid,
   measurementUnit: s.measurementUnit,
+  playerHeight: s.playerHeight,
+  playerSpeed: s.playerSpeed,
 });
 
 let persistTimeout = 0;

--- a/src/ui/SceneViewer.tsx
+++ b/src/ui/SceneViewer.tsx
@@ -18,6 +18,7 @@ interface ThreeContext {
   playerControls: PointerLockControls;
   group: THREE.Group;
   cabinetDragger: CabinetDragger;
+  setPlayerParams?: (p: { height?: number; speed?: number }) => void;
 }
 
 interface Props {
@@ -66,13 +67,20 @@ const SceneViewer: React.FC<Props> = ({ threeRef, addCountertop }) => {
       three.controls.enabled = false;
       three.cabinetDragger.disable();
       three.playerControls.lock();
-      three.camera.position.y = 1.6;
+      three.camera.position.y = store.playerHeight;
     } else {
       three.playerControls.unlock();
       three.controls.enabled = true;
       three.cabinetDragger.enable();
     }
-  }, [playerMode, threeRef]);
+  }, [playerMode, threeRef, store.playerHeight]);
+
+  useEffect(() => {
+    threeRef.current?.setPlayerParams?.({
+      height: store.playerHeight,
+      speed: store.playerSpeed,
+    });
+  }, [store.playerHeight, store.playerSpeed, threeRef]);
 
   const createCabinetMesh = (mod: Module3D, legHeight: number) => {
     const W = mod.size.w;

--- a/src/ui/panels/PlayPanel.tsx
+++ b/src/ui/panels/PlayPanel.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { usePlannerStore } from '../../state/store';
 
 interface Props {
   threeRef: React.MutableRefObject<any>;
@@ -6,18 +7,59 @@ interface Props {
 }
 
 export default function PlayPanel({ threeRef, t }: Props) {
+  const {
+    playerHeight,
+    playerSpeed,
+    setPlayerHeight,
+    setPlayerSpeed,
+  } = usePlannerStore();
+
+  const onHeightChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const v = Number((e.target as HTMLInputElement).value) || 0;
+    setPlayerHeight(v);
+    threeRef.current?.setPlayerParams?.({ height: v });
+  };
+
+  const onSpeedChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const v = Number((e.target as HTMLInputElement).value) || 0;
+    setPlayerSpeed(v);
+    threeRef.current?.setPlayerParams?.({ speed: v });
+  };
+
   return (
     <div className="section">
       <div className="hd">
         <div><div className="h1">{t('app.tabs.play')}</div></div>
       </div>
-      <div className="bd" style={{ display: 'flex', gap: 8 }}>
-        <button className="btnGhost" onClick={() => threeRef.current?.setPlayerMode?.(true)}>
-          Enter play mode
-        </button>
-        <button className="btnGhost" onClick={() => threeRef.current?.setPlayerMode?.(false)}>
-          Exit play mode
-        </button>
+      <div className="bd" style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+        <div>
+          <div className="small">{t('play.height')}</div>
+          <input
+            className="input"
+            type="number"
+            step="0.1"
+            value={playerHeight}
+            onChange={onHeightChange}
+          />
+        </div>
+        <div>
+          <div className="small">{t('play.speed')}</div>
+          <input
+            className="input"
+            type="number"
+            step="0.01"
+            value={playerSpeed}
+            onChange={onSpeedChange}
+          />
+        </div>
+        <div style={{ display: 'flex', gap: 8 }}>
+          <button className="btnGhost" onClick={() => threeRef.current?.setPlayerMode?.(true)}>
+            Enter play mode
+          </button>
+          <button className="btnGhost" onClick={() => threeRef.current?.setPlayerMode?.(false)}>
+            Exit play mode
+          </button>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- allow setting player height and speed in global store
- drive engine movement using store-driven playerHeight and playerSpeed
- add Play panel to tweak height and walking speed before entering play mode
- add i18n keys for new controls

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bff1a49e508322b511dcbdd5a66d55