### PR TITLE
Add placeable surfaces and ghost placement helper

### DIFF
--- a/src/scene/cabinetBuilder.ts
+++ b/src/scene/cabinetBuilder.ts
@@ -462,6 +462,8 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
     bottom.position.set(W / 2, legHeight + T / 2, bottomZ);
     bottom.userData.part = 'bottom';
     bottom.userData.originalMaterial = bottom.material;
+    bottom.userData.placeable = true;
+    bottom.userData.ignoreRaycast = true;
     addEdges(bottom);
     group.add(bottom);
     if (shouldBand(bottomPanelEdgeBanding, 'horizontal', 'front')) {
@@ -845,6 +847,8 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
       shelf.position.set(W / 2, y, -D / 2);
       shelf.userData.part = 'shelf';
       shelf.userData.originalMaterial = shelf.material;
+      shelf.userData.placeable = true;
+      shelf.userData.ignoreRaycast = true;
       addEdges(shelf);
       group.add(shelf);
       if (shouldBand(shelfEdgeBanding, 'horizontal', 'front')) {
@@ -943,6 +947,20 @@ export function buildCabinetMesh(opts: CabinetOptions): THREE.Group {
           frontMesh.add(handle);
         }
         group.add(fg);
+        const drawerBottom = new THREE.Mesh(
+          new THREE.BoxGeometry(availW, T, D),
+          carcMat,
+        );
+        drawerBottom.position.set(
+          gapLeft / 1000 + availW / 2,
+          currentY + T / 2,
+          -D / 2,
+        );
+        drawerBottom.visible = false;
+        drawerBottom.userData.part = 'drawerInterior';
+        drawerBottom.userData.placeable = true;
+        drawerBottom.userData.ignoreRaycast = true;
+        group.add(drawerBottom);
         currentY += h;
       }
     } else {

--- a/tests/cabinetBuilder.test.ts
+++ b/tests/cabinetBuilder.test.ts
@@ -21,7 +21,7 @@ describe('buildCabinetMesh', () => {
       family: FAMILY.BASE,
     });
     expect(g).toBeInstanceOf(THREE.Group);
-    expect(g.children.length).toBe(7);
+    expect(g.children.length).toBe(9);
   });
 
   it('creates provided number of drawer groups', () => {
@@ -37,6 +37,43 @@ describe('buildCabinetMesh', () => {
       (c) => c instanceof THREE.Group && (c as any).userData.type === 'drawer',
     );
     expect(drawers.length).toBe(3);
+  });
+
+  it('marks bottom and shelves as placeable', () => {
+    const g = buildCabinetMesh({
+      width: 1,
+      height: 0.9,
+      depth: 0.5,
+      drawers: 0,
+      shelves: 1,
+      gaps: { top: 0, bottom: 0 },
+      family: FAMILY.BASE,
+    });
+    const bottom = g.children.find(
+      (c) => c instanceof THREE.Mesh && (c as any).userData.part === 'bottom',
+    ) as THREE.Mesh | undefined;
+    const shelf = g.children.find(
+      (c) => c instanceof THREE.Mesh && (c as any).userData.part === 'shelf',
+    ) as THREE.Mesh | undefined;
+    expect(bottom?.userData.placeable).toBe(true);
+    expect(shelf?.userData.placeable).toBe(true);
+  });
+
+  it('creates placeable drawer interiors', () => {
+    const g = buildCabinetMesh({
+      width: 1,
+      height: 0.9,
+      depth: 0.5,
+      drawers: 2,
+      gaps: { top: 0, bottom: 0 },
+      family: FAMILY.BASE,
+    });
+    const interiors = g.children.filter(
+      (c) =>
+        c instanceof THREE.Mesh && (c as any).userData.part === 'drawerInterior',
+    );
+    expect(interiors.length).toBe(2);
+    interiors.forEach((m) => expect((m as any).userData.placeable).toBe(true));
   });
 
   it('returns group with expected children for doors', () => {


### PR DESCRIPTION
## Summary
- Mark cabinet bottoms, shelves, and drawer interiors as `placeable` surfaces
- Show ghost item on first free placeable surface when selecting hotbar items
- Place items only when ghost highlight is active and snap to its position

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0095bbb448322891799057fe86a0c