### PR TITLE
Sync room walls between 2D and 3D views

### DIFF
--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand';
 import { FAMILY } from '../core/catalog';
 import { Module3D, Room, Globals, Prices, Gaps, RoomShape, Wall } from '../types';
+import { shapeToWalls } from '../utils/roomShape';
 import { safeSetItem } from '../utils/storage';
 
 export const defaultGaps: Gaps = {
@@ -457,7 +458,27 @@ export const usePlannerStore = create<Store>((set, get) => ({
         future: [],
       };
     }),
-  setRoomShape: (shape) => set({ roomShape: shape }),
+  setRoomShape: (shape) =>
+    set((s) => {
+      const walls = shapeToWalls(shape, {
+        height: s.room.height / 1000,
+        thickness: s.selectedWall?.thickness ?? 0.1,
+      });
+      const updatedRoom = { ...s.room, walls };
+      return {
+        past: [
+          ...s.past,
+          {
+            modules: JSON.parse(JSON.stringify(s.modules)),
+            items: JSON.parse(JSON.stringify(s.items)),
+            room: JSON.parse(JSON.stringify(s.room)),
+          },
+        ],
+        roomShape: shape,
+        room: updatedRoom,
+        future: [],
+      };
+    }),
   setShowFronts: (v) => set({ showFronts: v }),
   setSnapAngle: (v) => set({ snapAngle: v }),
   setSnapLength: (v) => set({ snapLength: v }),

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -8,7 +8,7 @@ import { createTranslator } from './i18n';
 import MainTabs from './MainTabs';
 import { safeSetItem } from '../utils/storage';
 import { PlayerMode } from './types';
-import RoomDrawBoard, { shapeToWalls } from './build/RoomDrawBoard';
+import RoomDrawBoard from './build/RoomDrawBoard';
 
 type PlayerSubMode = Exclude<PlayerMode, null>;
 
@@ -47,12 +47,6 @@ export default function App() {
   const [mode, setMode] = useState<PlayerMode>(null);
   const [startMode, setStartMode] = useState<PlayerSubMode>('build');
   const [viewMode, setViewMode] = useState<'3d' | '2d'>('3d');
-  const roomShape = usePlannerStore((s) => s.roomShape);
-  const room = usePlannerStore((s) => s.room);
-  const wallThickness =
-    usePlannerStore((s) => s.selectedWall?.thickness) ?? 0.1;
-  const setRoom = usePlannerStore((s) => s.setRoom);
-  const setSelectedTool = usePlannerStore((s) => s.setSelectedTool);
 
   const undo = store.undo;
   const redo = store.redo;
@@ -79,19 +73,8 @@ export default function App() {
     if (mode !== null) setStartMode(mode);
   }, [mode]);
 
-  const closeDrawing = () => {
-    const walls = shapeToWalls(roomShape, {
-      height: room.height,
-      thickness: wallThickness,
-    });
-    setRoom({ walls });
-    setSelectedTool(null);
-    setViewMode('3d');
-  };
-
   const handleSetViewMode = (v: '3d' | '2d') => {
-    if (v === '3d') closeDrawing();
-    else setViewMode('2d');
+    setViewMode(v);
   };
 
   const toggleViewMode = () => {

--- a/src/ui/SceneViewer.tsx
+++ b/src/ui/SceneViewer.tsx
@@ -20,7 +20,6 @@ import { PlayerMode, PlayerSubMode, PLAYER_MODES } from './types';
 import RoomBuilder from './build/RoomBuilder';
 import RadialMenu from './components/RadialMenu';
 import RoomPanel from './panels/RoomPanel';
-import { shapeToWalls } from './build/RoomDrawBoard';
 import uuid from '../utils/uuid';
 
 interface ThreeContext {
@@ -425,11 +424,8 @@ const SceneViewer: React.FC<Props> = ({
         group.add(top);
       }
     });
-    // draw walls from room shape
-    const walls = shapeToWalls(store.roomShape, {
-      height: store.room.height / 1000,
-      thickness: store.selectedWall?.thickness ?? 0.1,
-    });
+    // draw walls from room data
+    const walls = store.room.walls;
     walls.forEach((w) => {
       const len = Math.hypot(w.end.x - w.start.x, w.end.y - w.start.y);
       const geom = new THREE.BoxGeometry(len, w.height, w.thickness);
@@ -481,9 +477,8 @@ const SceneViewer: React.FC<Props> = ({
     addCountertop,
     showEdges,
     showFronts,
-    store.roomShape,
+    store.room.walls,
     store.room.height,
-    store.selectedWall?.thickness,
   ]);
 
 

--- a/src/ui/build/RoomDrawBoard.tsx
+++ b/src/ui/build/RoomDrawBoard.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { usePlannerStore } from '../../state/store';
-import type { RoomShape, ShapePoint, ShapeSegment, Wall } from '../../types';
+import type { RoomShape, ShapePoint, ShapeSegment } from '../../types';
 import uuid from '../../utils/uuid';
 import { addSegmentToShape, removeSegmentFromShape } from '../../utils/roomShape';
 import ItemHotbar, {
@@ -411,17 +411,3 @@ const RoomDrawBoard: React.FC<Props> = ({
 };
 
 export default RoomDrawBoard;
-
-export const shapeToWalls = (
-  shape: RoomShape,
-  opts?: { height?: number; thickness?: number },
-): Wall[] => {
-  const { height = 2700, thickness = 0.1 } = opts || {};
-  return shape.segments.map((seg) => ({
-    id: uuid(),
-    start: { ...seg.start },
-    end: { ...seg.end },
-    height,
-    thickness,
-  }));
-};

--- a/src/utils/roomShape.ts
+++ b/src/utils/roomShape.ts
@@ -1,4 +1,4 @@
-import type { RoomShape, ShapePoint, ShapeSegment } from '../types';
+import type { RoomShape, ShapePoint, ShapeSegment, Wall } from '../types';
 import uuid from './uuid';
 
 /**
@@ -48,3 +48,18 @@ export const removeSegmentFromShape = (
 };
 
 export default addSegmentToShape;
+
+/** Converts a room shape to an array of walls. */
+export const shapeToWalls = (
+  shape: RoomShape,
+  opts?: { height?: number; thickness?: number },
+): Wall[] => {
+  const { height = 2.7, thickness = 0.1 } = opts || {};
+  return shape.segments.map((seg) => ({
+    id: uuid(),
+    start: { ...seg.start },
+    end: { ...seg.end },
+    height,
+    thickness,
+  }));
+};

--- a/tests/roomDrawBoard.edit.test.tsx
+++ b/tests/roomDrawBoard.edit.test.tsx
@@ -40,6 +40,7 @@ beforeEach(() => {
   HTMLCanvasElement.prototype.setPointerCapture = () => {};
   HTMLCanvasElement.prototype.releasePointerCapture = () => {};
   usePlannerStore.setState({
+    room: { height: 2700, origin: { x: 0, y: 0 }, walls: [], windows: [], doors: [] },
     roomShape: { points: [], segments: [] },
     snapToGrid: false,
   });

--- a/tests/viewSync.test.tsx
+++ b/tests/viewSync.test.tsx
@@ -1,0 +1,126 @@
+// @vitest-environment jsdom
+import { describe, it, beforeEach, expect, vi } from 'vitest';
+vi.mock('../src/utils/uuid', () => ({
+  default: () => 'test-uuid',
+  uuid: () => 'test-uuid',
+}));
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (s: string) => s }),
+}));
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { act } from 'react';
+import RoomDrawBoard from '../src/ui/build/RoomDrawBoard';
+import { usePlannerStore } from '../src/state/store';
+
+beforeEach(() => {
+  (global as any).PointerEvent = MouseEvent;
+  HTMLCanvasElement.prototype.getContext = () => ({
+    clearRect: () => {},
+    beginPath: () => {},
+    moveTo: () => {},
+    lineTo: () => {},
+    stroke: () => {},
+    setLineDash: () => {},
+    arc: () => {},
+    fill: () => {},
+  } as any);
+  HTMLCanvasElement.prototype.getBoundingClientRect = () => ({
+    left: 0,
+    top: 0,
+    width: 200,
+    height: 100,
+    right: 200,
+    bottom: 100,
+    x: 0,
+    y: 0,
+    toJSON() {},
+  });
+  HTMLCanvasElement.prototype.setPointerCapture = () => {};
+  HTMLCanvasElement.prototype.releasePointerCapture = () => {};
+  usePlannerStore.setState({
+    room: { height: 2700, origin: { x: 0, y: 0 }, walls: [], windows: [], doors: [] },
+    roomShape: { points: [], segments: [] },
+    snapToGrid: false,
+  });
+});
+
+const drawSegment = (
+  canvas: HTMLCanvasElement,
+  x1: number,
+  y1: number,
+  x2: number,
+  y2: number,
+) => {
+  act(() => {
+    canvas.dispatchEvent(
+      new PointerEvent('pointerdown', {
+        bubbles: true,
+        clientX: x1,
+        clientY: y1,
+        pointerId: 1,
+      }),
+    );
+  });
+  act(() => {
+    canvas.dispatchEvent(
+      new PointerEvent('pointermove', {
+        bubbles: true,
+        clientX: x2,
+        clientY: y2,
+        pointerId: 1,
+      }),
+    );
+    canvas.dispatchEvent(
+      new PointerEvent('pointerup', {
+        bubbles: true,
+        clientX: x2,
+        clientY: y2,
+        pointerId: 1,
+      }),
+    );
+  });
+};
+
+describe('View synchronization', () => {
+  it('updates room walls when drawing in 2D', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = ReactDOM.createRoot(container);
+    act(() => root.render(<RoomDrawBoard width={200} height={100} />));
+    const canvas = container.querySelector('canvas')!;
+
+    drawSegment(canvas, 10, 10, 110, 10);
+
+    expect(usePlannerStore.getState().room.walls.length).toBe(1);
+    root.unmount();
+    container.remove();
+  });
+
+  it('reflects 3D wall additions in 2D view', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = ReactDOM.createRoot(container);
+    act(() => root.render(<RoomDrawBoard width={200} height={100} />));
+
+    act(() => {
+      usePlannerStore
+        .getState()
+        .setRoom({
+          walls: [
+            {
+              id: 'w1',
+              start: { x: 0, y: 0 },
+              end: { x: 1, y: 0 },
+              height: 2.7,
+              thickness: 0.1,
+            },
+          ],
+        });
+    });
+
+    expect(usePlannerStore.getState().roomShape.segments.length).toBe(1);
+    root.unmount();
+    container.remove();
+  });
+});


### PR DESCRIPTION
## Summary
- Keep room walls and shape in sync by updating room state when `setRoomShape` is used
- Render 3D walls directly from `store.room.walls`
- Simplify view mode switching and share wall shape utilities
- Add tests confirming 2D/3D room synchronization

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1575e37f8832293270b2834d8443d