### PR TITLE
feat: add room drawing overlay

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -53,6 +53,7 @@
     "settings": "Settings — {{family}}",
     "collapse": "Collapse",
     "expand": "Expand",
+    "close": "Close",
     "margin": "Margin (0–1)",
     "labor": "Labor (PLN)",
     "cut": "Cut (PLN/m)",

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -53,6 +53,7 @@
     "settings": "Ustawienia — {{family}}",
     "collapse": "Zwiń",
     "expand": "Rozwiń",
+    "close": "Zamknij",
     "margin": "Marża (0–1)",
     "labor": "Robocizna (zł)",
     "cut": "Cięcie (zł/mb)",

--- a/src/ui/panels/RoomPanel.tsx
+++ b/src/ui/panels/RoomPanel.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { usePlannerStore } from '../../state/store';
+import RoomDrawBoard, { shapeToWalls } from '../build/RoomDrawBoard';
 
 export default function RoomPanel() {
   const { t } = useTranslation();
@@ -42,6 +43,8 @@ export default function RoomPanel() {
   const setThickness = usePlannerStore((s) => s.setSelectedWallThickness);
   const setIsRoomDrawing = usePlannerStore((s) => s.setIsRoomDrawing);
   const setSelectedTool = usePlannerStore((s) => s.setSelectedTool);
+  const isRoomDrawing = usePlannerStore((s) => s.isRoomDrawing);
+  const roomShape = usePlannerStore((s) => s.roomShape);
 
   const handleHeightChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setRoom({ height: parseInt(e.target.value, 10) });
@@ -56,8 +59,42 @@ export default function RoomPanel() {
     setSelectedTool('wall');
   };
 
+  const closeDrawing = () => {
+    const walls = shapeToWalls(roomShape, {
+      height: room.height,
+      thickness: wallThickness,
+    });
+    setRoom({ walls });
+    setIsRoomDrawing(false);
+    setSelectedTool(null);
+  };
+
   return (
     <>
+      {isRoomDrawing && (
+        <div
+          style={{
+            position: 'fixed',
+            inset: 0,
+            background: 'rgba(0,0,0,0.5)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            zIndex: 100,
+          }}
+        >
+          <div style={{ position: 'relative' }}>
+            <RoomDrawBoard />
+            <button
+              className="btnGhost"
+              style={{ position: 'absolute', top: 10, right: 10 }}
+              onClick={closeDrawing}
+            >
+              {t('global.close')}
+            </button>
+          </div>
+        </div>
+      )}
       <Section
         title={t('room.walls')}
         open={wallsOpen}

--- a/tests/roomPanel.test.tsx
+++ b/tests/roomPanel.test.tsx
@@ -196,5 +196,48 @@ describe('Room features', () => {
     root.unmount();
     container.remove();
   });
+
+  it('saves room and exits drawing when closing', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = ReactDOM.createRoot(container);
+
+    usePlannerStore.setState({
+      room: {
+        height: 2700,
+        origin: { x: 0, y: 0 },
+        walls: [],
+        windows: [],
+        doors: [],
+      },
+      roomShape: {
+        points: [
+          { x: 0, y: 0 },
+          { x: 1, y: 0 },
+        ],
+        segments: [{ start: { x: 0, y: 0 }, end: { x: 1, y: 0 } }],
+      },
+      selectedWall: { thickness: 0.1 },
+      isRoomDrawing: true,
+    });
+
+    act(() => {
+      root.render(<RoomPanel />);
+    });
+
+    const btn = Array.from(container.querySelectorAll('button')).find(
+      (b) => b.textContent === 'global.close',
+    );
+    act(() => {
+      btn?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    const state = usePlannerStore.getState();
+    expect(state.isRoomDrawing).toBe(false);
+    expect(state.room.walls.length).toBe(1);
+
+    root.unmount();
+    container.remove();
+  });
 });
 


### PR DESCRIPTION
## Summary
- render RoomDrawBoard overlay for room drawing mode
- add close button to save drawn walls
- add translations for closing label

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c094e482608322ac4b78d98fec1567