### PR TITLE
Prevent Ctrl+W from closing the player window

### DIFF
--- a/src/ui/SceneViewer.tsx
+++ b/src/ui/SceneViewer.tsx
@@ -207,6 +207,10 @@ const SceneViewer: React.FC<Props> = ({ threeRef, addCountertop }) => {
   useEffect(() => {
     const handleKey = (e: KeyboardEvent) => {
       if (!playerMode) return;
+      if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'w') {
+        e.preventDefault();
+        return;
+      }
       const n = Number(e.key);
       if (n >= 1 && n <= 9) {
         store.setSelectedItemSlot(n);


### PR DESCRIPTION
## Summary
- intercept Ctrl+W in SceneViewer so player mode doesn't close the browser tab

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c00de61a0c83229130d6ff61ce05ff