### PR TITLE
feat: unify player control locking across platforms

### DIFF
--- a/src/scene/engine.ts
+++ b/src/scene/engine.ts
@@ -46,6 +46,20 @@ export function setupThree(container: HTMLElement) {
   controls.enableDamping = true;
 
   const playerControls = new PointerLockControls(camera, renderer.domElement);
+  const isMobile =
+    typeof window !== 'undefined' &&
+    ('ontouchstart' in window ||
+      (typeof navigator !== 'undefined' && navigator.maxTouchPoints > 0));
+  if (isMobile) {
+    (playerControls as any).lock = () => {
+      (playerControls as any).isLocked = true;
+      playerControls.dispatchEvent({ type: 'lock' });
+    };
+    (playerControls as any).unlock = () => {
+      (playerControls as any).isLocked = false;
+      playerControls.dispatchEvent({ type: 'unlock' });
+    };
+  }
 
   const cabinetDragger = new CabinetDragger(
     renderer,

--- a/src/ui/SceneViewer.tsx
+++ b/src/ui/SceneViewer.tsx
@@ -214,32 +214,20 @@ const SceneViewer: React.FC<Props> = ({
     if (mode === 'furnish') {
       three.controls.enabled = false;
       three.cabinetDragger.enable();
-      if (isMobile) {
-        (three.playerControls as any).isLocked = true;
-      } else {
-        three.playerControls.lock();
-      }
+      three.playerControls.lock();
       three.camera.position.y = store.playerHeight;
     } else {
       three.cabinetDragger.disable();
       if (mode) {
         three.controls.enabled = false;
-        if (isMobile) {
-          (three.playerControls as any).isLocked = true;
-        } else {
-          three.playerControls.lock();
-        }
+        three.playerControls.lock();
         three.camera.position.y = store.playerHeight;
       } else {
-        if (isMobile) {
-          (three.playerControls as any).isLocked = false;
-        } else {
-          three.playerControls.unlock();
-        }
+        three.playerControls.unlock();
         three.controls.enabled = true;
       }
     }
-  }, [mode, threeRef, store.playerHeight, isMobile]);
+  }, [mode, threeRef, store.playerHeight]);
 
   useEffect(() => {
     threeRef.current?.setPlayerParams?.({


### PR DESCRIPTION
## Summary
- use lock/unlock methods in SceneViewer instead of toggling isLocked
- add mobile polyfill for PointerLockControls lock/unlock

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c07f3b70a48322992779e9d5e08787