### PR TITLE
Prevent Tab cycling when mode unset

### DIFF
--- a/src/ui/SceneViewer.tsx
+++ b/src/ui/SceneViewer.tsx
@@ -278,6 +278,7 @@ const SceneViewer: React.FC<Props> = ({
   }, [mode]);
 
   useEffect(() => {
+    if (mode === null) return;
     const handleTab = (e: KeyboardEvent) => {
       if (e.key !== 'Tab') return;
       e.preventDefault();
@@ -289,7 +290,7 @@ const SceneViewer: React.FC<Props> = ({
     };
     window.addEventListener('keydown', handleTab);
     return () => window.removeEventListener('keydown', handleTab);
-  }, [setMode]);
+  }, [mode, setMode]);
 
   useEffect(() => {
     updateGhost();

--- a/tests/sceneViewer.mode.test.tsx
+++ b/tests/sceneViewer.mode.test.tsx
@@ -77,3 +77,26 @@ describe('SceneViewer cabinetDragger mode control', () => {
     root.unmount();
   });
 });
+
+describe('SceneViewer Tab key', () => {
+  it('does nothing when mode is null', () => {
+    const threeRef: any = { current: null };
+    const setMode = vi.fn();
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = ReactDOM.createRoot(container);
+
+    act(() => {
+      root.render(
+        <SceneViewer threeRef={threeRef} addCountertop={false} mode={null} setMode={setMode} />
+      );
+    });
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab' }));
+    });
+    expect(setMode).not.toHaveBeenCalled();
+
+    root.unmount();
+  });
+});


### PR DESCRIPTION
## Summary
- stop registering Tab key handler when player mode is null
- add test verifying Tab key does nothing when mode is null

## Testing
- `npm test tests/sceneViewer.mode.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c02c4aff2483228f73d7fe5ed11a97