### PR TITLE
Preserve last play mode when toggling

### DIFF
--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -9,6 +9,8 @@ import MainTabs from './MainTabs';
 import { safeSetItem } from '../utils/storage';
 import { PlayerMode } from './types';
 
+type PlayerSubMode = Exclude<PlayerMode, null>;
+
 export default function App() {
   const store = usePlannerStore();
   const [family, setFamily] = useState<FAMILY>(FAMILY.BASE);
@@ -42,6 +44,7 @@ export default function App() {
   const [boardKerf, setBoardKerf] = useState(3);
   const [boardHasGrain, setBoardHasGrain] = useState(false);
   const [mode, setMode] = useState<PlayerMode>(null);
+  const [startMode, setStartMode] = useState<PlayerSubMode>('build');
 
   const undo = store.undo;
   const redo = store.redo;
@@ -62,6 +65,10 @@ export default function App() {
 
   useEffect(() => {
     if (mode !== null) setTab(null);
+  }, [mode]);
+
+  useEffect(() => {
+    if (mode !== null) setStartMode(mode);
   }, [mode]);
 
   return (
@@ -96,8 +103,9 @@ export default function App() {
             addCountertop={addCountertop}
             setAddCountertop={setAddCountertop}
             threeRef={threeRef}
-            mode={mode}
             setMode={setMode}
+            startMode={startMode}
+            setStartMode={setStartMode}
           />
         </div>
       )}
@@ -107,6 +115,7 @@ export default function App() {
           addCountertop={addCountertop}
           mode={mode}
           setMode={setMode}
+          startMode={startMode}
         />
         {mode === null && (
           <TopBar

--- a/src/ui/MainTabs.tsx
+++ b/src/ui/MainTabs.tsx
@@ -43,8 +43,9 @@ interface MainTabsProps {
   addCountertop: boolean;
   setAddCountertop: (v: boolean) => void;
   threeRef: React.MutableRefObject<any>;
-  mode: PlayerMode;
   setMode: (v: PlayerMode) => void;
+  startMode: Exclude<PlayerMode, null>;
+  setStartMode: (v: Exclude<PlayerMode, null>) => void;
 }
 
 export default function MainTabs({
@@ -76,6 +77,8 @@ export default function MainTabs({
   setAddCountertop,
   threeRef,
   setMode,
+  startMode,
+  setStartMode,
 }: MainTabsProps) {
   const toggleTab = (name: 'cab' | 'costs' | 'cut' | 'global' | 'play') => {
     setTab(tab === name ? null : name);
@@ -204,6 +207,8 @@ export default function MainTabs({
           <PlayPanel
             threeRef={threeRef}
             t={t}
+            startMode={startMode}
+            setStartMode={setStartMode}
             setMode={setMode}
             onClose={() => setTab(null)}
           />

--- a/src/ui/SceneViewer.tsx
+++ b/src/ui/SceneViewer.tsx
@@ -43,6 +43,7 @@ interface Props {
   addCountertop: boolean;
   mode: PlayerMode;
   setMode: React.Dispatch<React.SetStateAction<PlayerMode>>;
+  startMode: Exclude<PlayerMode, null>;
 }
 
 const INTERACT_DISTANCE = 1.5;
@@ -61,6 +62,7 @@ const SceneViewer: React.FC<Props> = ({
   addCountertop,
   mode,
   setMode,
+  startMode,
 }) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const store = usePlannerStore();
@@ -718,7 +720,7 @@ const SceneViewer: React.FC<Props> = ({
         </div>
       )}
       <div style={{ position: 'absolute', top: 10, left: 10 }}>
-        <button className="btnGhost" onClick={() => setMode((m) => (m ? null : 'furnish'))}>
+        <button className="btnGhost" onClick={() => setMode((m) => (m ? null : startMode))}>
           {mode ? 'Tryb edycji' : 'Tryb gracza'}
         </button>
       </div>

--- a/src/ui/panels/PlayPanel.tsx
+++ b/src/ui/panels/PlayPanel.tsx
@@ -1,23 +1,32 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { usePlannerStore } from '../../state/store';
 import { PlayerMode } from '../types';
+
+type PlayerSubMode = Exclude<PlayerMode, null>;
 
 interface Props {
   threeRef: React.MutableRefObject<any>;
   t: (key: string, opts?: any) => string;
   setMode: (v: PlayerMode) => void;
+  startMode: PlayerSubMode;
+  setStartMode: (v: PlayerSubMode) => void;
   onClose: () => void;
 }
 
-export default function PlayPanel({ threeRef, t, setMode, onClose }: Props) {
+export default function PlayPanel({
+  threeRef,
+  t,
+  setMode,
+  startMode,
+  setStartMode,
+  onClose,
+}: Props) {
   const {
     playerHeight,
     playerSpeed,
     setPlayerHeight,
     setPlayerSpeed,
   } = usePlannerStore();
-  const [startMode, setStartMode] = useState<PlayerMode>('build');
-
   const onHeightChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const v = Number((e.target as HTMLInputElement).value) || 0;
     setPlayerHeight(v);
@@ -62,7 +71,7 @@ export default function PlayPanel({ threeRef, t, setMode, onClose }: Props) {
               { key: 'build', label: t('play.mode.build') },
               { key: 'furnish', label: t('play.mode.furnish') },
               { key: 'decorate', label: t('play.mode.decorate') },
-            ] as { key: PlayerMode; label: string }[]
+            ] as { key: PlayerSubMode; label: string }[]
           ).map(({ key, label }) => (
             <button
               key={key}


### PR DESCRIPTION
## Summary
- Track last non-null player mode in App state and share with PlayPanel and SceneViewer
- Allow SceneViewer toggle to return to last selected or default mode instead of always 'furnish'
- PlayPanel uses shared start mode for persistent play-mode selection

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c035d9cc5883228592bada624d29ec