### PR TITLE
Add wall placement on ground click

### DIFF
--- a/src/ui/build/RoomBuilder.tsx
+++ b/src/ui/build/RoomBuilder.tsx
@@ -135,17 +135,20 @@ const RoomBuilder: React.FC<Props> = ({ threeRef }) => {
 
   useEffect(() => {
     if (!selectedTool) return;
-    if (selectedTool === 'wall') {
-      addWall();
-    } else if (selectedTool === 'window') {
+    if (selectedTool === 'window') {
       const lastWall = room.walls[room.walls.length - 1];
-      if (lastWall) addWindow(lastWall.id);
+      if (lastWall) {
+        addWindow(lastWall.id);
+        setSelectedTool(null);
+      }
     } else if (selectedTool === 'door') {
       const lastWall = room.walls[room.walls.length - 1];
-      if (lastWall) addDoor(lastWall.id);
+      if (lastWall) {
+        addDoor(lastWall.id);
+        setSelectedTool(null);
+      }
     }
-    setSelectedTool(null);
-  }, [selectedTool]);
+  }, [selectedTool, room.walls, setSelectedTool]);
 
   return (
     <div

--- a/tests/radialMenu.roomBuilder.test.tsx
+++ b/tests/radialMenu.roomBuilder.test.tsx
@@ -78,6 +78,12 @@ describe('RadialMenu integration with RoomBuilder', () => {
       path!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
 
+    act(() => {
+      window.dispatchEvent(
+        new MouseEvent('pointerdown', { clientX: 10, clientY: 10 }),
+      );
+    });
+
     expect(usePlannerStore.getState().room.walls.length).toBe(before + 1);
 
     root.unmount();


### PR DESCRIPTION
## Summary
- place walls by clicking the ground when the wall tool is selected
- stop auto-adding walls on tool selection, keeping existing window and door behavior
- adjust radial menu test for click-to-place walls

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c05c783f4083229d566f4ba8e9e7d0