### PR TITLE
fix: suppress browser Ctrl+W shortcut

### DIFF
--- a/src/scene/engine.ts
+++ b/src/scene/engine.ts
@@ -128,9 +128,8 @@ export function setupThree(container: HTMLElement) {
     'ControlRight',
   ]);
   const onKeyDown = (e: KeyboardEvent) => {
-    if (playerControls.isLocked && e.ctrlKey && e.code === 'KeyW') {
+    if (e.ctrlKey && e.code === 'KeyW') {
       e.preventDefault();
-      e.stopPropagation();
       return;
     }
     if (playerControls.isLocked && movementKeys.has(e.code)) {
@@ -167,6 +166,10 @@ export function setupThree(container: HTMLElement) {
     }
   };
   const onKeyUp = (e: KeyboardEvent) => {
+    if (e.ctrlKey && e.code === 'KeyW') {
+      e.preventDefault();
+      return;
+    }
     if (playerControls.isLocked && movementKeys.has(e.code)) {
       e.preventDefault();
       e.stopPropagation();

--- a/src/ui/SceneViewer.tsx
+++ b/src/ui/SceneViewer.tsx
@@ -251,15 +251,21 @@ const SceneViewer: React.FC<Props> = ({
         e.preventDefault();
         return;
       }
-      const n = Number(e.key);
-      if (n >= 1 && n <= 9) {
-        if (mode === 'decorate') {
-          store.setSelectedItemSlot(n);
+      if (e.type === 'keydown') {
+        const n = Number(e.key);
+        if (n >= 1 && n <= 9) {
+          if (mode === 'decorate') {
+            store.setSelectedItemSlot(n);
+          }
         }
       }
     };
     window.addEventListener('keydown', handleKey);
-    return () => window.removeEventListener('keydown', handleKey);
+    window.addEventListener('keyup', handleKey);
+    return () => {
+      window.removeEventListener('keydown', handleKey);
+      window.removeEventListener('keyup', handleKey);
+    };
   }, [store, mode]);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- handle Ctrl+W globally without stopping propagation so browser doesn't close during gameplay
- extend SceneViewer shortcut handling to cover keyup and ignore number keys on release

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c04e2d21fc8322938c0cabc65d3227