### PR TITLE
Add room planner translations and tests

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -37,6 +37,8 @@
     "windowsDoors": "Windows and doors",
     "decor": "Decorative elements",
     "draw": "Draw",
+    "height": "Height",
+    "wallThickness": "Thickness",
     "addWindow": "Add window",
     "addDoor": "Add door",
     "addDecor": "Add decoration",

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -37,6 +37,8 @@
     "windowsDoors": "Okna i drzwi",
     "decor": "Elementy dekoracyjne",
     "draw": "Rysuj",
+    "height": "Wysokość",
+    "wallThickness": "Grubość",
     "addWindow": "Dodaj okno",
     "addDoor": "Dodaj drzwi",
     "addDecor": "Dodaj dekorację",

--- a/tests/roomPanel.test.tsx
+++ b/tests/roomPanel.test.tsx
@@ -1,0 +1,200 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { act } from 'react';
+import * as THREE from 'three';
+
+import MainTabs from '../src/ui/MainTabs';
+import RoomPanel from '../src/ui/panels/RoomPanel';
+import SceneViewer from '../src/ui/SceneViewer';
+import { FAMILY } from '../src/core/catalog';
+import { usePlannerStore } from '../src/state/store';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (s: string) => s }),
+}));
+
+vi.mock('../src/scene/engine', () => {
+  return {
+    setupThree: () => {
+      const dom = document.createElement('canvas');
+      dom.getBoundingClientRect = () => ({
+        left: 0,
+        top: 0,
+        width: 100,
+        height: 100,
+        right: 100,
+        bottom: 100,
+        x: 0,
+        y: 0,
+        toJSON() {},
+      });
+      const camera = new THREE.PerspectiveCamera();
+      return {
+        scene: {},
+        camera,
+        renderer: { domElement: dom },
+        controls: { enabled: true, update: () => {}, enableRotate: true },
+        playerControls: {
+          lock: vi.fn(),
+          unlock: vi.fn(),
+          addEventListener: vi.fn(),
+          removeEventListener: vi.fn(),
+          isLocked: false,
+        },
+        group: { children: [], add: () => {}, remove: () => {} },
+        cabinetDragger: { enable: vi.fn(), disable: vi.fn() },
+      };
+    },
+  };
+});
+
+vi.mock('../src/ui/components/ItemHotbar', () => ({
+  default: () => null,
+  hotbarItems: [],
+  buildHotbarItems: () => ['wall'],
+  furnishHotbarItems: [],
+}));
+
+vi.mock('../src/ui/components/TouchJoystick', () => ({ default: () => null }));
+vi.mock('../src/ui/build/RoomBuilder', () => ({ default: () => null }));
+vi.mock('../src/ui/components/RadialMenu', () => ({ default: () => null }));
+vi.mock('../src/ui/components/WallToolSelector', () => ({ default: () => null }));
+
+describe('Room features', () => {
+  it('renders Room tab in main tabs', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = ReactDOM.createRoot(container);
+
+    act(() => {
+      root.render(
+        <MainTabs
+          t={(s: string) => s}
+          tab={null}
+          setTab={() => {}}
+          family={FAMILY.BASE}
+          setFamily={() => {}}
+          kind={null}
+          setKind={() => {}}
+          variant={null}
+          setVariant={() => {}}
+          widthMM={0}
+          setWidthMM={() => {}}
+          gLocal={{}}
+          setAdv={() => {}}
+          onAdd={() => {}}
+          initBlenda={() => {}}
+          initSidePanel={() => {}}
+          boardL={0}
+          setBoardL={() => {}}
+          boardW={0}
+          setBoardW={() => {}}
+          boardKerf={0}
+          setBoardKerf={() => {}}
+          boardHasGrain={false}
+          setBoardHasGrain={() => {}}
+          addCountertop={false}
+          setAddCountertop={() => {}}
+          threeRef={{ current: null }}
+          setMode={() => {}}
+          startMode="build"
+          setStartMode={() => {}}
+        />,
+      );
+    });
+
+    expect(container.textContent).toContain('app.tabs.room');
+
+    root.unmount();
+    container.remove();
+  });
+
+  it('clamps wall thickness slider between 8 and 25 cm', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = ReactDOM.createRoot(container);
+
+    usePlannerStore.setState({
+      room: { height: 2700, origin: { x: 0, y: 0 }, walls: [], windows: [], doors: [] },
+      selectedWall: { thickness: 0.1 },
+    });
+
+    act(() => {
+      root.render(<RoomPanel />);
+    });
+
+    const header = container.querySelector('.section .hd');
+    act(() => {
+      header?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    const slider = container.querySelector('input[type="range"]') as HTMLInputElement;
+    expect(slider.min).toBe('0.08');
+    expect(slider.max).toBe('0.25');
+
+    const setThickness = usePlannerStore.getState().setSelectedWallThickness;
+    act(() => setThickness(0.05));
+    expect(usePlannerStore.getState().selectedWall?.thickness).toBe(0.08);
+
+    act(() => setThickness(0.3));
+    expect(usePlannerStore.getState().selectedWall?.thickness).toBe(0.25);
+
+    act(() => setThickness(0.2));
+    expect(usePlannerStore.getState().selectedWall?.thickness).toBe(0.2);
+
+    root.unmount();
+    container.remove();
+  });
+
+  it('activates 2D view after clicking draw', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = ReactDOM.createRoot(container);
+    const threeRef: any = { current: null };
+    const setMode = vi.fn();
+
+    usePlannerStore.setState({
+      room: { height: 2700, origin: { x: 0, y: 0 }, walls: [], windows: [], doors: [] },
+      selectedWall: { thickness: 0.1 },
+      isRoomDrawing: false,
+      selectedTool: null,
+    });
+
+    act(() => {
+      root.render(
+        <>
+          <RoomPanel />
+          <SceneViewer
+            threeRef={threeRef}
+            addCountertop={false}
+            mode="build"
+            setMode={setMode}
+            startMode="build"
+          />
+        </>,
+      );
+    });
+
+    const header = container.querySelector('.section .hd');
+    act(() => {
+      header?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    const btn = Array.from(container.querySelectorAll('button')).find(
+      (b) => b.textContent === 'room.draw',
+    );
+    act(() => {
+      btn?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(usePlannerStore.getState().isRoomDrawing).toBe(true);
+    expect(usePlannerStore.getState().selectedTool).toBe('wall');
+    expect(threeRef.current.camera.position.y).toBeCloseTo(10);
+
+    root.unmount();
+    container.remove();
+  });
+});
+


### PR DESCRIPTION
## Summary
- add missing room-related translations for height and wall thickness
- cover Room tab, wall thickness clamping, and Draw button 2D mode with tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0903ef0e88322b04a5e319ebae855