### PR TITLE
Add editable room shape with undo/redo controls

### DIFF
--- a/src/ui/build/RoomDrawBoard.tsx
+++ b/src/ui/build/RoomDrawBoard.tsx
@@ -1,8 +1,8 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { usePlannerStore } from '../../state/store';
-import type { RoomShape, ShapePoint, Wall } from '../../types';
+import type { RoomShape, ShapePoint, ShapeSegment, Wall } from '../../types';
 import uuid from '../../utils/uuid';
-import addSegmentToShape from '../../utils/roomShape';
+import { addSegmentToShape, removeSegmentFromShape } from '../../utils/roomShape';
 
 interface Props {
   width?: number;
@@ -16,6 +16,17 @@ const RoomDrawBoard: React.FC<Props> = ({ width = 600, height = 400 }) => {
   const [preview, setPreview] = useState<ShapePoint | null>(null);
   const drawingRef = useRef(false);
   const pointerIdRef = useRef<number | null>(null);
+  const [selectedPoint, setSelectedPoint] = useState<ShapePoint | null>(null);
+  const [selectedSegment, setSelectedSegment] = useState<ShapeSegment | null>(
+    null,
+  );
+  const [history, setHistory] = useState<RoomShape[]>([]);
+  const [future, setFuture] = useState<RoomShape[]>([]);
+  const movingPointRef = useRef<ShapePoint | null>(null);
+  const movingSegmentRef = useRef<{
+    segment: ShapeSegment;
+    last: ShapePoint;
+  } | null>(null);
 
   const snap = (v: number) =>
     snapToGrid ? Math.round(v / gridSize) * gridSize : v;
@@ -27,6 +38,80 @@ const RoomDrawBoard: React.FC<Props> = ({ width = 600, height = 400 }) => {
     const x = e.clientX - rect.left;
     const y = e.clientY - rect.top;
     return { x: snap(x), y: snap(y) };
+  };
+
+  const cloneShape = (shape: RoomShape): RoomShape => ({
+    points: shape.points.map((p) => ({ ...p })),
+    segments: shape.segments.map((s) => ({
+      start: { ...s.start },
+      end: { ...s.end },
+    })),
+  });
+
+  const pushHistory = () => {
+    setHistory((h) => [...h, cloneShape(roomShape)]);
+    setFuture([]);
+  };
+
+  const undo = () => {
+    setHistory((h) => {
+      if (h.length === 0) return h;
+      const prev = h[h.length - 1];
+      setFuture((f) => [cloneShape(roomShape), ...f]);
+      setRoomShape(prev);
+      return h.slice(0, -1);
+    });
+  };
+
+  const redo = () => {
+    setFuture((f) => {
+      if (f.length === 0) return f;
+      const next = f[0];
+      setHistory((h) => [...h, cloneShape(roomShape)]);
+      setRoomShape(next);
+      return f.slice(1);
+    });
+  };
+
+  const deleteSelected = () => {
+    if (!selectedSegment) return;
+    pushHistory();
+    setRoomShape(removeSegmentFromShape(roomShape, selectedSegment));
+    setSelectedSegment(null);
+    setSelectedPoint(null);
+  };
+
+  const pointAt = (p: ShapePoint): ShapePoint | null =>
+    roomShape.points.find((pt) => Math.hypot(pt.x - p.x, pt.y - p.y) <= 5) ||
+    null;
+
+  const segmentAt = (p: ShapePoint): ShapeSegment | null => {
+    const distToSeg = (seg: ShapeSegment) => {
+      const { start, end } = seg;
+      const A = p.x - start.x;
+      const B = p.y - start.y;
+      const C = end.x - start.x;
+      const D = end.y - start.y;
+      const dot = A * C + B * D;
+      const lenSq = C * C + D * D;
+      let param = -1;
+      if (lenSq !== 0) param = dot / lenSq;
+      let xx, yy;
+      if (param < 0) {
+        xx = start.x;
+        yy = start.y;
+      } else if (param > 1) {
+        xx = end.x;
+        yy = end.y;
+      } else {
+        xx = start.x + param * C;
+        yy = start.y + param * D;
+      }
+      const dx = p.x - xx;
+      const dy = p.y - yy;
+      return Math.sqrt(dx * dx + dy * dy);
+    };
+    return roomShape.segments.find((seg) => distToSeg(seg) <= 5) || null;
   };
 
   const draw = () => {
@@ -56,14 +141,21 @@ const RoomDrawBoard: React.FC<Props> = ({ width = 600, height = 400 }) => {
       ctx.stroke();
     }
     // segments
-    ctx.strokeStyle = '#000';
     ctx.lineWidth = 2;
     roomShape.segments.forEach((seg) => {
       ctx.beginPath();
+      ctx.strokeStyle = seg === selectedSegment ? '#f00' : '#000';
       ctx.moveTo(seg.start.x, seg.start.y);
       ctx.lineTo(seg.end.x, seg.end.y);
       ctx.stroke();
     });
+    // selected point
+    if (selectedPoint) {
+      ctx.fillStyle = '#f00';
+      ctx.beginPath();
+      ctx.arc(selectedPoint.x, selectedPoint.y, 4, 0, Math.PI * 2);
+      ctx.fill();
+    }
     // preview
     if (drawingRef.current && start && preview) {
       ctx.strokeStyle = '#888';
@@ -78,17 +170,63 @@ const RoomDrawBoard: React.FC<Props> = ({ width = 600, height = 400 }) => {
 
   useEffect(() => {
     draw();
-  }, [roomShape, preview, gridSize, snapToGrid]);
+  }, [roomShape, preview, gridSize, snapToGrid, selectedPoint, selectedSegment]);
 
   const onPointerDown = (e: React.PointerEvent) => {
     const p = getPoint(e);
-    setStart(p);
-    drawingRef.current = true;
     pointerIdRef.current = e.pointerId;
     e.currentTarget.setPointerCapture(e.pointerId);
+
+    const pt = pointAt(p);
+    if (pt) {
+      setSelectedPoint(pt);
+      setSelectedSegment(null);
+      movingPointRef.current = pt;
+      pushHistory();
+      return;
+    }
+    const seg = segmentAt(p);
+    if (seg) {
+      setSelectedSegment(seg);
+      setSelectedPoint(null);
+      movingSegmentRef.current = { segment: seg, last: p };
+      pushHistory();
+      return;
+    }
+
+    setSelectedPoint(null);
+    setSelectedSegment(null);
+    setStart(p);
+    drawingRef.current = true;
   };
 
   const onPointerMove = (e: React.PointerEvent) => {
+    if (movingPointRef.current) {
+      const p = getPoint(e);
+      movingPointRef.current.x = p.x;
+      movingPointRef.current.y = p.y;
+      setRoomShape({
+        points: [...roomShape.points],
+        segments: [...roomShape.segments],
+      });
+      return;
+    }
+    if (movingSegmentRef.current) {
+      const p = getPoint(e);
+      const { segment, last } = movingSegmentRef.current;
+      const dx = p.x - last.x;
+      const dy = p.y - last.y;
+      segment.start.x += dx;
+      segment.start.y += dy;
+      segment.end.x += dx;
+      segment.end.y += dy;
+      movingSegmentRef.current.last = p;
+      setRoomShape({
+        points: [...roomShape.points],
+        segments: [...roomShape.segments],
+      });
+      return;
+    }
     if (!drawingRef.current) return;
     const p = getPoint(e);
     setPreview(p);
@@ -99,6 +237,14 @@ const RoomDrawBoard: React.FC<Props> = ({ width = 600, height = 400 }) => {
       e.currentTarget.releasePointerCapture(pointerIdRef.current);
       pointerIdRef.current = null;
     }
+    if (movingPointRef.current) {
+      movingPointRef.current = null;
+      return;
+    }
+    if (movingSegmentRef.current) {
+      movingSegmentRef.current = null;
+      return;
+    }
     if (!drawingRef.current || !start) {
       drawingRef.current = false;
       setStart(null);
@@ -108,6 +254,7 @@ const RoomDrawBoard: React.FC<Props> = ({ width = 600, height = 400 }) => {
     const end = getPoint(e);
     const distance = Math.hypot(end.x - start.x, end.y - start.y);
     if (distance >= 1) {
+      pushHistory();
       const segment = { start, end };
       setRoomShape(addSegmentToShape(roomShape, segment));
     }
@@ -121,22 +268,55 @@ const RoomDrawBoard: React.FC<Props> = ({ width = 600, height = 400 }) => {
       e.currentTarget.releasePointerCapture(pointerIdRef.current);
       pointerIdRef.current = null;
     }
+    movingPointRef.current = null;
+    movingSegmentRef.current = null;
     drawingRef.current = false;
     setStart(null);
     setPreview(null);
   };
 
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'z' && e.ctrlKey) {
+        e.preventDefault();
+        if (e.shiftKey) redo();
+        else undo();
+      } else if (e.key === 'y' && e.ctrlKey) {
+        e.preventDefault();
+        redo();
+      } else if (e.key === 'Delete') {
+        e.preventDefault();
+        deleteSelected();
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [undo, redo, deleteSelected]);
+
   return (
-    <canvas
-      ref={canvasRef}
-      width={width}
-      height={height}
-      style={{ border: '1px solid #ccc', touchAction: 'none' }}
-      onPointerDown={onPointerDown}
-      onPointerMove={onPointerMove}
-      onPointerUp={onPointerUp}
-      onPointerCancel={onPointerCancel}
-    />
+    <div>
+      <div style={{ marginBottom: 4 }}>
+        <button onClick={undo} disabled={!history.length}>
+          Undo
+        </button>
+        <button onClick={redo} disabled={!future.length}>
+          Redo
+        </button>
+        {selectedSegment && (
+          <button onClick={deleteSelected}>Delete</button>
+        )}
+      </div>
+      <canvas
+        ref={canvasRef}
+        width={width}
+        height={height}
+        style={{ border: '1px solid #ccc', touchAction: 'none' }}
+        onPointerDown={onPointerDown}
+        onPointerMove={onPointerMove}
+        onPointerUp={onPointerUp}
+        onPointerCancel={onPointerCancel}
+      />
+    </div>
   );
 };
 

--- a/src/utils/roomShape.ts
+++ b/src/utils/roomShape.ts
@@ -32,4 +32,19 @@ export const addSegmentToShape = (
   };
 };
 
+/** Removes a segment and any orphaned points from a room shape. */
+export const removeSegmentFromShape = (
+  shape: RoomShape,
+  seg: ShapeSegment,
+): RoomShape => {
+  const segments = shape.segments.filter((s) => s !== seg);
+  const used = new Set<string>();
+  segments.forEach((s) => {
+    used.add(s.start.id);
+    used.add(s.end.id);
+  });
+  const points = shape.points.filter((p) => used.has(p.id));
+  return { points, segments };
+};
+
 export default addSegmentToShape;

--- a/src/utils/uuid.ts
+++ b/src/utils/uuid.ts
@@ -1,5 +1,11 @@
-import { v4 as uuidv4 } from 'uuid';
-
-export const uuid = (): string => uuidv4();
+export const uuid = (): string => {
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto)
+    return (crypto as any).randomUUID();
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+    const r = (Math.random() * 16) | 0;
+    const v = c === 'x' ? r : (r & 0x3) | 0x8;
+    return v.toString(16);
+  });
+};
 
 export default uuid;

