### PR TITLE
Show ItemHotbar only when a mode is active

### DIFF
--- a/src/ui/SceneViewer.tsx
+++ b/src/ui/SceneViewer.tsx
@@ -254,6 +254,7 @@ const SceneViewer: React.FC<Props> = ({
     }, [threeRef, mode]);
 
   useEffect(() => {
+    if (!mode) return;
     const handleKey = (e: KeyboardEvent) => {
       if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'w') {
         e.preventDefault();
@@ -272,7 +273,7 @@ const SceneViewer: React.FC<Props> = ({
       window.removeEventListener('keydown', handleKey);
       window.removeEventListener('keyup', handleKey);
     };
-  }, [store]);
+  }, [store, mode]);
 
   useEffect(() => {
     if (mode === null) return;
@@ -823,7 +824,7 @@ const SceneViewer: React.FC<Props> = ({
           <RoomPanel />
         </div>
       )}
-      <ItemHotbar mode={mode} />
+      {mode && <ItemHotbar mode={mode} />}
       {mode && isMobile && (
         <>
           <TouchJoystick

--- a/src/ui/build/RoomDrawBoard.tsx
+++ b/src/ui/build/RoomDrawBoard.tsx
@@ -58,6 +58,8 @@ const RoomDrawBoard: React.FC<Props> = ({
   }, [items, store.selectedItemSlot, store.selectedTool, store]);
 
   useEffect(() => {
+    if (!mode) return;
+
     const handleKey = (e: KeyboardEvent) => {
       if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'w') {
         e.preventDefault();
@@ -76,7 +78,7 @@ const RoomDrawBoard: React.FC<Props> = ({
       window.removeEventListener('keydown', handleKey);
       window.removeEventListener('keyup', handleKey);
     };
-  }, [store]);
+  }, [store, mode]);
 
   const snap = (v: number) =>
     snapToGrid ? Math.round(v / gridSize) * gridSize : v;
@@ -405,7 +407,7 @@ const RoomDrawBoard: React.FC<Props> = ({
         onPointerCancel={onPointerCancel}
       />
       {mode === 'build' && <WallToolSelector />}
-      <ItemHotbar mode={mode} />
+      {mode && <ItemHotbar mode={mode} />}
     </div>
   );
 };

--- a/tests/sceneViewer.mode.test.tsx
+++ b/tests/sceneViewer.mode.test.tsx
@@ -47,13 +47,49 @@ vi.mock('../src/scene/engine', () => {
 });
 
 vi.mock('../src/ui/components/ItemHotbar', () => ({
-  default: () => null,
+  default: (props: any) => <div data-testid="item-hotbar" data-mode={props.mode}></div>,
   hotbarItems: [],
   buildHotbarItems: () => [],
   furnishHotbarItems: [],
 }));
 vi.mock('../src/ui/components/TouchJoystick', () => ({ default: () => null }));
 vi.mock('../src/ui/build/RoomBuilder', () => ({ default: () => null }));
+
+describe('SceneViewer hotbar visibility', () => {
+  it('renders hotbar only when mode is not null', () => {
+    const threeRef: any = { current: null };
+    const setMode = vi.fn();
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = ReactDOM.createRoot(container);
+
+    act(() => {
+      root.render(
+        <SceneViewer
+          threeRef={threeRef}
+          addCountertop={false}
+          mode={null}
+          setMode={setMode}
+        />, 
+      );
+    });
+    expect(container.querySelector('[data-testid="item-hotbar"]')).toBeNull();
+
+    act(() => {
+      root.render(
+        <SceneViewer
+          threeRef={threeRef}
+          addCountertop={false}
+          mode="build"
+          setMode={setMode}
+        />,
+      );
+    });
+    expect(container.querySelector('[data-testid="item-hotbar"]')).not.toBeNull();
+
+    root.unmount();
+  });
+});
 
 describe('SceneViewer cabinetDragger mode control', () => {
   it('enables cabinetDragger only in furnish mode', () => {
@@ -136,7 +172,7 @@ describe('SceneViewer Tab key', () => {
 });
 
 describe('SceneViewer hotbar keys', () => {
-  it('changes selectedItemSlot when mode is null', () => {
+  it('does not change selectedItemSlot when mode is null', () => {
     const threeRef: any = { current: null };
     const setMode = vi.fn();
     const container = document.createElement('div');
@@ -160,7 +196,7 @@ describe('SceneViewer hotbar keys', () => {
       act(() => {
         window.dispatchEvent(new KeyboardEvent('keydown', { key: keys[i] }));
       });
-      expect(usePlannerStore.getState().selectedItemSlot).toBe(i + 1);
+      expect(usePlannerStore.getState().selectedItemSlot).toBe(5);
     }
 
     root.unmount();


### PR DESCRIPTION
## Summary
- Render ItemHotbar in SceneViewer and RoomDrawBoard only when a player mode is selected
- Ignore number hotbar shortcuts outside of game modes
- Test hotbar visibility and shortcut behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c15c7c2fec8322a807abd329fb8034