### PR TITLE
Default wall thickness when missing

### DIFF
--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -438,9 +438,10 @@ export const usePlannerStore = create<Store>((set, get) => ({
     set((s) => {
       const newPatch: Partial<Room> = { ...patch };
       if (patch.walls) {
+        const defaultThickness = s.selectedWall?.thickness ?? 0.1;
         newPatch.walls = patch.walls.map((w) => ({
           ...w,
-          thickness: clamp(w.thickness, 0.08, 0.25),
+          thickness: clamp(w.thickness ?? defaultThickness, 0.08, 0.25),
         }));
       }
       const updatedRoom = { ...s.room, ...newPatch };


### PR DESCRIPTION
## Summary
- default wall thickness to selected value before clamping

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c15f130fbc8322a95b0b91636f1704