--- a/tests/roomDrawBoard.edit.test.tsx
+++ b/tests/roomDrawBoard.edit.test.tsx
@@ -1,0 +1,204 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+vi.mock('../src/utils/uuid', () => ({
+  default: () => 'test-uuid',
+  uuid: () => 'test-uuid',
+}));
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { act } from 'react';
+
+import RoomDrawBoard from '../src/ui/build/RoomDrawBoard';
+import { usePlannerStore } from '../src/state/store';
+
+beforeEach(() => {
+  (global as any).PointerEvent = MouseEvent;
+  HTMLCanvasElement.prototype.getContext = () => ({
+    clearRect: () => {},
+    beginPath: () => {},
+    moveTo: () => {},
+    lineTo: () => {},
+    stroke: () => {},
+    setLineDash: () => {},
+    arc: () => {},
+    fill: () => {},
+  } as any);
+  HTMLCanvasElement.prototype.getBoundingClientRect = () => ({
+    left: 0,
+    top: 0,
+    width: 200,
+    height: 100,
+    right: 200,
+    bottom: 100,
+    x: 0,
+    y: 0,
+    toJSON() {},
+  });
+  HTMLCanvasElement.prototype.setPointerCapture = () => {};
+  HTMLCanvasElement.prototype.releasePointerCapture = () => {};
+  usePlannerStore.setState({
+    roomShape: { points: [], segments: [] },
+    snapToGrid: false,
+  });
+});
+
+const drawSegment = (
+  canvas: HTMLCanvasElement,
+  x1: number,
+  y1: number,
+  x2: number,
+  y2: number,
+) => {
+  act(() => {
+    canvas.dispatchEvent(
+      new PointerEvent('pointerdown', {
+        bubbles: true,
+        clientX: x1,
+        clientY: y1,
+        pointerId: 1,
+      }),
+    );
+  });
+  act(() => {
+    canvas.dispatchEvent(
+      new PointerEvent('pointermove', {
+        bubbles: true,
+        clientX: x2,
+        clientY: y2,
+        pointerId: 1,
+      }),
+    );
+    canvas.dispatchEvent(
+      new PointerEvent('pointerup', {
+        bubbles: true,
+        clientX: x2,
+        clientY: y2,
+        pointerId: 1,
+      }),
+    );
+  });
+};
+
+describe('RoomDrawBoard editing', () => {
+  it('supports undo/redo for segments', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = ReactDOM.createRoot(container);
+    act(() => root.render(<RoomDrawBoard width={200} height={100} />));
+    const canvas = container.querySelector('canvas')!;
+
+    drawSegment(canvas, 10, 10, 110, 10);
+    drawSegment(canvas, 20, 20, 20, 80);
+    expect(usePlannerStore.getState().roomShape.segments.length).toBe(2);
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'z', ctrlKey: true }));
+    });
+    expect(usePlannerStore.getState().roomShape.segments.length).toBe(1);
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'z', ctrlKey: true }));
+    });
+    expect(usePlannerStore.getState().roomShape.segments.length).toBe(0);
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'y', ctrlKey: true }));
+    });
+    expect(usePlannerStore.getState().roomShape.segments.length).toBe(1);
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'y', ctrlKey: true }));
+    });
+    expect(usePlannerStore.getState().roomShape.segments.length).toBe(2);
+
+    root.unmount();
+    container.remove();
+  });
+
+  it('allows moving existing points with grid snapping', () => {
+    usePlannerStore.setState({ snapToGrid: true, gridSize: 50, roomShape: { points: [], segments: [] } });
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = ReactDOM.createRoot(container);
+    act(() => root.render(<RoomDrawBoard width={200} height={100} />));
+    const canvas = container.querySelector('canvas')!;
+
+    drawSegment(canvas, 0, 0, 50, 0);
+
+    act(() => {
+      canvas.dispatchEvent(
+        new PointerEvent('pointerdown', {
+          bubbles: true,
+          clientX: 0,
+          clientY: 0,
+          pointerId: 1,
+        }),
+      );
+    });
+    act(() => {
+      canvas.dispatchEvent(
+        new PointerEvent('pointermove', {
+          bubbles: true,
+          clientX: 78,
+          clientY: 83,
+          pointerId: 1,
+        }),
+      );
+      canvas.dispatchEvent(
+        new PointerEvent('pointerup', {
+          bubbles: true,
+          clientX: 78,
+          clientY: 83,
+          pointerId: 1,
+        }),
+      );
+    });
+
+    const pt = usePlannerStore.getState().roomShape.points[0];
+    expect(pt.x).toBe(100);
+    expect(pt.y).toBe(100);
+
+    root.unmount();
+    container.remove();
+  });
+
+  it('deletes selected segment', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = ReactDOM.createRoot(container);
+    act(() => root.render(<RoomDrawBoard width={200} height={100} />));
+    const canvas = container.querySelector('canvas')!;
+
+    drawSegment(canvas, 10, 10, 110, 10);
+    expect(usePlannerStore.getState().roomShape.segments.length).toBe(1);
+
+    act(() => {
+      canvas.dispatchEvent(
+        new PointerEvent('pointerdown', {
+          bubbles: true,
+          clientX: 60,
+          clientY: 10,
+          pointerId: 1,
+        }),
+      );
+    });
+    act(() => {
+      canvas.dispatchEvent(
+        new PointerEvent('pointerup', {
+          bubbles: true,
+          clientX: 60,
+          clientY: 10,
+          pointerId: 1,
+        }),
+      );
+    });
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Delete' }));
+    });
+    expect(usePlannerStore.getState().roomShape.segments.length).toBe(0);
+
+    root.unmount();
+    container.remove();
+  });
+});


### PR DESCRIPTION
## Summary
- add point and segment selection with drag-to-move and delete support
- implement undo/redo for room shape editing with keyboard shortcuts and buttons
- replace external uuid dependency and add tests for segment editing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c1490120408322ba3ceff4961ad9e4