### PR TITLE
feat: add room tab

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -25,11 +25,18 @@
       "costs": "Costs",
       "cut": "Cutlist",
       "global": "Settings",
-      "play": "Play"
+      "play": "Play",
+      "room": "Room"
     },
     "cabinetType": "Cabinet type",
     "subcategories": "Subcategories ({{family}})",
     "variant": "Variant"
+  },
+  "room": {
+    "walls": "Walls",
+    "windowsDoors": "Windows and doors",
+    "decor": "Decorative elements",
+    "draw": "Draw"
   },
   "catalog": {
     "choose": "Choose"

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -25,11 +25,18 @@
       "costs": "Koszty",
       "cut": "Formatki",
       "global": "Ustawienia",
-      "play": "Play"
+      "play": "Play",
+      "room": "Pomieszczenie"
     },
     "cabinetType": "Typ szafki",
     "subcategories": "Podkategorie ({{family}})",
     "variant": "Wariant"
+  },
+  "room": {
+    "walls": "Ściany",
+    "windowsDoors": "Okna i drzwi",
+    "decor": "Elementy dekoracyjne",
+    "draw": "Rysuj"
   },
   "catalog": {
     "choose": "Wybierz"

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -38,7 +38,7 @@ export default function App() {
     initSidePanel,
   } = useCabinetConfig(family, kind, variant, setVariant);
 
-  const [tab, setTab] = useState<'cab' | 'costs' | 'cut' | 'global' | 'play' | null>(null);
+  const [tab, setTab] = useState<'cab' | 'costs' | 'cut' | 'global' | 'play' | 'room' | null>(null);
   const [boardL, setBoardL] = useState(2800);
   const [boardW, setBoardW] = useState(2070);
   const [boardKerf, setBoardKerf] = useState(3);

--- a/src/ui/MainTabs.tsx
+++ b/src/ui/MainTabs.tsx
@@ -9,11 +9,12 @@ import { CabinetConfig, PlayerMode } from './types';
 import SlidingPanel from './components/SlidingPanel';
 import GlobalSettings from './panels/GlobalSettings';
 import PlayPanel from './panels/PlayPanel';
+import RoomPanel from './panels/RoomPanel';
 
 interface MainTabsProps {
   t: (key: string, opts?: any) => string;
-  tab: 'cab' | 'costs' | 'cut' | 'global' | 'play' | null;
-  setTab: (t: 'cab' | 'costs' | 'cut' | 'global' | 'play' | null) => void;
+  tab: 'cab' | 'costs' | 'cut' | 'global' | 'play' | 'room' | null;
+  setTab: (t: 'cab' | 'costs' | 'cut' | 'global' | 'play' | 'room' | null) => void;
   family: FAMILY;
   setFamily: (f: FAMILY) => void;
   kind: Kind | null;
@@ -80,7 +81,9 @@ export default function MainTabs({
   startMode,
   setStartMode,
 }: MainTabsProps) {
-  const toggleTab = (name: 'cab' | 'costs' | 'cut' | 'global' | 'play') => {
+  const toggleTab = (
+    name: 'cab' | 'costs' | 'cut' | 'global' | 'play' | 'room',
+  ) => {
     setTab(tab === name ? null : name);
   };
 
@@ -101,6 +104,9 @@ export default function MainTabs({
         </button>
         <button className={`tabBtn ${tab === 'play' ? 'active' : ''}`} onClick={() => toggleTab('play')}>
           {t('app.tabs.play')}
+        </button>
+        <button className={`tabBtn ${tab === 'room' ? 'active' : ''}`} onClick={() => toggleTab('room')}>
+          {t('app.tabs.room')}
         </button>
       </div>
 
@@ -213,6 +219,7 @@ export default function MainTabs({
             onClose={() => setTab(null)}
           />
         )}
+        {tab === 'room' && <RoomPanel />}
       </SlidingPanel>
     </>
   );

--- a/src/ui/panels/RoomPanel.tsx
+++ b/src/ui/panels/RoomPanel.tsx
@@ -1,0 +1,55 @@
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+export default function RoomPanel() {
+  const { t } = useTranslation();
+  const [wallsOpen, setWallsOpen] = useState(false);
+  const [windowsOpen, setWindowsOpen] = useState(false);
+  const [decorOpen, setDecorOpen] = useState(false);
+
+  const Section = ({
+    title,
+    open,
+    setOpen,
+  }: {
+    title: string;
+    open: boolean;
+    setOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  }) => (
+    <div className="section">
+      <div className="hd" onClick={() => setOpen((o) => !o)}>
+        <div>
+          <div className="h1">{title}</div>
+        </div>
+        <button className="btnGhost">
+          {open ? t('global.collapse') : t('global.expand')}
+        </button>
+      </div>
+      {open && (
+        <div className="bd">
+          <button className="btnGhost">{t('room.draw')}</button>
+        </div>
+      )}
+    </div>
+  );
+
+  return (
+    <>
+      <Section
+        title={t('room.walls')}
+        open={wallsOpen}
+        setOpen={setWallsOpen}
+      />
+      <Section
+        title={t('room.windowsDoors')}
+        open={windowsOpen}
+        setOpen={setWindowsOpen}
+      />
+      <Section
+        title={t('room.decor')}
+        open={decorOpen}
+        setOpen={setDecorOpen}
+      />
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- support a new "Room" tab in app state
- add Room tab with collapsible RoomPanel sections
- provide English and Polish translations for room features

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c086b07ae88322ad19836734af4204