### PR TITLE
Avoid capturing shortcuts when SceneViewer mode is inactive

### DIFF
--- a/src/ui/SceneViewer.tsx
+++ b/src/ui/SceneViewer.tsx
@@ -257,14 +257,16 @@ const SceneViewer: React.FC<Props> = ({
   }, [threeRef]);
 
   useEffect(() => {
+    if (!mode) return;
     const handleKey = (e: KeyboardEvent) => {
+      if (!mode) return;
       if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'w') {
         e.preventDefault();
         return;
       }
       if (e.type === 'keydown') {
         const n = Number(e.key);
-        if (n >= 1 && n <= 9 && mode) {
+        if (n >= 1 && n <= 9) {
           store.setSelectedItemSlot(n);
         }
       }


### PR DESCRIPTION
## Summary
- Stop blocking system shortcuts when SceneViewer mode is inactive
- Register keyboard listeners only when a mode is active

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c07b90646083229d76abbed36208af