### PR TITLE
feat: add selected tool state for build and furnish modes

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -208,6 +208,7 @@
   "radial": {
     "wall": "Wall",
     "window": "Window",
+    "door": "Door",
     "cup": "Cup",
     "plate": "Plate",
     "bottle": "Bottle"

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -208,6 +208,7 @@
   "radial": {
     "wall": "Ściana",
     "window": "Okno",
+    "door": "Drzwi",
     "cup": "Kubek",
     "plate": "Talerz",
     "bottle": "Butelka"

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -150,6 +150,7 @@ type Store = {
   playerHeight: number;
   playerSpeed: number;
   selectedItemSlot: number;
+  selectedTool: string | null;
   itemsByCabinet: (cabinetId: string) => Item[];
   itemsBySurface: (cabinetId: string, surfaceIndex: number) => Item[];
   setRole: (r: 'stolarz' | 'klient') => void;
@@ -177,6 +178,7 @@ type Store = {
   setPlayerHeight: (v: number) => void;
   setPlayerSpeed: (v: number) => void;
   setSelectedItemSlot: (slot: number) => void;
+  setSelectedTool: (tool: string | null) => void;
 };
 
 export const usePlannerStore = create<Store>((set, get) => ({
@@ -213,6 +215,7 @@ export const usePlannerStore = create<Store>((set, get) => ({
   playerHeight: persisted?.playerHeight ?? 1.6,
   playerSpeed: persisted?.playerSpeed ?? 0.1,
   selectedItemSlot: 1,
+  selectedTool: null,
   showFronts: true,
   itemsByCabinet: (cabinetId) =>
     get().items.filter((it) => it.cabinetId === cabinetId),
@@ -433,6 +436,7 @@ export const usePlannerStore = create<Store>((set, get) => ({
   setPlayerHeight: (v) => set({ playerHeight: v }),
   setPlayerSpeed: (v) => set({ playerSpeed: v }),
   setSelectedItemSlot: (slot) => set({ selectedItemSlot: slot }),
+  setSelectedTool: (tool) => set({ selectedTool: tool }),
 }));
 
 const persistSelector = (s: Store) => ({

--- a/src/ui/SceneViewer.tsx
+++ b/src/ui/SceneViewer.tsx
@@ -77,7 +77,7 @@ const SceneViewer: React.FC<Props> = ({
   const buildRadialItems: (string | null)[] = [
     'wall',
     'window',
-    null,
+    'door',
     null,
     null,
     null,
@@ -675,8 +675,18 @@ const SceneViewer: React.FC<Props> = ({
       <div ref={containerRef} style={{ position: 'absolute', inset: 0 }} />
       <RadialMenu
         items={radialItems}
-        selected={store.selectedItemSlot}
-        onSelect={store.setSelectedItemSlot}
+        selected={
+          mode === 'build' || mode === 'furnish'
+            ? radialItems.findIndex((it) => it === store.selectedTool) + 1
+            : store.selectedItemSlot
+        }
+        onSelect={(slot) => {
+          if (mode === 'build' || mode === 'furnish') {
+            store.setSelectedTool(radialItems[slot - 1]);
+          } else {
+            store.setSelectedItemSlot(slot);
+          }
+        }}
         visible={showRadial}
       />
       {mode === null && (

--- a/src/ui/build/RoomBuilder.tsx
+++ b/src/ui/build/RoomBuilder.tsx
@@ -15,6 +15,8 @@ interface Props {
 const RoomBuilder: React.FC<Props> = ({ threeRef }) => {
   const room = usePlannerStore((s) => s.room);
   const setRoom = usePlannerStore((s) => s.setRoom);
+  const selectedTool = usePlannerStore((s) => s.selectedTool);
+  const setSelectedTool = usePlannerStore((s) => s.setSelectedTool);
   const groupRef = useRef<THREE.Group | null>(null);
 
   // draw room elements whenever data changes
@@ -130,6 +132,20 @@ const RoomBuilder: React.FC<Props> = ({ threeRef }) => {
     };
     setRoom({ doors: [...room.doors, door] });
   };
+
+  useEffect(() => {
+    if (!selectedTool) return;
+    if (selectedTool === 'wall') {
+      addWall();
+    } else if (selectedTool === 'window') {
+      const lastWall = room.walls[room.walls.length - 1];
+      if (lastWall) addWindow(lastWall.id);
+    } else if (selectedTool === 'door') {
+      const lastWall = room.walls[room.walls.length - 1];
+      if (lastWall) addDoor(lastWall.id);
+    }
+    setSelectedTool(null);
+  }, [selectedTool]);
 
   return (
     <div


### PR DESCRIPTION
## Summary
- track `selectedTool` in planner store for building and furnishing modes
- update radial menu to manage `selectedTool` and add door option
- trigger wall/window/door creation in `RoomBuilder` based on `selectedTool`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c030bfe5f883229f58ea1fbea4e10a