### PR TITLE
Ensure wall creation uses only point coordinates

### DIFF
--- a/src/utils/roomShape.ts
+++ b/src/utils/roomShape.ts
@@ -57,8 +57,8 @@ export const shapeToWalls = (
   const { height = 2.7, thickness = 0.1 } = opts || {};
   return shape.segments.map((seg) => ({
     id: uuid(),
-    start: { ...seg.start },
-    end: { ...seg.end },
+    start: { x: seg.start.x, y: seg.start.y },
+    end: { x: seg.end.x, y: seg.end.y },
     height,
     thickness,
   }));


### PR DESCRIPTION
## Summary
- avoid leaking point ids into walls by copying only `x` and `y`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c163677f1c83228b60d401c58ca2f8