### PR TITLE
feat: lift player mode state to app

### DIFF
--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -40,6 +40,7 @@ export default function App() {
   const [boardW, setBoardW] = useState(2070);
   const [boardKerf, setBoardKerf] = useState(3);
   const [boardHasGrain, setBoardHasGrain] = useState(false);
+  const [playerMode, setPlayerMode] = useState(false);
 
   const undo = store.undo;
   const redo = store.redo;
@@ -58,52 +59,64 @@ export default function App() {
     return () => window.removeEventListener('keydown', handler);
   }, [undo, redo]);
 
+  useEffect(() => {
+    if (playerMode) setTab(null);
+  }, [playerMode]);
+
   return (
     <div className="app">
-      <div className="mainTabs">
-        <MainTabs
-          t={t}
-          tab={tab}
-          setTab={setTab}
-          family={family}
-          setFamily={setFamily}
-          kind={kind}
-          setKind={setKind}
-          variant={variant}
-          setVariant={setVariant}
-          widthMM={widthMM}
-          setWidthMM={setWidthMM}
-          gLocal={gLocal}
-          setAdv={setAdv}
-          onAdd={onAdd}
-          initBlenda={initBlenda}
-          initSidePanel={initSidePanel}
-          boardL={boardL}
-          setBoardL={setBoardL}
-          boardW={boardW}
-          setBoardW={setBoardW}
-          boardKerf={boardKerf}
-          setBoardKerf={setBoardKerf}
-          boardHasGrain={boardHasGrain}
-          setBoardHasGrain={setBoardHasGrain}
-          addCountertop={addCountertop}
-          setAddCountertop={setAddCountertop}
-          threeRef={threeRef}
-        />
-      </div>
+      {!playerMode && (
+        <div className="mainTabs">
+          <MainTabs
+            t={t}
+            tab={tab}
+            setTab={setTab}
+            family={family}
+            setFamily={setFamily}
+            kind={kind}
+            setKind={setKind}
+            variant={variant}
+            setVariant={setVariant}
+            widthMM={widthMM}
+            setWidthMM={setWidthMM}
+            gLocal={gLocal}
+            setAdv={setAdv}
+            onAdd={onAdd}
+            initBlenda={initBlenda}
+            initSidePanel={initSidePanel}
+            boardL={boardL}
+            setBoardL={setBoardL}
+            boardW={boardW}
+            setBoardW={setBoardW}
+            boardKerf={boardKerf}
+            setBoardKerf={setBoardKerf}
+            boardHasGrain={boardHasGrain}
+            setBoardHasGrain={setBoardHasGrain}
+            addCountertop={addCountertop}
+            setAddCountertop={setAddCountertop}
+            threeRef={threeRef}
+            playerMode={playerMode}
+            setPlayerMode={setPlayerMode}
+          />
+        </div>
+      )}
       <div className="canvasWrap">
         <SceneViewer
           threeRef={threeRef}
           addCountertop={addCountertop}
+          playerMode={playerMode}
+          setPlayerMode={setPlayerMode}
         />
-        <TopBar
-          t={t}
-          store={store}
-          setVariant={setVariant}
-          setKind={setKind}
-          lang={lang}
-          setLang={setLang}
-        />
+        {!playerMode && (
+          <TopBar
+            t={t}
+            store={store}
+            setVariant={setVariant}
+            setKind={setKind}
+            lang={lang}
+            setLang={setLang}
+          />
+        )}
       </div>
     </div>
   );

--- a/src/ui/MainTabs.tsx
+++ b/src/ui/MainTabs.tsx
@@ -43,6 +43,8 @@ interface MainTabsProps {
   addCountertop: boolean;
   setAddCountertop: (v: boolean) => void;
   threeRef: React.MutableRefObject<any>;
+  playerMode: boolean;
+  setPlayerMode: (v: boolean) => void;
 }
 
 export default function MainTabs({
@@ -73,6 +75,7 @@ export default function MainTabs({
   addCountertop,
   setAddCountertop,
   threeRef,
+  setPlayerMode,
 }: MainTabsProps) {
   const toggleTab = (name: 'cab' | 'costs' | 'cut' | 'global' | 'play') => {
     setTab(tab === name ? null : name);
@@ -197,7 +200,14 @@ export default function MainTabs({
           />
         )}
         {tab === 'global' && <GlobalSettings />}
-        {tab === 'play' && <PlayPanel threeRef={threeRef} t={t} />}
+        {tab === 'play' && (
+          <PlayPanel
+            threeRef={threeRef}
+            t={t}
+            setPlayerMode={setPlayerMode}
+            onClose={() => setTab(null)}
+          />
+        )}
       </SlidingPanel>
     </>
   );

--- a/src/ui/SceneViewer.tsx
+++ b/src/ui/SceneViewer.tsx
@@ -37,6 +37,8 @@ interface ThreeContext {
 interface Props {
   threeRef: React.MutableRefObject<ThreeContext | null>;
   addCountertop: boolean;
+  playerMode: boolean;
+  setPlayerMode: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 const INTERACT_DISTANCE = 1.5;
@@ -50,13 +52,17 @@ export const getLegHeight = (mod: Module3D, globals: Globals): number => {
   return 0.1;
 };
 
-const SceneViewer: React.FC<Props> = ({ threeRef, addCountertop }) => {
+const SceneViewer: React.FC<Props> = ({
+  threeRef,
+  addCountertop,
+  playerMode,
+  setPlayerMode,
+}) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const store = usePlannerStore();
   const showEdges = store.role === 'stolarz';
   const showFronts = store.showFronts;
 
-  const [playerMode, setPlayerMode] = useState(false);
   const [isMobile, setIsMobile] = useState(false);
   const lookVec = useRef({ x: 0, y: 0 });
   const targetRef = useRef<{ cab: THREE.Object3D; index: number } | null>(null);

--- a/src/ui/panels/PlayPanel.tsx
+++ b/src/ui/panels/PlayPanel.tsx
@@ -4,9 +4,11 @@ import { usePlannerStore } from '../../state/store';
 interface Props {
   threeRef: React.MutableRefObject<any>;
   t: (key: string, opts?: any) => string;
+  setPlayerMode: (v: boolean) => void;
+  onClose: () => void;
 }
 
-export default function PlayPanel({ threeRef, t }: Props) {
+export default function PlayPanel({ threeRef, t, setPlayerMode, onClose }: Props) {
   const {
     playerHeight,
     playerSpeed,
@@ -53,10 +55,16 @@ export default function PlayPanel({ threeRef, t }: Props) {
           />
         </div>
         <div style={{ display: 'flex', gap: 8 }}>
-          <button className="btnGhost" onClick={() => threeRef.current?.setPlayerMode?.(true)}>
+          <button
+            className="btnGhost"
+            onClick={() => {
+              setPlayerMode(true);
+              onClose();
+            }}
+          >
             Enter play mode
           </button>
-          <button className="btnGhost" onClick={() => threeRef.current?.setPlayerMode?.(false)}>
+          <button className="btnGhost" onClick={() => setPlayerMode(false)}>
             Exit play mode
           </button>
         </div>


### PR DESCRIPTION
## Summary
- lift `playerMode` state to App and toggle MainTabs/TopBar based on it
- pass `playerMode` controls through SceneViewer, MainTabs and PlayPanel
- close sidebar when entering play mode

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c0109ad0288322b139168d9936c834