### PR TITLE
Toggle radial menu with Q key

### DIFF
--- a/src/ui/SceneViewer.tsx
+++ b/src/ui/SceneViewer.tsx
@@ -263,8 +263,7 @@ const SceneViewer: React.FC<Props> = ({
   }, [store, mode]);
 
   useEffect(() => {
-    setShowRadial(false);
-    if (!mode) return;
+    if (mode === null) return;
     const down = (e: KeyboardEvent) => {
       if (e.code === 'KeyQ') {
         setShowRadial(true);
@@ -280,6 +279,7 @@ const SceneViewer: React.FC<Props> = ({
     return () => {
       window.removeEventListener('keydown', down);
       window.removeEventListener('keyup', up);
+      setShowRadial(false);
     };
   }, [mode]);
 

--- a/tests/sceneViewer.radialMenu.test.tsx
+++ b/tests/sceneViewer.radialMenu.test.tsx
@@ -1,0 +1,92 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import React from 'react';
+import { act } from 'react';
+import ReactDOM from 'react-dom/client';
+import * as THREE from 'three';
+import SceneViewer from '../src/ui/SceneViewer';
+
+const visibleStates: boolean[] = [];
+
+vi.mock('../src/scene/engine', () => {
+  return {
+    setupThree: () => {
+      const dom = document.createElement('canvas');
+      dom.getBoundingClientRect = () => ({
+        left: 0,
+        top: 0,
+        width: 100,
+        height: 100,
+        right: 100,
+        bottom: 100,
+        x: 0,
+        y: 0,
+        toJSON() {},
+      });
+      return {
+        scene: {},
+        camera: {
+          position: { y: 0 },
+          getWorldPosition: () => new THREE.Vector3(),
+          getWorldDirection: () => new THREE.Vector3(0, 0, -1),
+        },
+        renderer: { domElement: dom },
+        controls: { enabled: true, dollyIn: () => {}, dollyOut: () => {}, update: () => {} },
+        playerControls: {
+          lock: vi.fn(),
+          unlock: vi.fn(),
+          addEventListener: vi.fn(),
+          removeEventListener: vi.fn(),
+          isLocked: false,
+        },
+        group: { children: [], add: () => {}, remove: () => {} },
+        cabinetDragger: { enable: vi.fn(), disable: vi.fn() },
+      };
+    },
+  };
+});
+
+vi.mock('../src/ui/components/ItemHotbar', () => ({ default: () => null, hotbarItems: [] }));
+vi.mock('../src/ui/components/TouchJoystick', () => ({ default: () => null }));
+vi.mock('../src/ui/build/RoomBuilder', () => ({ default: () => null }));
+vi.mock('../src/ui/components/RadialMenu', () => ({
+  default: (props: any) => {
+    visibleStates.push(props.visible);
+    return null;
+  },
+}));
+
+describe('SceneViewer RadialMenu visibility', () => {
+  it('shows on Q down and hides on Q up', () => {
+    visibleStates.length = 0;
+    const threeRef: any = { current: null };
+    const setMode = vi.fn();
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = ReactDOM.createRoot(container);
+
+    act(() => {
+      root.render(
+        <SceneViewer
+          threeRef={threeRef}
+          addCountertop={false}
+          mode="build"
+          setMode={setMode}
+        />,
+      );
+    });
+    expect(visibleStates[visibleStates.length - 1]).toBe(false);
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { code: 'KeyQ' }));
+    });
+    expect(visibleStates[visibleStates.length - 1]).toBe(true);
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keyup', { code: 'KeyQ' }));
+    });
+    expect(visibleStates[visibleStates.length - 1]).toBe(false);
+
+    root.unmount();
+  });
+});


### PR DESCRIPTION
## Summary
- Add Q key listeners in SceneViewer to control radial menu visibility
- Pass visibility state to RadialMenu component
- Test that holding and releasing Q shows and hides the radial menu

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c0479aa624832299b5fff7604ab15f