### PR TITLE
Use UUIDs for wall identifiers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "react-i18next": "^15.7.3",
         "react-icons": "^5.5.0",
         "three": "^0.161.0",
+        "uuid": "^9.0.1",
         "zustand": "^4.5.2"
       },
       "devDependencies": {
@@ -4509,6 +4510,19 @@
       "optional": true,
       "dependencies": {
         "base64-arraybuffer": "^1.0.2"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "react-i18next": "^15.7.3",
     "react-icons": "^5.5.0",
     "three": "^0.161.0",
+    "uuid": "^9.0.1",
     "zustand": "^4.5.2"
   },
   "devDependencies": {

--- a/src/ui/SceneViewer.tsx
+++ b/src/ui/SceneViewer.tsx
@@ -21,6 +21,7 @@ import RoomBuilder from './build/RoomBuilder';
 import RadialMenu from './components/RadialMenu';
 import RoomPanel from './panels/RoomPanel';
 import { shapeToWalls } from './build/RoomDrawBoard';
+import uuid from '../utils/uuid';
 
 interface ThreeContext {
   scene: THREE.Scene;
@@ -524,7 +525,7 @@ const SceneViewer: React.FC<Props> = ({
               y: point.z + orientation.y * half,
             };
             const wall: Wall = {
-              id: Math.random().toString(36).slice(2),
+              id: uuid(),
               start,
               end,
               height: store.room.height / 1000,

--- a/src/ui/build/RoomBuilder.tsx
+++ b/src/ui/build/RoomBuilder.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useRef } from 'react';
 import * as THREE from 'three';
 import { usePlannerStore } from '../../state/store';
 import type { Wall, WallOpening } from '../../types';
+import uuid from '../../utils/uuid';
 
 interface Props {
   threeRef: React.MutableRefObject<any>;
@@ -258,7 +259,7 @@ const RoomBuilder: React.FC<Props> = ({ threeRef }) => {
   const addWall = () => {
     const wallHeight = room.height / 1000;
     const newWall: Wall = {
-      id: Math.random().toString(36).slice(2),
+      id: uuid(),
       start: { x: 0, y: 0 },
       end: { x: 2, y: 0 },
       height: wallHeight,
@@ -282,7 +283,7 @@ const RoomBuilder: React.FC<Props> = ({ threeRef }) => {
       wall.end.y - wall.start.y,
     );
     const win: WallOpening = {
-      id: Math.random().toString(36).slice(2),
+      id: uuid(),
       wallId,
       offset: len / 2,
       width: 1,
@@ -300,7 +301,7 @@ const RoomBuilder: React.FC<Props> = ({ threeRef }) => {
       wall.end.y - wall.start.y,
     );
     const door: WallOpening = {
-      id: Math.random().toString(36).slice(2),
+      id: uuid(),
       wallId,
       offset: len / 3,
       width: 0.9,
@@ -414,7 +415,7 @@ const RoomBuilder: React.FC<Props> = ({ threeRef }) => {
       const { x: sx, y: sy } = startRef.current;
       const wallHeight = room.height / 1000;
       const newWall: Wall = {
-        id: Math.random().toString(36).slice(2),
+        id: uuid(),
         start: { x: sx, y: sy },
         end,
         height: wallHeight,

--- a/src/ui/build/RoomDrawBoard.tsx
+++ b/src/ui/build/RoomDrawBoard.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { usePlannerStore } from '../../state/store';
 import type { RoomShape, ShapePoint, Wall } from '../../types';
+import uuid from '../../utils/uuid';
 
 interface Props {
   width?: number;
@@ -148,8 +149,8 @@ export const shapeToWalls = (
   opts?: { height?: number; thickness?: number },
 ): Wall[] => {
   const { height = 2700, thickness = 0.1 } = opts || {};
-  return shape.segments.map((seg, i) => ({
-    id: `w${i}`,
+  return shape.segments.map((seg) => ({
+    id: uuid(),
     start: { ...seg.start },
     end: { ...seg.end },
     height,

--- a/src/utils/uuid.ts
+++ b/src/utils/uuid.ts
@@ -1,0 +1,5 @@
+import { v4 as uuidv4 } from 'uuid';
+
+export const uuid = (): string => uuidv4();
+
+export default uuid;

--- a/tests/radialMenu.roomBuilder.test.tsx
+++ b/tests/radialMenu.roomBuilder.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi } from 'vitest';
+vi.mock('../src/utils/uuid', () => ({ default: () => 'test-uuid', uuid: () => 'test-uuid' }));
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { act } from 'react';
@@ -92,6 +93,7 @@ describe('RadialMenu integration with RoomBuilder', () => {
     });
 
     expect(usePlannerStore.getState().room.walls.length).toBe(before + 1);
+    expect(usePlannerStore.getState().room.walls[0].id).toBe('test-uuid');
 
     root.unmount();
   });

--- a/tests/roomPanel.test.tsx
+++ b/tests/roomPanel.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeAll } from 'vitest';
+vi.mock('../src/utils/uuid', () => ({ default: () => 'test-uuid', uuid: () => 'test-uuid' }));
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { act } from 'react';
@@ -244,6 +245,7 @@ describe('Room features', () => {
     const state = usePlannerStore.getState();
     expect(state.isRoomDrawing).toBe(false);
     expect(state.room.walls.length).toBe(1);
+    expect(state.room.walls[0].id).toBe('test-uuid');
 
     root.unmount();
     container.remove();
@@ -280,6 +282,7 @@ describe('Room features', () => {
 
     const state = usePlannerStore.getState();
     expect(state.room.walls.length).toBe(1);
+    expect(state.room.walls[0].id).toBe('test-uuid');
 
     root.unmount();
     container.remove();


### PR DESCRIPTION
## Summary
- add `uuid` dependency and utility
- generate UUIDs for walls instead of sequential IDs
- mock UUIDs in tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c144f4008483229fb89c890ad25acb