### PR TITLE
Add mobile mode bar and Tab mode cycling

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -48,3 +48,6 @@ details>summary{cursor:pointer;padding:8px 0;font-weight:600}
 details.active>summary{color:var(--accent);text-decoration:underline;font-weight:700}
 details>div{padding:8px 0;animation:fadeIn .2s ease}
 @keyframes fadeIn{from{opacity:0}to{opacity:1}}
+.modeBar{position:absolute;bottom:0;left:0;right:0;display:flex;justify-content:space-around;gap:8px;background:rgba(255,255,255,.85);border-top:1px solid var(--border);padding:8px;backdrop-filter:blur(6px)}
+.modeItem{flex:1;text-align:center;padding:8px 0;border:1px solid var(--border);border-radius:8px;cursor:pointer;background:var(--white)}
+.modeItem.active{background:var(--accent);color:var(--white)}

--- a/src/ui/SceneViewer.tsx
+++ b/src/ui/SceneViewer.tsx
@@ -229,6 +229,20 @@ const SceneViewer: React.FC<Props> = ({
   }, [mode, store]);
 
   useEffect(() => {
+    const handleTab = (e: KeyboardEvent) => {
+      if (e.key !== 'Tab') return;
+      e.preventDefault();
+      setMode((m) => {
+        const modes: PlayerMode[] = ['build', 'furnish', 'decorate'];
+        const idx = modes.indexOf(m ?? 'decorate');
+        return modes[(idx + 1) % modes.length];
+      });
+    };
+    window.addEventListener('keydown', handleTab);
+    return () => window.removeEventListener('keydown', handleTab);
+  }, [setMode]);
+
+  useEffect(() => {
     updateGhost();
   }, [updateGhost]);
 
@@ -704,6 +718,25 @@ const SceneViewer: React.FC<Props> = ({
             Centrum
           </button>
         </>
+      )}
+      {isMobile && (
+        <div className="modeBar">
+          {(
+            [
+              { key: 'build', label: '🔨' },
+              { key: 'furnish', label: '🪑' },
+              { key: 'decorate', label: '🎨' },
+            ] as { key: PlayerMode; label: string }[]
+          ).map(({ key, label }) => (
+            <div
+              key={key}
+              className={`modeItem${mode === key ? ' active' : ''}`}
+              onClick={() => setMode(key)}
+            >
+              {label}
+            </div>
+          ))}
+        </div>
       )}
       {mode === null && (
         <div


### PR DESCRIPTION
## Summary
- Cycle between build, furnish and decorate modes with the Tab key
- Add mobile mode bar with icons to switch modes
- Highlight active mode and sync with global state

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c0172a3cfc8322b2bbb89a5249f662