### PR TITLE
Skip negligible segments in room drawing

### DIFF
--- a/src/ui/build/RoomDrawBoard.tsx
+++ b/src/ui/build/RoomDrawBoard.tsx
@@ -104,11 +104,14 @@ const RoomDrawBoard: React.FC<Props> = ({ width = 600, height = 400 }) => {
       return;
     }
     const end = getPoint(e);
-    const segment = { start, end };
-    setRoomShape({
-      points: [...roomShape.points, start, end],
-      segments: [...roomShape.segments, segment],
-    });
+    const distance = Math.hypot(end.x - start.x, end.y - start.y);
+    if (distance >= 1) {
+      const segment = { start, end };
+      setRoomShape({
+        points: [...roomShape.points, start, end],
+        segments: [...roomShape.segments, segment],
+      });
+    }
     drawingRef.current = false;
     setStart(null);
     setPreview(null);


### PR DESCRIPTION
## Summary
- Avoid adding near-zero-length segments on pointer release
- Always reset drawing state after pointer up

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c140e524948322aaed3e387b961f4b