### PR TITLE
feat(play): enable room drawing in game mode

### DIFF
--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -8,6 +8,7 @@ import { createTranslator } from './i18n';
 import MainTabs from './MainTabs';
 import { safeSetItem } from '../utils/storage';
 import { PlayerMode } from './types';
+import RoomDrawBoard, { shapeToWalls } from './build/RoomDrawBoard';
 
 type PlayerSubMode = Exclude<PlayerMode, null>;
 
@@ -46,6 +47,15 @@ export default function App() {
   const [mode, setMode] = useState<PlayerMode>(null);
   const [startMode, setStartMode] = useState<PlayerSubMode>('build');
 
+  const isRoomDrawing = usePlannerStore((s) => s.isRoomDrawing);
+  const roomShape = usePlannerStore((s) => s.roomShape);
+  const room = usePlannerStore((s) => s.room);
+  const wallThickness =
+    usePlannerStore((s) => s.selectedWall?.thickness) ?? 0.1;
+  const setRoom = usePlannerStore((s) => s.setRoom);
+  const setIsRoomDrawing = usePlannerStore((s) => s.setIsRoomDrawing);
+  const setSelectedTool = usePlannerStore((s) => s.setSelectedTool);
+
   const undo = store.undo;
   const redo = store.redo;
   useEffect(() => {
@@ -71,8 +81,42 @@ export default function App() {
     if (mode !== null) setStartMode(mode);
   }, [mode]);
 
+  const closeDrawing = () => {
+    const walls = shapeToWalls(roomShape, {
+      height: room.height,
+      thickness: wallThickness,
+    });
+    setRoom({ walls });
+    setIsRoomDrawing(false);
+    setSelectedTool(null);
+  };
+
   return (
     <div className="app">
+      {isRoomDrawing && (
+        <div
+          style={{
+            position: 'fixed',
+            inset: 0,
+            background: 'rgba(0,0,0,0.5)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            zIndex: 100,
+          }}
+        >
+          <div style={{ position: 'relative' }}>
+            <RoomDrawBoard />
+            <button
+              className="btnGhost"
+              style={{ position: 'absolute', top: 10, right: 10 }}
+              onClick={closeDrawing}
+            >
+              {t('global.close')}
+            </button>
+          </div>
+        </div>
+      )}
       {mode === null && (
         <div className="mainTabs">
           <MainTabs

--- a/src/ui/panels/PlayPanel.tsx
+++ b/src/ui/panels/PlayPanel.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { usePlannerStore } from '../../state/store';
 import { PlayerMode, PlayerSubMode, PLAYER_MODES } from '../types';
-import RoomPanel from './RoomPanel';
 
 interface Props {
   threeRef: React.MutableRefObject<any>;
@@ -25,6 +24,8 @@ export default function PlayPanel({
     playerSpeed,
     setPlayerHeight,
     setPlayerSpeed,
+    setIsRoomDrawing,
+    setSelectedTool,
   } = usePlannerStore();
   const onHeightChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const v = Number((e.target as HTMLInputElement).value) || 0;
@@ -36,6 +37,11 @@ export default function PlayPanel({
     const v = Number((e.target as HTMLInputElement).value) || 0;
     setPlayerSpeed(v);
     threeRef.current?.setPlayerParams?.({ speed: v });
+  };
+
+  const startDrawing = () => {
+    setIsRoomDrawing(true);
+    setSelectedTool('wall');
   };
 
   return (
@@ -65,6 +71,9 @@ export default function PlayPanel({
               onChange={onSpeedChange}
             />
           </div>
+          <button className="btnGhost" onClick={startDrawing}>
+            {t('room.draw')}
+          </button>
           <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
             {PLAYER_MODES.map((key) => (
               <button
@@ -92,7 +101,6 @@ export default function PlayPanel({
           </button>
         </div>
       </div>
-      <RoomPanel />
     </>
   );
 }


### PR DESCRIPTION
## Summary
- add Draw button in Play panel to start room sketching during gameplay
- show RoomDrawBoard overlay globally and sync drawn walls to 3D scene

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c09d31f7d08322a53ebce727abb493