### PR TITLE
Simplify wall tool to thickness-only

### DIFF
--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -151,7 +151,7 @@ type Store = {
   playerSpeed: number;
   selectedItemSlot: number;
   selectedTool: string | null;
-  selectedWall: { kind: 'bearing' | 'partition'; thickness: number } | null;
+  selectedWall: { thickness: number } | null;
   isRoomDrawing: boolean;
   itemsByCabinet: (cabinetId: string) => Item[];
   itemsBySurface: (cabinetId: string, surfaceIndex: number) => Item[];
@@ -181,7 +181,6 @@ type Store = {
   setPlayerSpeed: (v: number) => void;
   setSelectedItemSlot: (slot: number) => void;
   setSelectedTool: (tool: string | null) => void;
-  setSelectedWallKind: (kind: 'bearing' | 'partition') => void;
   setSelectedWallThickness: (thickness: number) => void;
   setIsRoomDrawing: (v: boolean) => void;
 };
@@ -453,21 +452,10 @@ export const usePlannerStore = create<Store>((set, get) => ({
   setPlayerSpeed: (v) => set({ playerSpeed: v }),
   setSelectedItemSlot: (slot) => set({ selectedItemSlot: slot }),
   setSelectedTool: (tool) => set({ selectedTool: tool }),
-  setSelectedWallKind: (kind) =>
-    set((s) => ({
-      selectedWall: {
-        kind,
-        thickness:
-          s.selectedWall?.thickness ?? (kind === 'bearing' ? 0.3 : 0.1),
-      },
-    })),
   setSelectedWallThickness: (thickness) =>
-    set((s) => ({
-      selectedWall: {
-        kind: s.selectedWall?.kind ?? 'partition',
-        thickness: clamp(thickness, 0.08, 0.25),
-      },
-    })),
+    set({
+      selectedWall: { thickness: clamp(thickness, 0.08, 0.25) },
+    }),
   setIsRoomDrawing: (v) => set({ isRoomDrawing: v }),
 }));
 

--- a/src/ui/SceneViewer.tsx
+++ b/src/ui/SceneViewer.tsx
@@ -91,28 +91,19 @@ const SceneViewer: React.FC<Props> = ({
 
   const radialItems =
     mode === 'build'
-      ? buildHotbarItems(store.selectedWall)
+      ? buildHotbarItems()
       : mode === 'furnish'
         ? furnishHotbarItems
         : hotbarItems;
 
-  const wallSubMenu = {
-    items: ['bearing', 'partition'] as (string | null)[],
-    selected: store.selectedWall?.kind === 'bearing' ? 1 : 2,
-    onSelect: (slot: number) =>
-      store.setSelectedWallKind(slot === 1 ? 'bearing' : 'partition'),
-  };
-
   useEffect(() => {
     if (mode === 'build') {
-      const tool = buildHotbarItems(store.selectedWall)[
-        store.selectedItemSlot - 1
-      ];
+      const tool = buildHotbarItems()[store.selectedItemSlot - 1];
       if (store.selectedTool !== tool) store.setSelectedTool(tool);
     } else if (store.selectedTool) {
       store.setSelectedTool(null);
     }
-  }, [mode, store.selectedItemSlot, store.selectedWall, store.selectedTool]);
+  }, [mode, store.selectedItemSlot, store.selectedTool]);
 
   useEffect(() => {
     const three = threeRef.current;
@@ -778,7 +769,6 @@ const SceneViewer: React.FC<Props> = ({
           }
         }}
         visible={showRadial}
-        subMenu={wallSubMenu}
       />
       {mode === null && (
         <div className="zoomControls">

--- a/src/ui/components/ItemHotbar.tsx
+++ b/src/ui/components/ItemHotbar.tsx
@@ -15,14 +15,8 @@ export const hotbarItems: (string | null)[] = [
   null,
 ];
 
-export const buildHotbarItems = (
-  selectedWall: { kind: 'bearing' | 'partition'; thickness: number } | null,
-): (string | null)[] => [
-  selectedWall
-    ? selectedWall.kind === 'bearing'
-      ? 'bearingWall'
-      : 'partitionWall'
-    : 'wall',
+export const buildHotbarItems = (): (string | null)[] => [
+  'wall',
   'window',
   'door',
   null,
@@ -43,12 +37,11 @@ const ItemHotbar: React.FC<Props> = ({ mode }) => {
   const { t } = useTranslation();
   const selected = usePlannerStore((s) => s.selectedItemSlot);
   const setSelected = usePlannerStore((s) => s.setSelectedItemSlot);
-  const selectedWall = usePlannerStore((s) => s.selectedWall);
   if (!mode) return null;
 
   const items =
     mode === 'build'
-      ? buildHotbarItems(selectedWall)
+      ? buildHotbarItems()
       : mode === 'furnish'
         ? furnishHotbarItems
         : hotbarItems;

--- a/src/ui/components/WallToolSelector.tsx
+++ b/src/ui/components/WallToolSelector.tsx
@@ -2,14 +2,9 @@ import React from 'react';
 import { usePlannerStore } from '../../state/store';
 
 const WallToolSelector: React.FC = () => {
-  const selectedWall = usePlannerStore((s) => s.selectedWall);
-  const setKind = usePlannerStore((s) => s.setSelectedWallKind);
+  const thickness =
+    usePlannerStore((s) => s.selectedWall?.thickness) ?? 0.1;
   const setThickness = usePlannerStore((s) => s.setSelectedWallThickness);
-
-  const kind = selectedWall?.kind ?? 'partition';
-  const thickness = selectedWall?.thickness ?? (kind === 'bearing' ? 0.3 : 0.1);
-  const min = kind === 'bearing' ? 0.2 : 0.05;
-  const max = kind === 'bearing' ? 0.5 : 0.15;
 
   return (
     <div
@@ -25,31 +20,11 @@ const WallToolSelector: React.FC = () => {
         pointerEvents: 'auto',
       }}
     >
-      <div style={{ display: 'flex', gap: 8, marginBottom: 8 }}>
-        <button
-          className="btnGhost"
-          onClick={() => setKind('bearing')}
-          style={{
-            background: kind === 'bearing' ? 'rgba(255,255,255,0.3)' : 'transparent',
-          }}
-        >
-          Load-bearing
-        </button>
-        <button
-          className="btnGhost"
-          onClick={() => setKind('partition')}
-          style={{
-            background: kind === 'partition' ? 'rgba(255,255,255,0.3)' : 'transparent',
-          }}
-        >
-          Partition
-        </button>
-      </div>
       <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
         <input
           type="range"
-          min={min}
-          max={max}
+          min={0.08}
+          max={0.25}
           step={0.01}
           value={thickness}
           onChange={(e) => setThickness(parseFloat(e.target.value))}

--- a/tests/radialMenu.roomBuilder.test.tsx
+++ b/tests/radialMenu.roomBuilder.test.tsx
@@ -59,6 +59,7 @@ describe('RadialMenu integration with RoomBuilder', () => {
 
     usePlannerStore.setState({
       selectedTool: null,
+      selectedWall: { thickness: 0.1 },
       room: { height: 2700, origin: { x: 0, y: 0 }, walls: [], windows: [], doors: [] },
     });
 

--- a/tests/sceneViewer.radialMenu.selection.test.tsx
+++ b/tests/sceneViewer.radialMenu.selection.test.tsx
@@ -66,7 +66,11 @@ describe('SceneViewer radial menu selection', () => {
     const root = ReactDOM.createRoot(container);
 
     act(() => {
-      usePlannerStore.setState({ selectedItemSlot: 1, selectedTool: null, selectedWall: null });
+      usePlannerStore.setState({
+        selectedItemSlot: 1,
+        selectedTool: null,
+        selectedWall: { thickness: 0.1 },
+      });
       root.render(
         <SceneViewer threeRef={threeRef} addCountertop={false} mode="build" setMode={setMode} />,
       );


### PR DESCRIPTION
## Summary
- track only wall thickness in store and remove wall type kind
- streamline UI with single wall thickness slider and hotbar always showing "wall"
- drop wall type submenu and adjust tests for new API

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c08abf77b083228e3475a95ac42920