### PR TITLE
Add SceneViewer mode and radial menu tests

### DIFF
--- a/tests/radialMenu.roomBuilder.test.tsx
+++ b/tests/radialMenu.roomBuilder.test.tsx
@@ -1,0 +1,85 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { act } from 'react';
+import * as THREE from 'three';
+import SceneViewer from '../src/ui/SceneViewer';
+import { usePlannerStore } from '../src/state/store';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (s: string) => s }),
+}));
+
+vi.mock('../src/scene/engine', () => {
+  return {
+    setupThree: () => {
+      const dom = document.createElement('canvas');
+      dom.getBoundingClientRect = () => ({
+        left: 0,
+        top: 0,
+        width: 100,
+        height: 100,
+        right: 100,
+        bottom: 100,
+        x: 0,
+        y: 0,
+        toJSON() {},
+      });
+      return {
+        scene: {},
+        camera: {
+          position: { y: 0 },
+          getWorldPosition: () => new THREE.Vector3(),
+          getWorldDirection: () => new THREE.Vector3(0, 0, -1),
+        },
+        renderer: { domElement: dom },
+        controls: { enabled: true, dollyIn: () => {}, dollyOut: () => {}, update: () => {} },
+        playerControls: {
+          lock: vi.fn(),
+          unlock: vi.fn(),
+          addEventListener: vi.fn(),
+          removeEventListener: vi.fn(),
+          isLocked: false,
+        },
+        group: { children: [], add: () => {}, remove: () => {} },
+        cabinetDragger: { enable: vi.fn(), disable: vi.fn() },
+      };
+    },
+  };
+});
+
+describe('RadialMenu integration with RoomBuilder', () => {
+  it('selecting wall adds a wall to the room', () => {
+    const threeRef: any = { current: null };
+    const setMode = vi.fn();
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = ReactDOM.createRoot(container);
+
+    usePlannerStore.setState({
+      selectedTool: null,
+      room: { height: 2700, origin: { x: 0, y: 0 }, walls: [], windows: [], doors: [] },
+    });
+
+    act(() => {
+      root.render(<SceneViewer threeRef={threeRef} addCountertop={false} mode="build" setMode={setMode} />);
+    });
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { code: 'KeyQ' }));
+    });
+
+    const before = usePlannerStore.getState().room.walls.length;
+    const path = document.querySelector('path');
+    expect(path).not.toBeNull();
+
+    act(() => {
+      path!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(usePlannerStore.getState().room.walls.length).toBe(before + 1);
+
+    root.unmount();
+  });
+});

--- a/tests/sceneViewer.mode.test.tsx
+++ b/tests/sceneViewer.mode.test.tsx
@@ -101,6 +101,33 @@ describe('SceneViewer Tab key', () => {
 
     root.unmount();
   });
+
+  it('cycles through modes when active', () => {
+    const threeRef: any = { current: null };
+    let mode: PlayerMode = 'build';
+    const setMode = vi.fn((updater: any) => {
+      mode = typeof updater === 'function' ? updater(mode) : updater;
+    });
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = ReactDOM.createRoot(container);
+
+    act(() => {
+      root.render(
+        <SceneViewer threeRef={threeRef} addCountertop={false} mode={mode} setMode={setMode} />
+      );
+    });
+
+    const expected: PlayerMode[] = ['furnish', 'decorate', 'build'];
+    for (const exp of expected) {
+      act(() => {
+        window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab' }));
+      });
+      expect(mode).toBe(exp);
+    }
+
+    root.unmount();
+  });
 });
 
 describe('SceneViewer hotbar keys', () => {
@@ -112,6 +139,7 @@ describe('SceneViewer hotbar keys', () => {
     const root = ReactDOM.createRoot(container);
 
     const modes: (PlayerMode | null)[] = [null, 'build', 'furnish'];
+    const keys = ['1', '2', '3', '4', '5', '6', '7', '8', '9'];
     for (const m of modes) {
       act(() => {
         usePlannerStore.setState({ selectedItemSlot: 5 });
@@ -121,13 +149,15 @@ describe('SceneViewer hotbar keys', () => {
             addCountertop={false}
             mode={m}
             setMode={setMode}
-          />,
+          />, 
         );
       });
-      act(() => {
-        window.dispatchEvent(new KeyboardEvent('keydown', { key: '1' }));
-      });
-      expect(usePlannerStore.getState().selectedItemSlot).toBe(5);
+      for (const key of keys) {
+        act(() => {
+          window.dispatchEvent(new KeyboardEvent('keydown', { key }));
+        });
+        expect(usePlannerStore.getState().selectedItemSlot).toBe(5);
+      }
     }
 
     root.unmount();


### PR DESCRIPTION
## Summary
- cover Tab-based mode cycling and hotbar inactivity outside decorate
- verify radial menu selections trigger RoomBuilder actions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c043d3b2848322b2552e35f1ae57ae