### PR TITLE
feat: add segment snapping for length and angle

### DIFF
--- a/tests/roomBuilder.snap.test.tsx
+++ b/tests/roomBuilder.snap.test.tsx
@@ -1,0 +1,90 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+vi.mock('../src/utils/uuid', () => ({
+  default: () => 'test-uuid',
+  uuid: () => 'test-uuid',
+}));
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (s: string) => s }),
+}));
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { act } from 'react';
+import * as THREE from 'three';
+import RoomBuilder from '../src/ui/build/RoomBuilder';
+import { usePlannerStore } from '../src/state/store';
+
+beforeEach(() => {
+  (global as any).PointerEvent = MouseEvent;
+  HTMLCanvasElement.prototype.getContext = () => ({ clearRect: () => {} }) as any;
+  HTMLCanvasElement.prototype.getBoundingClientRect = () => ({
+    left: 0,
+    top: 0,
+    width: 100,
+    height: 100,
+    right: 100,
+    bottom: 100,
+    x: 0,
+    y: 0,
+    toJSON() {},
+  });
+  HTMLCanvasElement.prototype.setPointerCapture = () => {};
+  HTMLCanvasElement.prototype.releasePointerCapture = () => {};
+  usePlannerStore.setState({
+    room: { height: 2700, origin: { x: 0, y: 0 }, walls: [], windows: [], doors: [] },
+    selectedTool: 'wall',
+    selectedWall: { thickness: 0.1 },
+    snapLength: 1,
+    snapAngle: 90,
+    snapRightAngles: true,
+  });
+});
+
+describe('RoomBuilder snapping', () => {
+  it('snaps new wall length and angle', () => {
+    const canvas = document.createElement('canvas');
+    const camera = new THREE.PerspectiveCamera(75, 1, 0.1, 1000);
+    camera.position.set(0, 5, 5);
+    camera.lookAt(0, 0, 0);
+    const threeRef: any = {
+      current: {
+        renderer: { domElement: canvas },
+        camera,
+        group: { children: [], add: () => {}, remove: () => {} },
+      },
+    };
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = ReactDOM.createRoot(container);
+    act(() => root.render(<RoomBuilder threeRef={threeRef} />));
+
+    act(() => {
+      window.dispatchEvent(
+        new PointerEvent('pointerdown', { bubbles: true, clientX: 50, clientY: 50 }),
+      );
+    });
+    act(() => {
+      window.dispatchEvent(
+        new PointerEvent('pointermove', { bubbles: true, clientX: 80, clientY: 60 }),
+      );
+    });
+    act(() => {
+      window.dispatchEvent(
+        new PointerEvent('pointerup', { bubbles: true, clientX: 80, clientY: 60 }),
+      );
+    });
+
+    const wall = usePlannerStore.getState().room.walls[0];
+    expect(wall).toBeDefined();
+    const len = Math.hypot(wall.end.x - wall.start.x, wall.end.y - wall.start.y);
+    expect(wall.start.y).toBeCloseTo(0);
+    expect(wall.end.y).toBeCloseTo(0);
+    expect(wall.start.x).toBeCloseTo(0);
+    expect(wall.end.x).toBeCloseTo(3);
+    expect(len).toBeCloseTo(3);
+
+    root.unmount();
+    container.remove();
+  });
+});

--- a/tests/roomDrawBoard.edit.test.tsx
+++ b/tests/roomDrawBoard.edit.test.tsx
@@ -185,6 +185,40 @@ describe('RoomDrawBoard editing', () => {
     container.remove();
   });
 
+  it('snaps segment length and angle', () => {
+    usePlannerStore.setState({
+      snapToGrid: false,
+      snapLength: 50,
+      snapAngle: 90,
+      snapRightAngles: true,
+      roomShape: { points: [], segments: [] },
+    });
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = ReactDOM.createRoot(container);
+    act(() => root.render(<RoomDrawBoard width={200} height={100} />));
+    const canvas = container.querySelector('canvas')!;
+
+    drawSegment(canvas, 0, 0, 80, 10);
+    drawSegment(canvas, 150, 0, 160, 40);
+    const segments = usePlannerStore.getState().roomShape.segments;
+    const len1 = Math.hypot(
+      segments[0].end.x - segments[0].start.x,
+      segments[0].end.y - segments[0].start.y,
+    );
+    const len2 = Math.hypot(
+      segments[1].end.x - segments[1].start.x,
+      segments[1].end.y - segments[1].start.y,
+    );
+    expect(len1).toBe(100);
+    expect(segments[0].start.y).toBe(segments[0].end.y);
+    expect(len2).toBe(50);
+    expect(segments[1].start.x).toBe(segments[1].end.x);
+
+    root.unmount();
+    container.remove();
+  });
+
   it('deletes selected segment', () => {
     const container = document.createElement('div');
     document.body.appendChild(container);


### PR DESCRIPTION
## Summary
- snap new points in RoomDrawBoard to configurable angles and segment lengths
- respect snap settings when drawing walls in RoomBuilder
- test snapping behaviour for both RoomDrawBoard and RoomBuilder

## Testing
- `npm test -- tests/roomDrawBoard.edit.test.tsx tests/roomBuilder.snap.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c1773fff908322a65fa9973e345711