### PR TITLE
deduplicate room shape points

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -214,6 +214,7 @@ export interface PricingData {
 }
 
 export interface ShapePoint {
+  id?: string;
   x: number;
   y: number;
 }

--- a/src/ui/build/RoomDrawBoard.tsx
+++ b/src/ui/build/RoomDrawBoard.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import { usePlannerStore } from '../../state/store';
 import type { RoomShape, ShapePoint, Wall } from '../../types';
 import uuid from '../../utils/uuid';
+import addSegmentToShape from '../../utils/roomShape';
 
 interface Props {
   width?: number;
@@ -108,10 +109,7 @@ const RoomDrawBoard: React.FC<Props> = ({ width = 600, height = 400 }) => {
     const distance = Math.hypot(end.x - start.x, end.y - start.y);
     if (distance >= 1) {
       const segment = { start, end };
-      setRoomShape({
-        points: [...roomShape.points, start, end],
-        segments: [...roomShape.segments, segment],
-      });
+      setRoomShape(addSegmentToShape(roomShape, segment));
     }
     drawingRef.current = false;
     setStart(null);

--- a/src/utils/roomShape.ts
+++ b/src/utils/roomShape.ts
@@ -1,0 +1,35 @@
+import type { RoomShape, ShapePoint, ShapeSegment } from '../types';
+import uuid from './uuid';
+
+/**
+ * Adds a segment to the given room shape, ensuring start/end points are unique.
+ * If a point with the same coordinates already exists, it's reused instead of creating a duplicate.
+ */
+export const addSegmentToShape = (
+  shape: RoomShape,
+  segment: ShapeSegment,
+): RoomShape => {
+  const findPoint = (p: ShapePoint) =>
+    shape.points.find((pt) => pt.x === p.x && pt.y === p.y);
+
+  const points: ShapePoint[] = [...shape.points];
+
+  let startPoint = findPoint(segment.start);
+  if (!startPoint) {
+    startPoint = { ...segment.start, id: uuid() };
+    points.push(startPoint);
+  }
+
+  let endPoint = findPoint(segment.end);
+  if (!endPoint) {
+    endPoint = { ...segment.end, id: uuid() };
+    points.push(endPoint);
+  }
+
+  return {
+    points,
+    segments: [...shape.segments, { start: startPoint, end: endPoint }],
+  };
+};
+
+export default addSegmentToShape;

--- a/tests/roomShape.test.ts
+++ b/tests/roomShape.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect, vi } from 'vitest';
+import { addSegmentToShape } from '../src/utils/roomShape';
+import type { RoomShape } from '../src/types';
+
+vi.mock('../src/utils/uuid', () => ({
+  default: () => 'test-uuid',
+  uuid: () => 'test-uuid',
+}));
+
+describe('addSegmentToShape', () => {
+  it('avoids storing duplicate points when segments share endpoints', () => {
+    let shape: RoomShape = { points: [], segments: [] };
+    shape = addSegmentToShape(shape, { start: { x: 0, y: 0 }, end: { x: 1, y: 0 } });
+    shape = addSegmentToShape(shape, { start: { x: 1, y: 0 }, end: { x: 1, y: 1 } });
+    shape = addSegmentToShape(shape, { start: { x: 1, y: 1 }, end: { x: 0, y: 0 } });
+
+    expect(shape.points.length).toBe(3);
+    const coords = shape.points.map((p) => `${p.x},${p.y}`);
+    expect(new Set(coords).size).toBe(3);
+    const ids = shape.points.map((p) => p.id);
+    expect(ids.every((id) => typeof id === 'string')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- extend `ShapePoint` with optional `id`
- add `addSegmentToShape` helper to merge points and segments
- use helper in `RoomDrawBoard` and add tests for point deduplication

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c147bf35808322a24cb5cda6c5dbdb