### PR TITLE
Expose room controls in build and play panels

### DIFF
--- a/src/ui/SceneViewer.tsx
+++ b/src/ui/SceneViewer.tsx
@@ -19,6 +19,7 @@ import TouchJoystick from './components/TouchJoystick';
 import { PlayerMode, PlayerSubMode, PLAYER_MODES } from './types';
 import RoomBuilder from './build/RoomBuilder';
 import RadialMenu from './components/RadialMenu';
+import RoomPanel from './panels/RoomPanel';
 
 interface ThreeContext {
   scene: THREE.Scene;
@@ -808,6 +809,11 @@ const SceneViewer: React.FC<Props> = ({
       </div>
       {mode === 'build' && isRoomDrawing && <RoomBuilder threeRef={threeRef} />}
       {mode === 'build' && !isRoomDrawing && <WallToolSelector />}
+      {mode === 'build' && (
+        <div style={{ position: 'absolute', top: 60, left: 10 }}>
+          <RoomPanel />
+        </div>
+      )}
       <ItemHotbar mode={mode} />
       {mode && isMobile && (
         <>

--- a/src/ui/panels/PlayPanel.tsx
+++ b/src/ui/panels/PlayPanel.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { usePlannerStore } from '../../state/store';
 import { PlayerMode, PlayerSubMode, PLAYER_MODES } from '../types';
+import RoomPanel from './RoomPanel';
 
 interface Props {
   threeRef: React.MutableRefObject<any>;
@@ -38,57 +39,60 @@ export default function PlayPanel({
   };
 
   return (
-    <div className="section">
-      <div className="hd">
-        <div><div className="h1">{t('app.tabs.play')}</div></div>
+    <>
+      <div className="section">
+        <div className="hd">
+          <div><div className="h1">{t('app.tabs.play')}</div></div>
+        </div>
+        <div className="bd" style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+          <div>
+            <div className="small">{t('play.height')}</div>
+            <input
+              className="input"
+              type="number"
+              step="0.1"
+              value={playerHeight}
+              onChange={onHeightChange}
+            />
+          </div>
+          <div>
+            <div className="small">{t('play.speed')}</div>
+            <input
+              className="input"
+              type="number"
+              step="0.01"
+              value={playerSpeed}
+              onChange={onSpeedChange}
+            />
+          </div>
+          <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+            {PLAYER_MODES.map((key) => (
+              <button
+                key={key}
+                className="btnGhost"
+                style={
+                  startMode === key
+                    ? { background: 'var(--accent)', color: 'var(--white)' }
+                    : undefined
+                }
+                onClick={() => setStartMode(key)}
+              >
+                {t(`play.mode.${key}`)}
+              </button>
+            ))}
+          </div>
+          <button
+            className="btnGhost"
+            onClick={() => {
+              setMode(startMode);
+              onClose();
+            }}
+          >
+            Enter play mode
+          </button>
+        </div>
       </div>
-      <div className="bd" style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
-        <div>
-          <div className="small">{t('play.height')}</div>
-          <input
-            className="input"
-            type="number"
-            step="0.1"
-            value={playerHeight}
-            onChange={onHeightChange}
-          />
-        </div>
-        <div>
-          <div className="small">{t('play.speed')}</div>
-          <input
-            className="input"
-            type="number"
-            step="0.01"
-            value={playerSpeed}
-            onChange={onSpeedChange}
-          />
-        </div>
-        <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
-          {PLAYER_MODES.map((key) => (
-            <button
-              key={key}
-              className="btnGhost"
-              style={
-                startMode === key
-                  ? { background: 'var(--accent)', color: 'var(--white)' }
-                  : undefined
-              }
-              onClick={() => setStartMode(key)}
-            >
-              {t(`play.mode.${key}`)}
-            </button>
-          ))}
-        </div>
-        <button
-          className="btnGhost"
-          onClick={() => {
-            setMode(startMode);
-            onClose();
-          }}
-        >
-          Enter play mode
-        </button>
-      </div>
-    </div>
+      <RoomPanel />
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- Show `RoomPanel` HUD while building to adjust room parameters
- Reuse `RoomPanel` in play panel for consistent room settings

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c08f44d2ac83229189f02599eb429b