### PR TITLE
Scale RoomDrawBoard canvas for device pixel ratio

### DIFF
--- a/src/ui/build/RoomDrawBoard.tsx
+++ b/src/ui/build/RoomDrawBoard.tsx
@@ -124,20 +124,33 @@ const RoomDrawBoard: React.FC<Props> = ({ width = 600, height = 400 }) => {
       return;
     }
     if (!ctx) return;
-    ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+    const dpr = window.devicePixelRatio || 1;
+    canvas.width = width * dpr;
+    canvas.height = height * dpr;
+    canvas.style.width = `${width}px`;
+    canvas.style.height = `${height}px`;
+
+    const canvasWidth = canvas.width / dpr;
+    const canvasHeight = canvas.height / dpr;
+    if (typeof ctx.scale === 'function') {
+      ctx.scale(dpr, dpr);
+    }
+    ctx.clearRect(0, 0, canvasWidth, canvasHeight);
+
     // grid
     ctx.strokeStyle = '#eee';
     ctx.lineWidth = 1;
-    for (let x = 0; x <= canvas.width; x += gridSize) {
+    for (let x = 0; x <= canvasWidth; x += gridSize) {
       ctx.beginPath();
       ctx.moveTo(x + 0.5, 0);
-      ctx.lineTo(x + 0.5, canvas.height);
+      ctx.lineTo(x + 0.5, canvasHeight);
       ctx.stroke();
     }
-    for (let y = 0; y <= canvas.height; y += gridSize) {
+    for (let y = 0; y <= canvasHeight; y += gridSize) {
       ctx.beginPath();
       ctx.moveTo(0, y + 0.5);
-      ctx.lineTo(canvas.width, y + 0.5);
+      ctx.lineTo(canvasWidth, y + 0.5);
       ctx.stroke();
     }
     // segments


### PR DESCRIPTION
## Summary
- scale RoomDrawBoard canvas based on `window.devicePixelRatio`
- render grid and segments using scaled context to prevent blurriness on high-DPI displays

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c14b57818c83229aec71fc07625ace