### PR TITLE
feat: add wall tool selector

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -204,6 +204,8 @@
     "cup": "Cup",
     "plate": "Plate",
     "bottle": "Bottle",
+    "bearingWall": "Load-bearing wall",
+    "partitionWall": "Partition wall",
     "wall": "Wall",
     "window": "Window",
     "door": "Door"
@@ -214,7 +216,9 @@
     "door": "Door",
     "cup": "Cup",
     "plate": "Plate",
-    "bottle": "Bottle"
+    "bottle": "Bottle",
+    "bearing": "Load-bearing",
+    "partition": "Partition"
   },
   "cutlist": {
     "validation": "Validation for sheet {{width}}×{{height}}",

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -151,6 +151,7 @@ type Store = {
   playerSpeed: number;
   selectedItemSlot: number;
   selectedTool: string | null;
+  selectedWall: { kind: 'bearing' | 'partition'; thickness: number } | null;
   itemsByCabinet: (cabinetId: string) => Item[];
   itemsBySurface: (cabinetId: string, surfaceIndex: number) => Item[];
   setRole: (r: 'stolarz' | 'klient') => void;
@@ -179,6 +180,8 @@ type Store = {
   setPlayerSpeed: (v: number) => void;
   setSelectedItemSlot: (slot: number) => void;
   setSelectedTool: (tool: string | null) => void;
+  setSelectedWallKind: (kind: 'bearing' | 'partition') => void;
+  setSelectedWallThickness: (thickness: number) => void;
 };
 
 export const usePlannerStore = create<Store>((set, get) => ({
@@ -216,6 +219,7 @@ export const usePlannerStore = create<Store>((set, get) => ({
   playerSpeed: persisted?.playerSpeed ?? 0.1,
   selectedItemSlot: 1,
   selectedTool: null,
+  selectedWall: null,
   showFronts: true,
   itemsByCabinet: (cabinetId) =>
     get().items.filter((it) => it.cabinetId === cabinetId),
@@ -437,6 +441,21 @@ export const usePlannerStore = create<Store>((set, get) => ({
   setPlayerSpeed: (v) => set({ playerSpeed: v }),
   setSelectedItemSlot: (slot) => set({ selectedItemSlot: slot }),
   setSelectedTool: (tool) => set({ selectedTool: tool }),
+  setSelectedWallKind: (kind) =>
+    set((s) => ({
+      selectedWall: {
+        kind,
+        thickness:
+          s.selectedWall?.thickness ?? (kind === 'bearing' ? 0.3 : 0.1),
+      },
+    })),
+  setSelectedWallThickness: (thickness) =>
+    set((s) => ({
+      selectedWall: {
+        kind: s.selectedWall?.kind ?? 'partition',
+        thickness,
+      },
+    })),
 }));
 
 const persistSelector = (s: Store) => ({

--- a/src/ui/SceneViewer.tsx
+++ b/src/ui/SceneViewer.tsx
@@ -11,9 +11,9 @@ import { Module3D, ModuleAdv, Globals } from '../types';
 import { loadItemModel } from '../scene/itemLoader';
 import ItemHotbar, {
   hotbarItems,
-  buildHotbarItems,
   furnishHotbarItems,
 } from './components/ItemHotbar';
+import WallToolSelector from './components/WallToolSelector';
 import TouchJoystick from './components/TouchJoystick';
 import { PlayerMode } from './types';
 import RoomBuilder from './build/RoomBuilder';
@@ -81,12 +81,31 @@ const SceneViewer: React.FC<Props> = ({
   const [targetCabinet, setTargetCabinet] = useState<THREE.Object3D | null>(null);
   const ghostRef = useRef<THREE.Object3D | null>(null);
 
+  const buildRadialItems: (string | null)[] = [
+    'wall',
+    'window',
+    'door',
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+  ];
+
   const radialItems =
     mode === 'build'
-      ? buildHotbarItems
+      ? buildRadialItems
       : mode === 'furnish'
         ? furnishHotbarItems
         : hotbarItems;
+
+  const wallSubMenu = {
+    items: ['bearing', 'partition'] as (string | null)[],
+    selected: store.selectedWall?.kind === 'bearing' ? 1 : 2,
+    onSelect: (slot: number) =>
+      store.setSelectedWallKind(slot === 1 ? 'bearing' : 'partition'),
+  };
 
   const updateGhost = React.useCallback(() => {
     const three = threeRef.current;
@@ -688,6 +707,7 @@ const SceneViewer: React.FC<Props> = ({
           }
         }}
         visible={showRadial}
+        subMenu={wallSubMenu}
       />
       {mode === null && (
         <div className="zoomControls">
@@ -721,6 +741,7 @@ const SceneViewer: React.FC<Props> = ({
         </button>
       </div>
       {mode === 'build' && <RoomBuilder threeRef={threeRef} />}
+      {mode === 'build' && <WallToolSelector />}
       {mode && <ItemHotbar mode={mode} />}
       {mode && isMobile && (
         <>

--- a/src/ui/components/ItemHotbar.tsx
+++ b/src/ui/components/ItemHotbar.tsx
@@ -15,8 +15,14 @@ export const hotbarItems: (string | null)[] = [
   null,
 ];
 
-export const buildHotbarItems: (string | null)[] = [
-  'wall',
+export const buildHotbarItems = (
+  selectedWall: { kind: 'bearing' | 'partition'; thickness: number } | null,
+): (string | null)[] => [
+  selectedWall
+    ? selectedWall.kind === 'bearing'
+      ? 'bearingWall'
+      : 'partitionWall'
+    : 'wall',
   'window',
   'door',
   null,
@@ -37,11 +43,12 @@ const ItemHotbar: React.FC<Props> = ({ mode }) => {
   const { t } = useTranslation();
   const selected = usePlannerStore((s) => s.selectedItemSlot);
   const setSelected = usePlannerStore((s) => s.setSelectedItemSlot);
+  const selectedWall = usePlannerStore((s) => s.selectedWall);
   if (!mode) return null;
 
   const items =
     mode === 'build'
-      ? buildHotbarItems
+      ? buildHotbarItems(selectedWall)
       : mode === 'furnish'
         ? furnishHotbarItems
         : hotbarItems;

--- a/src/ui/components/RadialMenu.tsx
+++ b/src/ui/components/RadialMenu.tsx
@@ -1,21 +1,34 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 
+interface SubMenu {
+  items: (string | null)[];
+  selected: number;
+  onSelect: (slot: number) => void;
+}
+
 interface Props {
   items: (string | null)[];
   selected: number;
   onSelect: (slot: number) => void;
   visible: boolean;
+  subMenu?: SubMenu;
 }
 
-const RadialMenu: React.FC<Props> = ({ items, selected, onSelect, visible }) => {
+const RadialMenu: React.FC<Props> = ({
+  items,
+  selected,
+  onSelect,
+  visible,
+  subMenu,
+}) => {
   const { t } = useTranslation();
 
   if (!visible) return null;
 
   const size = 200;
   const radius = size / 2;
-  const angle = (2 * Math.PI) / 9;
+  const angle = (2 * Math.PI) / items.length;
 
   return (
     <div
@@ -70,6 +83,63 @@ const RadialMenu: React.FC<Props> = ({ items, selected, onSelect, visible }) => 
           );
         })}
       </svg>
+      {items[selected - 1] === 'wall' && subMenu && (
+        <svg
+          width={size * 1.5}
+          height={size * 1.5}
+          style={{
+            position: 'absolute',
+            top: -(size * 0.25),
+            left: -(size * 0.25),
+            pointerEvents: 'auto',
+          }}
+        >
+          {subMenu.items.map((item, idx) => {
+            const subAngle = (2 * Math.PI) / subMenu.items.length;
+            const subRadius = (size * 1.5) / 2;
+            const start = idx * subAngle - Math.PI / 2;
+            const end = start + subAngle;
+            const x1 = subRadius + subRadius * Math.cos(start);
+            const y1 = subRadius + subRadius * Math.sin(start);
+            const x2 = subRadius + subRadius * Math.cos(end);
+            const y2 = subRadius + subRadius * Math.sin(end);
+            const largeArc = subAngle > Math.PI ? 1 : 0;
+            const path = `M ${subRadius} ${subRadius} L ${x1} ${y1} A ${subRadius} ${subRadius} 0 ${largeArc} 1 ${x2} ${y2} Z`;
+            const mid = start + subAngle / 2;
+            const tx = subRadius + subRadius * 0.6 * Math.cos(mid);
+            const ty = subRadius + subRadius * 0.6 * Math.sin(mid);
+            const label = item ? t(`radial.${item}`) : '';
+            const isSelected = subMenu.selected === idx + 1;
+            return (
+              <g key={idx}>
+                <path
+                  d={path}
+                  fill={
+                    isSelected ? 'rgba(255,255,255,0.3)' : 'rgba(0,0,0,0.3)'
+                  }
+                  stroke="#fff"
+                  onMouseEnter={() => subMenu.onSelect(idx + 1)}
+                  onClick={() => subMenu.onSelect(idx + 1)}
+                  onTouchStart={() => subMenu.onSelect(idx + 1)}
+                />
+                {label && (
+                  <text
+                    x={tx}
+                    y={ty}
+                    fill="#fff"
+                    fontSize={12}
+                    textAnchor="middle"
+                    dominantBaseline="middle"
+                    pointerEvents="none"
+                  >
+                    {label}
+                  </text>
+                )}
+              </g>
+            );
+          })}
+        </svg>
+      )}
     </div>
   );
 };

--- a/src/ui/components/WallToolSelector.tsx
+++ b/src/ui/components/WallToolSelector.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { usePlannerStore } from '../../state/store';
+
+const WallToolSelector: React.FC = () => {
+  const selectedWall = usePlannerStore((s) => s.selectedWall);
+  const setKind = usePlannerStore((s) => s.setSelectedWallKind);
+  const setThickness = usePlannerStore((s) => s.setSelectedWallThickness);
+
+  const kind = selectedWall?.kind ?? 'partition';
+  const thickness = selectedWall?.thickness ?? (kind === 'bearing' ? 0.3 : 0.1);
+  const min = kind === 'bearing' ? 0.2 : 0.05;
+  const max = kind === 'bearing' ? 0.5 : 0.15;
+
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        bottom: 50,
+        left: '50%',
+        transform: 'translateX(-50%)',
+        background: 'rgba(0,0,0,0.6)',
+        color: '#fff',
+        padding: 8,
+        borderRadius: 4,
+        pointerEvents: 'auto',
+      }}
+    >
+      <div style={{ display: 'flex', gap: 8, marginBottom: 8 }}>
+        <button
+          className="btnGhost"
+          onClick={() => setKind('bearing')}
+          style={{
+            background: kind === 'bearing' ? 'rgba(255,255,255,0.3)' : 'transparent',
+          }}
+        >
+          Load-bearing
+        </button>
+        <button
+          className="btnGhost"
+          onClick={() => setKind('partition')}
+          style={{
+            background: kind === 'partition' ? 'rgba(255,255,255,0.3)' : 'transparent',
+          }}
+        >
+          Partition
+        </button>
+      </div>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+        <input
+          type="range"
+          min={min}
+          max={max}
+          step={0.01}
+          value={thickness}
+          onChange={(e) => setThickness(parseFloat(e.target.value))}
+        />
+        <span>{(thickness * 1000).toFixed(0)} mm</span>
+      </div>
+    </div>
+  );
+};
+
+export default WallToolSelector;

--- a/tests/sceneViewer.mode.test.tsx
+++ b/tests/sceneViewer.mode.test.tsx
@@ -49,7 +49,7 @@ vi.mock('../src/scene/engine', () => {
 vi.mock('../src/ui/components/ItemHotbar', () => ({
   default: () => null,
   hotbarItems: [],
-  buildHotbarItems: [],
+  buildHotbarItems: () => [],
   furnishHotbarItems: [],
 }));
 vi.mock('../src/ui/components/TouchJoystick', () => ({ default: () => null }));

--- a/tests/sceneViewer.radialMenu.test.tsx
+++ b/tests/sceneViewer.radialMenu.test.tsx
@@ -49,7 +49,7 @@ vi.mock('../src/scene/engine', () => {
 vi.mock('../src/ui/components/ItemHotbar', () => ({
   default: () => null,
   hotbarItems: [],
-  buildHotbarItems: [],
+  buildHotbarItems: () => [],
   furnishHotbarItems: [],
 }));
 vi.mock('../src/ui/components/TouchJoystick', () => ({ default: () => null }));


### PR DESCRIPTION
## Summary
- support optional submenu in radial menu
- add wall tool selector with kind and thickness controls
- track selected wall in store and compute hotbar label

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c058f13c608322a7884ffe51f741ae