### PR TITLE
Add dispose cleanup for three.js

### DIFF
--- a/src/scene/engine.ts
+++ b/src/scene/engine.ts
@@ -289,6 +289,16 @@ export function setupThree(container: HTMLElement) {
     if (typeof speed === 'number') playerSpeed = speed;
   };
 
+  const dispose = () => {
+    document.removeEventListener('keydown', onKeyDown, { capture: true });
+    document.removeEventListener('keyup', onKeyUp, { capture: true });
+    window.removeEventListener('pointerdown', onPointerDown);
+    window.removeEventListener('pointermove', onPointerMove);
+    window.removeEventListener('pointerup', onPointerUp);
+    window.removeEventListener('pointercancel', onPointerUp);
+    window.removeEventListener('resize', onResize);
+  };
+
   return {
     scene,
     camera,
@@ -304,5 +314,6 @@ export function setupThree(container: HTMLElement) {
     resetCameraRotation,
     onJump,
     onCrouch,
+    dispose,
   };
 }

--- a/src/ui/SceneViewer.tsx
+++ b/src/ui/SceneViewer.tsx
@@ -35,6 +35,7 @@ interface ThreeContext {
   resetCameraRotation?: () => void;
   onJump?: () => void;
   onCrouch?: (active: boolean) => void;
+  dispose?: () => void;
 }
 
 interface Props {
@@ -185,6 +186,7 @@ const SceneViewer: React.FC<Props> = ({
     pc.addEventListener('unlock', onUnlock);
     return () => {
       pc.removeEventListener('unlock', onUnlock);
+      threeRef.current?.dispose?.();
     };
   }, [threeRef]);
 


### PR DESCRIPTION
## Summary
- add dispose function in `setupThree` to detach all event listeners
- call `dispose` when `SceneViewer` unmounts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c0341042cc8322a5cf4382ad112b1c