### PR TITLE
Restrict cabinet dragging to furnish mode

### DIFF
--- a/src/ui/SceneViewer.tsx
+++ b/src/ui/SceneViewer.tsx
@@ -172,10 +172,9 @@ const SceneViewer: React.FC<Props> = ({
   useEffect(() => {
     const three = threeRef.current;
     if (!three) return;
-    if (mode) {
+    if (mode === 'furnish') {
       three.controls.enabled = false;
-      if (mode === 'furnish') three.cabinetDragger.enable();
-      else three.cabinetDragger.disable();
+      three.cabinetDragger.enable();
       if (isMobile) {
         (three.playerControls as any).isLocked = true;
       } else {
@@ -183,13 +182,23 @@ const SceneViewer: React.FC<Props> = ({
       }
       three.camera.position.y = store.playerHeight;
     } else {
-      if (isMobile) {
-        (three.playerControls as any).isLocked = false;
+      three.cabinetDragger.disable();
+      if (mode) {
+        three.controls.enabled = false;
+        if (isMobile) {
+          (three.playerControls as any).isLocked = true;
+        } else {
+          three.playerControls.lock();
+        }
+        three.camera.position.y = store.playerHeight;
       } else {
-        three.playerControls.unlock();
+        if (isMobile) {
+          (three.playerControls as any).isLocked = false;
+        } else {
+          three.playerControls.unlock();
+        }
+        three.controls.enabled = true;
       }
-      three.controls.enabled = true;
-      three.cabinetDragger.enable();
     }
   }, [mode, threeRef, store.playerHeight, isMobile]);
 

--- a/tests/sceneViewer.mode.test.tsx
+++ b/tests/sceneViewer.mode.test.tsx
@@ -1,0 +1,79 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import React from 'react';
+import { act } from 'react';
+import ReactDOM from 'react-dom/client';
+import * as THREE from 'three';
+import SceneViewer from '../src/ui/SceneViewer';
+
+vi.mock('../src/scene/engine', () => {
+  return {
+    setupThree: () => {
+      const dom = document.createElement('canvas');
+      dom.getBoundingClientRect = () => ({
+        left: 0,
+        top: 0,
+        width: 100,
+        height: 100,
+        right: 100,
+        bottom: 100,
+        x: 0,
+        y: 0,
+        toJSON() {},
+      });
+      return {
+        scene: {},
+        camera: {
+          position: { y: 0 },
+          getWorldPosition: () => new THREE.Vector3(),
+          getWorldDirection: () => new THREE.Vector3(0, 0, -1),
+        },
+        renderer: { domElement: dom },
+        controls: { enabled: true, dollyIn: () => {}, dollyOut: () => {}, update: () => {} },
+        playerControls: {
+          lock: vi.fn(),
+          unlock: vi.fn(),
+          addEventListener: vi.fn(),
+          removeEventListener: vi.fn(),
+          isLocked: false,
+        },
+        group: { children: [], add: () => {}, remove: () => {} },
+        cabinetDragger: { enable: vi.fn(), disable: vi.fn() },
+      };
+    },
+  };
+});
+
+vi.mock('../src/ui/components/ItemHotbar', () => ({ default: () => null, hotbarItems: [] }));
+vi.mock('../src/ui/components/TouchJoystick', () => ({ default: () => null }));
+vi.mock('../src/ui/build/RoomBuilder', () => ({ default: () => null }));
+
+describe('SceneViewer cabinetDragger mode control', () => {
+  it('enables cabinetDragger only in furnish mode', () => {
+    const threeRef: any = { current: null };
+    const setMode = vi.fn();
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = ReactDOM.createRoot(container);
+
+    act(() => {
+      root.render(<SceneViewer threeRef={threeRef} addCountertop={false} mode={null} setMode={setMode} />);
+    });
+    const dragger = threeRef.current.cabinetDragger;
+    expect(dragger.enable).not.toHaveBeenCalled();
+    expect(dragger.disable).toHaveBeenCalled();
+
+    act(() => {
+      root.render(<SceneViewer threeRef={threeRef} addCountertop={false} mode="furnish" setMode={setMode} />);
+    });
+    expect(dragger.enable).toHaveBeenCalled();
+
+    const before = dragger.disable.mock.calls.length;
+    act(() => {
+      root.render(<SceneViewer threeRef={threeRef} addCountertop={false} mode="build" setMode={setMode} />);
+    });
+    expect(dragger.disable.mock.calls.length).toBeGreaterThan(before);
+
+    root.unmount();
+  });
+});


### PR DESCRIPTION
## Summary
- Enable cabinet dragging only when mode is `furnish`
- Add tests covering mode-based dragger activation

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c01a3d4c8c832292a77b1af85af113