### PR TITLE
refactor: centralize player modes

### DIFF
--- a/src/ui/SceneViewer.tsx
+++ b/src/ui/SceneViewer.tsx
@@ -16,7 +16,7 @@ import ItemHotbar, {
 } from './components/ItemHotbar';
 import WallToolSelector from './components/WallToolSelector';
 import TouchJoystick from './components/TouchJoystick';
-import { PlayerMode } from './types';
+import { PlayerMode, PlayerSubMode, PLAYER_MODES } from './types';
 import RoomBuilder from './build/RoomBuilder';
 import RadialMenu from './components/RadialMenu';
 
@@ -53,6 +53,11 @@ interface Props {
 
 const INTERACT_DISTANCE = 1.5;
 const PLATE_HEIGHT = 0.02;
+const MODE_ICONS: Record<PlayerSubMode, string> = {
+  build: '🔨',
+  furnish: '🪑',
+  decorate: '🎨',
+};
 
 export const getLegHeight = (mod: Module3D, globals: Globals): number => {
   if (mod.family !== FAMILY.BASE) return 0;
@@ -306,9 +311,8 @@ const SceneViewer: React.FC<Props> = ({
       if (e.key !== 'Tab') return;
       e.preventDefault();
       setMode((m) => {
-        const modes: PlayerMode[] = ['build', 'furnish', 'decorate'];
-        const idx = modes.indexOf(m ?? 'decorate');
-        return modes[(idx + 1) % modes.length];
+        const idx = PLAYER_MODES.indexOf(m as PlayerSubMode);
+        return PLAYER_MODES[(idx + 1) % PLAYER_MODES.length];
       });
     };
     window.addEventListener('keydown', handleTab);
@@ -814,19 +818,13 @@ const SceneViewer: React.FC<Props> = ({
       )}
       {isMobile && (
         <div className="modeBar">
-          {(
-            [
-              { key: 'build', label: '🔨' },
-              { key: 'furnish', label: '🪑' },
-              { key: 'decorate', label: '🎨' },
-            ] as { key: PlayerMode; label: string }[]
-          ).map(({ key, label }) => (
+          {PLAYER_MODES.map((key) => (
             <div
               key={key}
               className={`modeItem${mode === key ? ' active' : ''}`}
               onClick={() => setMode(key)}
             >
-              {label}
+              {MODE_ICONS[key]}
             </div>
           ))}
           <div

--- a/src/ui/panels/PlayPanel.tsx
+++ b/src/ui/panels/PlayPanel.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import { usePlannerStore } from '../../state/store';
-import { PlayerMode } from '../types';
-
-type PlayerSubMode = Exclude<PlayerMode, null>;
+import { PlayerMode, PlayerSubMode, PLAYER_MODES } from '../types';
 
 interface Props {
   threeRef: React.MutableRefObject<any>;
@@ -66,13 +64,7 @@ export default function PlayPanel({
           />
         </div>
         <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
-          {(
-            [
-              { key: 'build', label: t('play.mode.build') },
-              { key: 'furnish', label: t('play.mode.furnish') },
-              { key: 'decorate', label: t('play.mode.decorate') },
-            ] as { key: PlayerSubMode; label: string }[]
-          ).map(({ key, label }) => (
+          {PLAYER_MODES.map((key) => (
             <button
               key={key}
               className="btnGhost"
@@ -83,7 +75,7 @@ export default function PlayPanel({
               }
               onClick={() => setStartMode(key)}
             >
-              {label}
+              {t(`play.mode.${key}`)}
             </button>
           ))}
         </div>

--- a/src/ui/types.ts
+++ b/src/ui/types.ts
@@ -35,4 +35,6 @@ export interface CabinetConfig {
   legs?: { type: string; height: number; category?: string; legsOffset?: number };
 }
 
-export type PlayerMode = 'build' | 'furnish' | 'decorate' | null;
+export const PLAYER_MODES = ['build', 'furnish', 'decorate'] as const;
+export type PlayerSubMode = (typeof PLAYER_MODES)[number];
+export type PlayerMode = PlayerSubMode | null;

--- a/tests/sceneViewer.mode.test.tsx
+++ b/tests/sceneViewer.mode.test.tsx
@@ -6,7 +6,7 @@ import ReactDOM from 'react-dom/client';
 import * as THREE from 'three';
 import SceneViewer from '../src/ui/SceneViewer';
 import { usePlannerStore } from '../src/state/store';
-import { PlayerMode } from '../src/ui/types';
+import { PlayerMode, PLAYER_MODES } from '../src/ui/types';
 
 vi.mock('../src/scene/engine', () => {
   return {
@@ -109,7 +109,7 @@ describe('SceneViewer Tab key', () => {
 
   it('cycles through modes when active', () => {
     const threeRef: any = { current: null };
-    let mode: PlayerMode = 'build';
+    let mode: PlayerMode = PLAYER_MODES[0];
     const setMode = vi.fn((updater: any) => {
       mode = typeof updater === 'function' ? updater(mode) : updater;
     });
@@ -123,7 +123,7 @@ describe('SceneViewer Tab key', () => {
       );
     });
 
-    const expected: PlayerMode[] = ['furnish', 'decorate', 'build'];
+    const expected: PlayerMode[] = PLAYER_MODES.slice(1).concat(PLAYER_MODES[0]);
     for (const exp of expected) {
       act(() => {
         window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab' }));
@@ -173,7 +173,7 @@ describe('SceneViewer hotbar keys', () => {
     document.body.appendChild(container);
     const root = ReactDOM.createRoot(container);
 
-    const modes: PlayerMode[] = ['build', 'furnish', 'decorate'];
+    const modes = PLAYER_MODES;
     const keys = ['1', '2', '3', '4', '5', '6', '7', '8', '9'];
     for (const m of modes) {
       act(() => {


### PR DESCRIPTION
## Summary
- define PLAYER_MODES constant centralizing play modes
- use PLAYER_MODES for Tab cycling and mobile bar in SceneViewer
- generate play mode buttons in PlayPanel from PLAYER_MODES
- update tests to reference new constant

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c07c7a5e108322a1de81f35fdc4062