### PR TITLE
Restrict hotbar selection to decorate mode

### DIFF
--- a/src/ui/SceneViewer.tsx
+++ b/src/ui/SceneViewer.tsx
@@ -249,12 +249,14 @@ const SceneViewer: React.FC<Props> = ({
       }
       const n = Number(e.key);
       if (n >= 1 && n <= 9) {
-        store.setSelectedItemSlot(n);
+        if (mode === 'decorate') {
+          store.setSelectedItemSlot(n);
+        }
       }
     };
     window.addEventListener('keydown', handleKey);
     return () => window.removeEventListener('keydown', handleKey);
-  }, [store]);
+  }, [store, mode]);
 
   useEffect(() => {
     setShowRadial(false);

--- a/tests/sceneViewer.mode.test.tsx
+++ b/tests/sceneViewer.mode.test.tsx
@@ -5,6 +5,8 @@ import { act } from 'react';
 import ReactDOM from 'react-dom/client';
 import * as THREE from 'three';
 import SceneViewer from '../src/ui/SceneViewer';
+import { usePlannerStore } from '../src/state/store';
+import { PlayerMode } from '../src/ui/types';
 
 vi.mock('../src/scene/engine', () => {
   return {
@@ -96,6 +98,37 @@ describe('SceneViewer Tab key', () => {
       window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab' }));
     });
     expect(setMode).not.toHaveBeenCalled();
+
+    root.unmount();
+  });
+});
+
+describe('SceneViewer hotbar keys', () => {
+  it('does not change selectedItemSlot when mode is not decorate', () => {
+    const threeRef: any = { current: null };
+    const setMode = vi.fn();
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = ReactDOM.createRoot(container);
+
+    const modes: (PlayerMode | null)[] = [null, 'build', 'furnish'];
+    for (const m of modes) {
+      act(() => {
+        usePlannerStore.setState({ selectedItemSlot: 5 });
+        root.render(
+          <SceneViewer
+            threeRef={threeRef}
+            addCountertop={false}
+            mode={m}
+            setMode={setMode}
+          />,
+        );
+      });
+      act(() => {
+        window.dispatchEvent(new KeyboardEvent('keydown', { key: '1' }));
+      });
+      expect(usePlannerStore.getState().selectedItemSlot).toBe(5);
+    }
 
     root.unmount();
   });


### PR DESCRIPTION
## Summary
- only allow hotbar slot changes when mode is `decorate`
- test that numeric keys do not switch slots in other modes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c02dd9dc5483228b0d265b7fb38bda