### PR TITLE
refactor: remove top-view camera logic

### DIFF
--- a/src/ui/SceneViewer.tsx
+++ b/src/ui/SceneViewer.tsx
@@ -81,7 +81,6 @@ const SceneViewer: React.FC<Props> = ({
   const showEdges = store.role === 'stolarz';
   const showFronts = store.showFronts;
   const isRoomDrawing = store.isRoomDrawing;
-  const cameraState = useRef<{ position: THREE.Vector3; rotation: THREE.Euler } | null>(null);
 
   const [isMobile, setIsMobile] = useState(false);
   const [showRadial, setShowRadial] = useState(false);
@@ -113,27 +112,6 @@ const SceneViewer: React.FC<Props> = ({
     }
   }, [mode, store.selectedItemSlot, store.selectedTool]);
 
-  useEffect(() => {
-    const three = threeRef.current;
-    if (!three) return;
-    const { camera, controls } = three;
-    if (isRoomDrawing) {
-      cameraState.current = {
-        position: camera.position.clone(),
-        rotation: camera.rotation.clone(),
-      };
-      controls.enableRotate = false;
-      camera.position.set(0, 10, 0);
-      camera.up.set(0, 0, -1);
-      camera.lookAt(0, 0, 0);
-      controls.update();
-    } else if (cameraState.current) {
-      controls.enableRotate = true;
-      camera.position.copy(cameraState.current.position);
-      camera.rotation.copy(cameraState.current.rotation);
-      controls.update();
-    }
-  }, [isRoomDrawing, threeRef]);
 
   const updateGhost = React.useCallback(() => {
     const three = threeRef.current;

--- a/src/ui/build/RoomBuilder.tsx
+++ b/src/ui/build/RoomBuilder.tsx
@@ -32,23 +32,6 @@ const RoomBuilder: React.FC<Props> = ({ threeRef }) => {
     roomRef.current = room;
   }, [room]);
 
-  useEffect(() => {
-    const three = threeRef.current;
-    if (!three) return;
-    const { controls, scene } = three;
-    const prevRotate = controls.enableRotate;
-    controls.enableRotate = false;
-    const grid = new THREE.GridHelper(20, 40, 0x999999, 0xcccccc);
-    scene.add(grid);
-    return () => {
-      controls.enableRotate = prevRotate;
-      scene.remove(grid);
-      grid.geometry.dispose();
-      if (Array.isArray(grid.material)) grid.material.forEach((m) => m.dispose());
-      else grid.material.dispose();
-    };
-  }, [threeRef]);
-
   // draw room elements whenever data changes
   useEffect(() => {
     const three = threeRef.current;

--- a/src/ui/build/RoomDrawBoard.tsx
+++ b/src/ui/build/RoomDrawBoard.tsx
@@ -26,7 +26,12 @@ const RoomDrawBoard: React.FC<Props> = ({ width = 600, height = 400 }) => {
   const draw = () => {
     const canvas = canvasRef.current;
     if (!canvas) return;
-    const ctx = canvas.getContext('2d');
+    let ctx: CanvasRenderingContext2D | null = null;
+    try {
+      ctx = canvas.getContext('2d');
+    } catch {
+      return;
+    }
     if (!ctx) return;
     ctx.clearRect(0, 0, canvas.width, canvas.height);
     // grid


### PR DESCRIPTION
## Summary
- remove camera top-down switching when drawing rooms
- simplify RoomBuilder initialization and handle missing canvas context
- update room panel tests to assert RoomDrawBoard rendering

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c09a84c4248322b46e343fc61fe45f