### PR TITLE
feat: extend hotbar to build and furnish modes

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -203,7 +203,10 @@
   "items": {
     "cup": "Cup",
     "plate": "Plate",
-    "bottle": "Bottle"
+    "bottle": "Bottle",
+    "wall": "Wall",
+    "window": "Window",
+    "door": "Door"
   },
   "radial": {
     "wall": "Wall",

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -203,7 +203,10 @@
   "items": {
     "cup": "Kubek",
     "plate": "Talerz",
-    "bottle": "Butelka"
+    "bottle": "Butelka",
+    "wall": "Ściana",
+    "window": "Okno",
+    "door": "Drzwi"
   },
   "radial": {
     "wall": "Ściana",

--- a/src/ui/SceneViewer.tsx
+++ b/src/ui/SceneViewer.tsx
@@ -9,7 +9,11 @@ import { FAMILY } from '../core/catalog';
 import { usePlannerStore, legCategories } from '../state/store';
 import { Module3D, ModuleAdv, Globals } from '../types';
 import { loadItemModel } from '../scene/itemLoader';
-import ItemHotbar, { hotbarItems } from './components/ItemHotbar';
+import ItemHotbar, {
+  hotbarItems,
+  buildHotbarItems,
+  furnishHotbarItems,
+} from './components/ItemHotbar';
 import TouchJoystick from './components/TouchJoystick';
 import { PlayerMode } from './types';
 import RoomBuilder from './build/RoomBuilder';
@@ -77,23 +81,11 @@ const SceneViewer: React.FC<Props> = ({
   const [targetCabinet, setTargetCabinet] = useState<THREE.Object3D | null>(null);
   const ghostRef = useRef<THREE.Object3D | null>(null);
 
-  const buildRadialItems: (string | null)[] = [
-    'wall',
-    'window',
-    'door',
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-  ];
-  const furnishRadialItems: (string | null)[] = Array(9).fill(null);
   const radialItems =
     mode === 'build'
-      ? buildRadialItems
+      ? buildHotbarItems
       : mode === 'furnish'
-        ? furnishRadialItems
+        ? furnishHotbarItems
         : hotbarItems;
 
   const updateGhost = React.useCallback(() => {
@@ -253,10 +245,8 @@ const SceneViewer: React.FC<Props> = ({
       }
       if (e.type === 'keydown') {
         const n = Number(e.key);
-        if (n >= 1 && n <= 9) {
-          if (mode === 'decorate') {
-            store.setSelectedItemSlot(n);
-          }
+        if (n >= 1 && n <= 9 && mode) {
+          store.setSelectedItemSlot(n);
         }
       }
     };
@@ -731,7 +721,7 @@ const SceneViewer: React.FC<Props> = ({
         </button>
       </div>
       {mode === 'build' && <RoomBuilder threeRef={threeRef} />}
-      {mode === 'decorate' && <ItemHotbar mode={mode} />}
+      {mode && <ItemHotbar mode={mode} />}
       {mode && isMobile && (
         <>
           <TouchJoystick

--- a/src/ui/components/ItemHotbar.tsx
+++ b/src/ui/components/ItemHotbar.tsx
@@ -15,6 +15,20 @@ export const hotbarItems: (string | null)[] = [
   null,
 ];
 
+export const buildHotbarItems: (string | null)[] = [
+  'wall',
+  'window',
+  'door',
+  null,
+  null,
+  null,
+  null,
+  null,
+  null,
+];
+
+export const furnishHotbarItems: (string | null)[] = Array(9).fill(null);
+
 interface Props {
   mode: PlayerMode | null;
 }
@@ -23,8 +37,14 @@ const ItemHotbar: React.FC<Props> = ({ mode }) => {
   const { t } = useTranslation();
   const selected = usePlannerStore((s) => s.selectedItemSlot);
   const setSelected = usePlannerStore((s) => s.setSelectedItemSlot);
+  if (!mode) return null;
 
-  if (mode !== 'decorate') return null;
+  const items =
+    mode === 'build'
+      ? buildHotbarItems
+      : mode === 'furnish'
+        ? furnishHotbarItems
+        : hotbarItems;
 
   return (
     <div
@@ -38,7 +58,7 @@ const ItemHotbar: React.FC<Props> = ({ mode }) => {
         padding: 4,
       }}
     >
-      {hotbarItems.map((item, idx) => (
+      {items.map((item, idx) => (
         <div
           key={idx}
           onClick={() => setSelected(idx + 1)}

--- a/tests/sceneViewer.mode.test.tsx
+++ b/tests/sceneViewer.mode.test.tsx
@@ -46,7 +46,12 @@ vi.mock('../src/scene/engine', () => {
   };
 });
 
-vi.mock('../src/ui/components/ItemHotbar', () => ({ default: () => null, hotbarItems: [] }));
+vi.mock('../src/ui/components/ItemHotbar', () => ({
+  default: () => null,
+  hotbarItems: [],
+  buildHotbarItems: [],
+  furnishHotbarItems: [],
+}));
 vi.mock('../src/ui/components/TouchJoystick', () => ({ default: () => null }));
 vi.mock('../src/ui/build/RoomBuilder', () => ({ default: () => null }));
 
@@ -131,14 +136,44 @@ describe('SceneViewer Tab key', () => {
 });
 
 describe('SceneViewer hotbar keys', () => {
-  it('does not change selectedItemSlot when mode is not decorate', () => {
+  it('does not change selectedItemSlot when mode is null', () => {
     const threeRef: any = { current: null };
     const setMode = vi.fn();
     const container = document.createElement('div');
     document.body.appendChild(container);
     const root = ReactDOM.createRoot(container);
 
-    const modes: (PlayerMode | null)[] = [null, 'build', 'furnish'];
+    act(() => {
+      usePlannerStore.setState({ selectedItemSlot: 5 });
+      root.render(
+        <SceneViewer
+          threeRef={threeRef}
+          addCountertop={false}
+          mode={null}
+          setMode={setMode}
+        />,
+      );
+    });
+
+    const keys = ['1', '2', '3', '4', '5', '6', '7', '8', '9'];
+    for (const key of keys) {
+      act(() => {
+        window.dispatchEvent(new KeyboardEvent('keydown', { key }));
+      });
+      expect(usePlannerStore.getState().selectedItemSlot).toBe(5);
+    }
+
+    root.unmount();
+  });
+
+  it('changes selectedItemSlot when mode is active', () => {
+    const threeRef: any = { current: null };
+    const setMode = vi.fn();
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = ReactDOM.createRoot(container);
+
+    const modes: PlayerMode[] = ['build', 'furnish', 'decorate'];
     const keys = ['1', '2', '3', '4', '5', '6', '7', '8', '9'];
     for (const m of modes) {
       act(() => {
@@ -149,14 +184,14 @@ describe('SceneViewer hotbar keys', () => {
             addCountertop={false}
             mode={m}
             setMode={setMode}
-          />, 
+          />,
         );
       });
-      for (const key of keys) {
+      for (let i = 0; i < keys.length; i++) {
         act(() => {
-          window.dispatchEvent(new KeyboardEvent('keydown', { key }));
+          window.dispatchEvent(new KeyboardEvent('keydown', { key: keys[i] }));
         });
-        expect(usePlannerStore.getState().selectedItemSlot).toBe(5);
+        expect(usePlannerStore.getState().selectedItemSlot).toBe(i + 1);
       }
     }
 

--- a/tests/sceneViewer.radialMenu.test.tsx
+++ b/tests/sceneViewer.radialMenu.test.tsx
@@ -46,7 +46,12 @@ vi.mock('../src/scene/engine', () => {
   };
 });
 
-vi.mock('../src/ui/components/ItemHotbar', () => ({ default: () => null, hotbarItems: [] }));
+vi.mock('../src/ui/components/ItemHotbar', () => ({
+  default: () => null,
+  hotbarItems: [],
+  buildHotbarItems: [],
+  furnishHotbarItems: [],
+}));
 vi.mock('../src/ui/components/TouchJoystick', () => ({ default: () => null }));
 vi.mock('../src/ui/build/RoomBuilder', () => ({ default: () => null }));
 vi.mock('../src/ui/components/RadialMenu', () => ({


### PR DESCRIPTION
## Summary
- show number hotbar in build and furnish modes
- add translations for wall/window/door items

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c04ba867c08322befd55770ecb25cf