### PR TITLE
Add room builder with wall painting

### DIFF
--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -191,8 +191,17 @@ export const usePlannerStore = create<Store>((set, get) => ({
     ? {
         ...persisted.room,
         origin: persisted.room.origin || { x: 0, y: 0 },
+        walls: persisted.room.walls || [],
+        windows: persisted.room.windows || [],
+        doors: persisted.room.doors || [],
       }
-    : { height: 2700, origin: { x: 0, y: 0 } },
+    : {
+        height: 2700,
+        origin: { x: 0, y: 0 },
+        walls: [],
+        windows: [],
+        doors: [],
+      },
   snapAngle: persisted?.snapAngle ?? 90,
   snapLength: persisted?.snapLength ?? 10,
   snapRightAngles: true,

--- a/src/types.ts
+++ b/src/types.ts
@@ -182,9 +182,30 @@ export interface Module3D {
   openStates?: boolean[];
 }
 
+export interface Wall {
+  id: string;
+  start: { x: number; y: number };
+  end: { x: number; y: number };
+  height: number;
+  thickness: number;
+  color?: string;
+}
+
+export interface WallOpening {
+  id: string;
+  wallId: string;
+  offset: number;
+  width: number;
+  height: number;
+  bottom: number;
+}
+
 export interface Room {
   height: number;
   origin: { x: number; y: number };
+  walls: Wall[];
+  windows: WallOpening[];
+  doors: WallOpening[];
 }
 
 export interface PricingData {

--- a/src/ui/SceneViewer.tsx
+++ b/src/ui/SceneViewer.tsx
@@ -12,6 +12,7 @@ import { loadItemModel } from '../scene/itemLoader';
 import ItemHotbar, { hotbarItems } from './components/ItemHotbar';
 import TouchJoystick from './components/TouchJoystick';
 import { PlayerMode } from './types';
+import RoomBuilder from './build/RoomBuilder';
 
 interface ThreeContext {
   scene: THREE.Scene;
@@ -695,6 +696,7 @@ const SceneViewer: React.FC<Props> = ({
           {mode ? 'Tryb edycji' : 'Tryb gracza'}
         </button>
       </div>
+      {mode === 'build' && <RoomBuilder threeRef={threeRef} />}
       {mode === 'decorate' && <ItemHotbar />}
       {mode && isMobile && (
         <>

--- a/src/ui/build/RoomBuilder.tsx
+++ b/src/ui/build/RoomBuilder.tsx
@@ -1,0 +1,177 @@
+import React, { useEffect, useRef } from 'react';
+import * as THREE from 'three';
+import { usePlannerStore } from '../../state/store';
+import type { Wall, WallOpening } from '../../types';
+
+interface Props {
+  threeRef: React.MutableRefObject<any>;
+}
+
+/**
+ * Simple room builder that draws walls, windows and doors based on the
+ * `room` structure in the store. Allows basic editing such as adding walls
+ * and changing wall colors.
+ */
+const RoomBuilder: React.FC<Props> = ({ threeRef }) => {
+  const room = usePlannerStore((s) => s.room);
+  const setRoom = usePlannerStore((s) => s.setRoom);
+  const groupRef = useRef<THREE.Group | null>(null);
+
+  // draw room elements whenever data changes
+  useEffect(() => {
+    const three = threeRef.current;
+    if (!three) return;
+    if (!groupRef.current) {
+      groupRef.current = new THREE.Group();
+      groupRef.current.userData.kind = 'room';
+      three.group.add(groupRef.current);
+    }
+    const g = groupRef.current;
+    // clear previous meshes
+    while (g.children.length > 0) {
+      const c = g.children.pop() as THREE.Object3D;
+      g.remove(c);
+      c.traverse((o) => {
+        if (o instanceof THREE.Mesh) {
+          o.geometry.dispose();
+          if (Array.isArray(o.material)) o.material.forEach((m) => m.dispose());
+          else o.material.dispose();
+        }
+      });
+    }
+    const wallHeight = room.height / 1000;
+    // draw walls
+    room.walls.forEach((w) => {
+      const len = Math.hypot(w.end.x - w.start.x, w.end.y - w.start.y);
+      const geom = new THREE.BoxGeometry(len, w.height || wallHeight, w.thickness);
+      const mat = new THREE.MeshStandardMaterial({ color: w.color || '#ffffff' });
+      const mesh = new THREE.Mesh(geom, mat);
+      const midx = (w.start.x + w.end.x) / 2;
+      const midy = (w.start.y + w.end.y) / 2;
+      mesh.position.set(midx, (w.height || wallHeight) / 2, midy);
+      const angle = Math.atan2(w.end.y - w.start.y, w.end.x - w.start.x);
+      mesh.rotation.y = -angle;
+      mesh.userData.wallId = w.id;
+      g.add(mesh);
+    });
+    // helper to draw openings (windows/doors)
+    const drawOpening = (op: WallOpening, color: number) => {
+      const wall = room.walls.find((w) => w.id === op.wallId);
+      if (!wall) return;
+      const len = Math.hypot(wall.end.x - wall.start.x, wall.end.y - wall.start.y);
+      const angle = Math.atan2(wall.end.y - wall.start.y, wall.end.x - wall.start.x);
+      const geom = new THREE.BoxGeometry(op.width, op.height, wall.thickness + 0.01);
+      const mat = new THREE.MeshStandardMaterial({ color });
+      const mesh = new THREE.Mesh(geom, mat);
+      const ratio = op.offset / len;
+      const px = wall.start.x + (wall.end.x - wall.start.x) * ratio;
+      const py = wall.start.y + (wall.end.y - wall.start.y) * ratio;
+      mesh.position.set(px, op.bottom + op.height / 2, py);
+      mesh.rotation.y = -angle;
+      g.add(mesh);
+    };
+    room.windows.forEach((w) => drawOpening(w, 0x87cefa));
+    room.doors.forEach((d) => drawOpening(d, 0x8b4513));
+  }, [room, threeRef]);
+
+  // cleanup on unmount
+  useEffect(() => {
+    return () => {
+      const three = threeRef.current;
+      if (three && groupRef.current) {
+        three.group.remove(groupRef.current);
+      }
+    };
+  }, [threeRef]);
+
+  const addWall = () => {
+    const wallHeight = room.height / 1000;
+    const newWall: Wall = {
+      id: Math.random().toString(36).slice(2),
+      start: { x: 0, y: 0 },
+      end: { x: 2, y: 0 },
+      height: wallHeight,
+      thickness: 0.1,
+      color: '#ffffff',
+    };
+    setRoom({ walls: [...room.walls, newWall] });
+  };
+
+  const updateWallColor = (id: string, color: string) => {
+    setRoom({ walls: room.walls.map((w) => (w.id === id ? { ...w, color } : w)) });
+  };
+
+  const addWindow = (wallId: string) => {
+    const wall = room.walls.find((w) => w.id === wallId);
+    if (!wall) return;
+    const len = Math.hypot(wall.end.x - wall.start.x, wall.end.y - wall.start.y);
+    const win: WallOpening = {
+      id: Math.random().toString(36).slice(2),
+      wallId,
+      offset: len / 2,
+      width: 1,
+      height: 1,
+      bottom: 1,
+    };
+    setRoom({ windows: [...room.windows, win] });
+  };
+
+  const addDoor = (wallId: string) => {
+    const wall = room.walls.find((w) => w.id === wallId);
+    if (!wall) return;
+    const len = Math.hypot(wall.end.x - wall.start.x, wall.end.y - wall.start.y);
+    const door: WallOpening = {
+      id: Math.random().toString(36).slice(2),
+      wallId,
+      offset: len / 3,
+      width: 0.9,
+      height: 2,
+      bottom: 0,
+    };
+    setRoom({ doors: [...room.doors, door] });
+  };
+
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        top: 10,
+        right: 10,
+        background: '#fff',
+        padding: 8,
+        borderRadius: 4,
+      }}
+    >
+      <button className="btnGhost" onClick={addWall}>
+        Dodaj ścianę
+      </button>
+      {room.walls.map((w) => (
+        <div key={w.id} style={{ marginTop: 4 }}>
+          <span>Ściana</span>
+          <input
+            type="color"
+            value={w.color || '#ffffff'}
+            onChange={(e) => updateWallColor(w.id, e.target.value)}
+            style={{ marginLeft: 4 }}
+          />
+          <button
+            className="btnGhost"
+            style={{ marginLeft: 4 }}
+            onClick={() => addWindow(w.id)}
+          >
+            +Okno
+          </button>
+          <button
+            className="btnGhost"
+            style={{ marginLeft: 4 }}
+            onClick={() => addDoor(w.id)}
+          >
+            +Drzwi
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default RoomBuilder;


### PR DESCRIPTION
## Summary
- extend room state to include walls, windows and doors
- add RoomBuilder component for wall/window/door editing and painting
- wire RoomBuilder into SceneViewer build mode

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c01858bd6c8322a3153efb6952cdf3