### PR TITLE
feat: add radial menu for slot selection

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -205,6 +205,13 @@
     "plate": "Plate",
     "bottle": "Bottle"
   },
+  "radial": {
+    "wall": "Wall",
+    "window": "Window",
+    "cup": "Cup",
+    "plate": "Plate",
+    "bottle": "Bottle"
+  },
   "cutlist": {
     "validation": "Validation for sheet {{width}}×{{height}}",
     "sheets": "Sheets: {{sheets}}",

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -205,6 +205,13 @@
     "plate": "Talerz",
     "bottle": "Butelka"
   },
+  "radial": {
+    "wall": "Ściana",
+    "window": "Okno",
+    "cup": "Kubek",
+    "plate": "Talerz",
+    "bottle": "Butelka"
+  },
   "cutlist": {
     "validation": "Walidacja formatu {{width}}×{{height}}",
     "sheets": "Arkusze: {{sheets}}",

--- a/src/ui/SceneViewer.tsx
+++ b/src/ui/SceneViewer.tsx
@@ -13,6 +13,7 @@ import ItemHotbar, { hotbarItems } from './components/ItemHotbar';
 import TouchJoystick from './components/TouchJoystick';
 import { PlayerMode } from './types';
 import RoomBuilder from './build/RoomBuilder';
+import RadialMenu from './components/RadialMenu';
 
 interface ThreeContext {
   scene: THREE.Scene;
@@ -66,11 +67,31 @@ const SceneViewer: React.FC<Props> = ({
   const showFronts = store.showFronts;
 
   const [isMobile, setIsMobile] = useState(false);
+  const [showRadial, setShowRadial] = useState(false);
   const lookVec = useRef({ x: 0, y: 0 });
   const targetRef = useRef<{ cab: THREE.Object3D; index: number } | null>(null);
   const [showHint, setShowHint] = useState(false);
   const [targetCabinet, setTargetCabinet] = useState<THREE.Object3D | null>(null);
   const ghostRef = useRef<THREE.Object3D | null>(null);
+
+  const buildRadialItems: (string | null)[] = [
+    'wall',
+    'window',
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+  ];
+  const furnishRadialItems: (string | null)[] = Array(9).fill(null);
+  const radialItems =
+    mode === 'build'
+      ? buildRadialItems
+      : mode === 'furnish'
+        ? furnishRadialItems
+        : hotbarItems;
 
   const updateGhost = React.useCallback(() => {
     const three = threeRef.current;
@@ -222,7 +243,6 @@ const SceneViewer: React.FC<Props> = ({
 
   useEffect(() => {
     const handleKey = (e: KeyboardEvent) => {
-      if (mode !== 'decorate') return;
       if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'w') {
         e.preventDefault();
         return;
@@ -234,7 +254,28 @@ const SceneViewer: React.FC<Props> = ({
     };
     window.addEventListener('keydown', handleKey);
     return () => window.removeEventListener('keydown', handleKey);
-  }, [mode, store]);
+  }, [store]);
+
+  useEffect(() => {
+    setShowRadial(false);
+    if (!mode) return;
+    const down = (e: KeyboardEvent) => {
+      if (e.code === 'KeyQ') {
+        setShowRadial(true);
+      }
+    };
+    const up = (e: KeyboardEvent) => {
+      if (e.code === 'KeyQ') {
+        setShowRadial(false);
+      }
+    };
+    window.addEventListener('keydown', down);
+    window.addEventListener('keyup', up);
+    return () => {
+      window.removeEventListener('keydown', down);
+      window.removeEventListener('keyup', up);
+    };
+  }, [mode]);
 
   useEffect(() => {
     const handleTab = (e: KeyboardEvent) => {
@@ -629,6 +670,12 @@ const SceneViewer: React.FC<Props> = ({
   return (
     <div style={{ position: 'absolute', inset: 0 }}>
       <div ref={containerRef} style={{ position: 'absolute', inset: 0 }} />
+      <RadialMenu
+        items={radialItems}
+        selected={store.selectedItemSlot}
+        onSelect={store.setSelectedItemSlot}
+        visible={showRadial}
+      />
       {mode === null && (
         <div className="zoomControls">
           <button className="btnGhost" onClick={handleZoomIn}>
@@ -702,6 +749,14 @@ const SceneViewer: React.FC<Props> = ({
               {label}
             </div>
           ))}
+          <div
+            className="modeItem"
+            onTouchStart={() => setShowRadial(true)}
+            onTouchEnd={() => setShowRadial(false)}
+            onTouchCancel={() => setShowRadial(false)}
+          >
+            ⭮
+          </div>
         </div>
       )}
     </div>

--- a/src/ui/components/RadialMenu.tsx
+++ b/src/ui/components/RadialMenu.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+interface Props {
+  items: (string | null)[];
+  selected: number;
+  onSelect: (slot: number) => void;
+  visible: boolean;
+}
+
+const RadialMenu: React.FC<Props> = ({ items, selected, onSelect, visible }) => {
+  const { t } = useTranslation();
+
+  if (!visible) return null;
+
+  const size = 200;
+  const radius = size / 2;
+  const angle = (2 * Math.PI) / 9;
+
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        top: '50%',
+        left: '50%',
+        transform: 'translate(-50%, -50%)',
+        pointerEvents: 'none',
+        zIndex: 20,
+      }}
+    >
+      <svg width={size} height={size} style={{ pointerEvents: 'auto' }}>
+        {items.map((item, idx) => {
+          const start = idx * angle - Math.PI / 2;
+          const end = start + angle;
+          const x1 = radius + radius * Math.cos(start);
+          const y1 = radius + radius * Math.sin(start);
+          const x2 = radius + radius * Math.cos(end);
+          const y2 = radius + radius * Math.sin(end);
+          const largeArc = angle > Math.PI ? 1 : 0;
+          const path = `M ${radius} ${radius} L ${x1} ${y1} A ${radius} ${radius} 0 ${largeArc} 1 ${x2} ${y2} Z`;
+          const mid = start + angle / 2;
+          const tx = radius + radius * 0.6 * Math.cos(mid);
+          const ty = radius + radius * 0.6 * Math.sin(mid);
+          const label = item ? t(`radial.${item}`) : '';
+          const isSelected = selected === idx + 1;
+          return (
+            <g key={idx}>
+              <path
+                d={path}
+                fill={isSelected ? 'rgba(255,255,255,0.3)' : 'rgba(0,0,0,0.3)'}
+                stroke="#fff"
+                onMouseEnter={() => onSelect(idx + 1)}
+                onClick={() => onSelect(idx + 1)}
+                onTouchStart={() => onSelect(idx + 1)}
+              />
+              {label && (
+                <text
+                  x={tx}
+                  y={ty}
+                  fill="#fff"
+                  fontSize={12}
+                  textAnchor="middle"
+                  dominantBaseline="middle"
+                  pointerEvents="none"
+                >
+                  {label}
+                </text>
+              )}
+            </g>
+          );
+        })}
+      </svg>
+    </div>
+  );
+};
+
+export default RadialMenu;


### PR DESCRIPTION
## Summary
- add `RadialMenu` component displaying 9 selectable sectors
- wire radial menu into `SceneViewer` with Q-key toggle and mobile button
- add translations for radial menu items

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c025d997008322b8725a4398dbd53b