### PR TITLE
feat: add 2D room drawing board

### DIFF
--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
 import { FAMILY } from '../core/catalog';
-import { Module3D, Room, Globals, Prices, Gaps } from '../types';
+import { Module3D, Room, Globals, Prices, Gaps, RoomShape } from '../types';
 import { safeSetItem } from '../utils/storage';
 
 export const defaultGaps: Gaps = {
@@ -138,6 +138,7 @@ type Store = {
   past: { modules: Module3D[]; items: Item[]; room: Room }[];
   future: { modules: Module3D[]; items: Item[]; room: Room }[];
   room: Room;
+  roomShape: RoomShape;
   snapAngle: number;
   snapLength: number;
   snapRightAngles: boolean;
@@ -168,6 +169,7 @@ type Store = {
   undo: () => void;
   redo: () => void;
   setRoom: (patch: Partial<Room>) => void;
+  setRoomShape: (shape: RoomShape) => void;
   setShowFronts: (v: boolean) => void;
   setSnapAngle: (v: number) => void;
   setSnapLength: (v: number) => void;
@@ -206,8 +208,9 @@ export const usePlannerStore = create<Store>((set, get) => ({
         origin: { x: 0, y: 0 },
         walls: [],
         windows: [],
-        doors: [],
+      doors: [],
       },
+  roomShape: persisted?.roomShape || { points: [], segments: [] },
   snapAngle: persisted?.snapAngle ?? 90,
   snapLength: persisted?.snapLength ?? 10,
   snapRightAngles: true,
@@ -439,6 +442,7 @@ export const usePlannerStore = create<Store>((set, get) => ({
         future: [],
       };
     }),
+  setRoomShape: (shape) => set({ roomShape: shape }),
   setShowFronts: (v) => set({ showFronts: v }),
   setSnapAngle: (v) => set({ snapAngle: v }),
   setSnapLength: (v) => set({ snapLength: v }),
@@ -466,6 +470,7 @@ const persistSelector = (s: Store) => ({
   modules: s.modules,
   items: s.items,
   room: s.room,
+  roomShape: s.roomShape,
   snapAngle: s.snapAngle,
   snapLength: s.snapLength,
   angleToPrev: s.angleToPrev,

--- a/src/types.ts
+++ b/src/types.ts
@@ -212,3 +212,18 @@ export interface PricingData {
   prices: Prices;
   globals: Globals;
 }
+
+export interface ShapePoint {
+  x: number;
+  y: number;
+}
+
+export interface ShapeSegment {
+  start: ShapePoint;
+  end: ShapePoint;
+}
+
+export interface RoomShape {
+  points: ShapePoint[];
+  segments: ShapeSegment[];
+}

--- a/src/ui/build/RoomDrawBoard.tsx
+++ b/src/ui/build/RoomDrawBoard.tsx
@@ -1,0 +1,124 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { usePlannerStore } from '../../state/store';
+import type { RoomShape, ShapePoint, Wall } from '../../types';
+
+interface Props {
+  width?: number;
+  height?: number;
+}
+
+const RoomDrawBoard: React.FC<Props> = ({ width = 600, height = 400 }) => {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const { roomShape, setRoomShape, gridSize, snapToGrid } = usePlannerStore();
+  const [start, setStart] = useState<ShapePoint | null>(null);
+  const [preview, setPreview] = useState<ShapePoint | null>(null);
+  const drawingRef = useRef(false);
+
+  const snap = (v: number) => (snapToGrid ? Math.round(v / gridSize) * gridSize : v);
+
+  const getPoint = (e: React.PointerEvent): ShapePoint => {
+    const rect = (canvasRef.current as HTMLCanvasElement).getBoundingClientRect();
+    const x = e.clientX - rect.left;
+    const y = e.clientY - rect.top;
+    return { x: snap(x), y: snap(y) };
+  };
+
+  const draw = () => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    // grid
+    ctx.strokeStyle = '#eee';
+    ctx.lineWidth = 1;
+    for (let x = 0; x <= canvas.width; x += gridSize) {
+      ctx.beginPath();
+      ctx.moveTo(x + 0.5, 0);
+      ctx.lineTo(x + 0.5, canvas.height);
+      ctx.stroke();
+    }
+    for (let y = 0; y <= canvas.height; y += gridSize) {
+      ctx.beginPath();
+      ctx.moveTo(0, y + 0.5);
+      ctx.lineTo(canvas.width, y + 0.5);
+      ctx.stroke();
+    }
+    // segments
+    ctx.strokeStyle = '#000';
+    ctx.lineWidth = 2;
+    roomShape.segments.forEach((seg) => {
+      ctx.beginPath();
+      ctx.moveTo(seg.start.x, seg.start.y);
+      ctx.lineTo(seg.end.x, seg.end.y);
+      ctx.stroke();
+    });
+    // preview
+    if (drawingRef.current && start && preview) {
+      ctx.strokeStyle = '#888';
+      ctx.setLineDash([5, 5]);
+      ctx.beginPath();
+      ctx.moveTo(start.x, start.y);
+      ctx.lineTo(preview.x, preview.y);
+      ctx.stroke();
+      ctx.setLineDash([]);
+    }
+  };
+
+  useEffect(() => {
+    draw();
+  }, [roomShape, preview, gridSize, snapToGrid]);
+
+  const onPointerDown = (e: React.PointerEvent) => {
+    const p = getPoint(e);
+    setStart(p);
+    drawingRef.current = true;
+  };
+
+  const onPointerMove = (e: React.PointerEvent) => {
+    if (!drawingRef.current) return;
+    const p = getPoint(e);
+    setPreview(p);
+  };
+
+  const onPointerUp = (e: React.PointerEvent) => {
+    if (!drawingRef.current || !start) return;
+    const end = getPoint(e);
+    const segment = { start, end };
+    setRoomShape({
+      points: [...roomShape.points, start, end],
+      segments: [...roomShape.segments, segment],
+    });
+    drawingRef.current = false;
+    setStart(null);
+    setPreview(null);
+  };
+
+  return (
+    <canvas
+      ref={canvasRef}
+      width={width}
+      height={height}
+      style={{ border: '1px solid #ccc', touchAction: 'none' }}
+      onPointerDown={onPointerDown}
+      onPointerMove={onPointerMove}
+      onPointerUp={onPointerUp}
+    />
+  );
+};
+
+export default RoomDrawBoard;
+
+export const shapeToWalls = (
+  shape: RoomShape,
+  opts?: { height?: number; thickness?: number },
+): Wall[] => {
+  const { height = 2700, thickness = 0.1 } = opts || {};
+  return shape.segments.map((seg, i) => ({
+    id: `w${i}`,
+    start: { ...seg.start },
+    end: { ...seg.end },
+    height,
+    thickness,
+  }));
+};


### PR DESCRIPTION
## Summary
- add `roomShape` state with setter and persistence
- introduce canvas-based `RoomDrawBoard` with snapping and shape-to-walls helper
- define types for 2D room shapes

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c093aa157883228630b9da4917525e