### PR TITLE
Enable interactive wall drawing with preview

### DIFF
--- a/tests/radialMenu.roomBuilder.test.tsx
+++ b/tests/radialMenu.roomBuilder.test.tsx
@@ -82,6 +82,12 @@ describe('RadialMenu integration with RoomBuilder', () => {
       window.dispatchEvent(
         new MouseEvent('pointerdown', { clientX: 10, clientY: 10 }),
       );
+      window.dispatchEvent(
+        new MouseEvent('pointermove', { clientX: 50, clientY: 10 }),
+      );
+      window.dispatchEvent(
+        new MouseEvent('pointerup', { clientX: 50, clientY: 10 }),
+      );
     });
 
     expect(usePlannerStore.getState().room.walls.length).toBe(before + 1);


### PR DESCRIPTION
## Summary
- Track pointer events in RoomBuilder to draw walls by dragging
- Show a preview wall mesh that updates with cursor position
- Create new wall on release and reset tool
- Update integration test for drag-based wall creation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c05e9fb760832287b73481542f7473