### PR TITLE
feat: expand room editing tools

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -36,7 +36,12 @@
     "walls": "Walls",
     "windowsDoors": "Windows and doors",
     "decor": "Decorative elements",
-    "draw": "Draw"
+    "draw": "Draw",
+    "addWindow": "Add window",
+    "addDoor": "Add door",
+    "addDecor": "Add decoration",
+    "noWindows": "No windows or doors",
+    "noDecor": "No decorations"
   },
   "catalog": {
     "choose": "Choose"

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -36,7 +36,12 @@
     "walls": "Ściany",
     "windowsDoors": "Okna i drzwi",
     "decor": "Elementy dekoracyjne",
-    "draw": "Rysuj"
+    "draw": "Rysuj",
+    "addWindow": "Dodaj okno",
+    "addDoor": "Dodaj drzwi",
+    "addDecor": "Dodaj dekorację",
+    "noWindows": "Brak okien lub drzwi",
+    "noDecor": "Brak dekoracji"
   },
   "catalog": {
     "choose": "Wybierz"

--- a/src/ui/SceneViewer.tsx
+++ b/src/ui/SceneViewer.tsx
@@ -97,8 +97,14 @@ const SceneViewer: React.FC<Props> = ({
         : hotbarItems;
 
   useEffect(() => {
-    if (mode === 'build') {
-      const tool = buildHotbarItems()[store.selectedItemSlot - 1];
+    const items =
+      mode === 'build'
+        ? buildHotbarItems()
+        : mode === 'furnish'
+          ? furnishHotbarItems
+          : hotbarItems;
+    const tool = items[store.selectedItemSlot - 1];
+    if (tool === 'wall' || tool === 'window' || tool === 'door') {
       if (store.selectedTool !== tool) store.setSelectedTool(tool);
     } else if (store.selectedTool) {
       store.setSelectedTool(null);
@@ -268,9 +274,7 @@ const SceneViewer: React.FC<Props> = ({
     }, [threeRef, mode]);
 
   useEffect(() => {
-    if (!mode) return;
     const handleKey = (e: KeyboardEvent) => {
-      if (!mode) return;
       if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'w') {
         e.preventDefault();
         return;
@@ -288,7 +292,7 @@ const SceneViewer: React.FC<Props> = ({
       window.removeEventListener('keydown', handleKey);
       window.removeEventListener('keyup', handleKey);
     };
-  }, [store, mode]);
+  }, [store]);
 
   useEffect(() => {
     if (mode === null) return;
@@ -762,8 +766,9 @@ const SceneViewer: React.FC<Props> = ({
         selected={store.selectedItemSlot}
         onSelect={(slot) => {
           store.setSelectedItemSlot(slot);
-          if (mode === 'build') {
-            store.setSelectedTool(radialItems[slot - 1]);
+          const tool = radialItems[slot - 1];
+          if (tool === 'wall' || tool === 'window' || tool === 'door') {
+            store.setSelectedTool(tool);
           } else {
             store.setSelectedTool(null);
           }
@@ -803,7 +808,7 @@ const SceneViewer: React.FC<Props> = ({
       </div>
       {mode === 'build' && isRoomDrawing && <RoomBuilder threeRef={threeRef} />}
       {mode === 'build' && !isRoomDrawing && <WallToolSelector />}
-      {mode && <ItemHotbar mode={mode} />}
+      <ItemHotbar mode={mode} />
       {mode && isMobile && (
         <>
           <TouchJoystick

--- a/src/ui/components/ItemHotbar.tsx
+++ b/src/ui/components/ItemHotbar.tsx
@@ -4,11 +4,11 @@ import { usePlannerStore } from '../../state/store';
 import { PlayerMode } from '../types';
 
 export const hotbarItems: (string | null)[] = [
+  'window',
+  'door',
   'cup',
   'plate',
   'bottle',
-  null,
-  null,
   null,
   null,
   null,
@@ -19,9 +19,9 @@ export const buildHotbarItems = (): (string | null)[] => [
   'wall',
   'window',
   'door',
-  null,
-  null,
-  null,
+  'cup',
+  'plate',
+  'bottle',
   null,
   null,
   null,
@@ -37,7 +37,6 @@ const ItemHotbar: React.FC<Props> = ({ mode }) => {
   const { t } = useTranslation();
   const selected = usePlannerStore((s) => s.selectedItemSlot);
   const setSelected = usePlannerStore((s) => s.setSelectedItemSlot);
-  if (!mode) return null;
 
   const items =
     mode === 'build'

--- a/src/ui/panels/RoomPanel.tsx
+++ b/src/ui/panels/RoomPanel.tsx
@@ -34,6 +34,9 @@ export default function RoomPanel() {
 
   const room = usePlannerStore((s) => s.room);
   const setRoom = usePlannerStore((s) => s.setRoom);
+  const windows = usePlannerStore((s) => s.room.windows);
+  const doors = usePlannerStore((s) => s.room.doors);
+  const items = usePlannerStore((s) => s.items);
   const wallThickness =
     usePlannerStore((s) => s.selectedWall?.thickness) ?? 0.1;
   const setThickness = usePlannerStore((s) => s.setSelectedWallThickness);
@@ -90,12 +93,46 @@ export default function RoomPanel() {
         title={t('room.windowsDoors')}
         open={windowsOpen}
         setOpen={setWindowsOpen}
-      />
+      >
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+          <div>
+            {windows.length + doors.length === 0 ? (
+              <div>{t('room.noWindows')}</div>
+            ) : (
+              <ul>
+                {windows.map((_, idx) => (
+                  <li key={`w-${idx}`}>{t('items.window')} {idx + 1}</li>
+                ))}
+                {doors.map((_, idx) => (
+                  <li key={`d-${idx}`}>{t('items.door')} {idx + 1}</li>
+                ))}
+              </ul>
+            )}
+            <div style={{ display: 'flex', gap: 4 }}>
+              <button className="btnGhost">{t('room.addWindow')}</button>
+              <button className="btnGhost">{t('room.addDoor')}</button>
+            </div>
+          </div>
+        </div>
+      </Section>
       <Section
         title={t('room.decor')}
         open={decorOpen}
         setOpen={setDecorOpen}
-      />
+      >
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+          {items.length === 0 ? (
+            <div>{t('room.noDecor')}</div>
+          ) : (
+            <ul>
+              {items.map((it) => (
+                <li key={it.id}>{t(`items.${it.type}`)}</li>
+              ))}
+            </ul>
+          )}
+          <button className="btnGhost">{t('room.addDecor')}</button>
+        </div>
+      </Section>
     </>
   );
 }

--- a/tests/sceneViewer.mode.test.tsx
+++ b/tests/sceneViewer.mode.test.tsx
@@ -136,7 +136,7 @@ describe('SceneViewer Tab key', () => {
 });
 
 describe('SceneViewer hotbar keys', () => {
-  it('does not change selectedItemSlot when mode is null', () => {
+  it('changes selectedItemSlot when mode is null', () => {
     const threeRef: any = { current: null };
     const setMode = vi.fn();
     const container = document.createElement('div');
@@ -156,11 +156,11 @@ describe('SceneViewer hotbar keys', () => {
     });
 
     const keys = ['1', '2', '3', '4', '5', '6', '7', '8', '9'];
-    for (const key of keys) {
+    for (let i = 0; i < keys.length; i++) {
       act(() => {
-        window.dispatchEvent(new KeyboardEvent('keydown', { key }));
+        window.dispatchEvent(new KeyboardEvent('keydown', { key: keys[i] }));
       });
-      expect(usePlannerStore.getState().selectedItemSlot).toBe(5);
+      expect(usePlannerStore.getState().selectedItemSlot).toBe(i + 1);
     }
 
     root.unmount();

--- a/tests/sceneViewer.radialMenu.selection.test.tsx
+++ b/tests/sceneViewer.radialMenu.selection.test.tsx
@@ -52,8 +52,8 @@ vi.mock('../src/ui/components/RadialMenu', () => ({
 
 vi.mock('../src/ui/components/ItemHotbar', () => ({
   default: () => null,
-  hotbarItems: ['cup', null, null, null, null, null, null, null, null],
-  buildHotbarItems: () => ['wall', 'window', 'door', null, null, null, null, null, null],
+  hotbarItems: ['window', 'door', 'cup', 'plate', 'bottle', null, null, null, null],
+  buildHotbarItems: () => ['wall', 'window', 'door', 'cup', 'plate', 'bottle', null, null, null],
   furnishHotbarItems: ['chair', null, null, null, null, null, null, null, null],
 }));
 


### PR DESCRIPTION
## Summary
- show placeholder lists for windows, doors and decor in Room panel
- drive radial menu tool selection from store and keep hotbar keys active outside player mode
- expose window, door and decor slots on the hotbar in all modes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c08c6912648322a01bd812a774fc3d