### PR TITLE
feat: support metric units for drawing

### DIFF
--- a/src/ui/build/RoomBuilder.tsx
+++ b/src/ui/build/RoomBuilder.tsx
@@ -22,6 +22,7 @@ const RoomBuilder: React.FC<Props> = ({ threeRef }) => {
   const snapAngle = usePlannerStore((s) => s.snapAngle);
   const snapLength = usePlannerStore((s) => s.snapLength);
   const snapRightAngles = usePlannerStore((s) => s.snapRightAngles);
+  const measurementUnit = usePlannerStore((s) => s.measurementUnit);
   const groupRef = useRef<THREE.Group | null>(null);
   const roomRef = useRef(room);
   const startRef = useRef<{ x: number; y: number } | null>(null);
@@ -376,7 +377,9 @@ const RoomBuilder: React.FC<Props> = ({ threeRef }) => {
       const y = rect.top + ((-pos.y + 1) / 2) * rect.height;
       labelRef.current.style.left = `${x}px`;
       labelRef.current.style.top = `${y}px`;
-      labelRef.current.textContent = `${Math.round(len * 1000)} mm`;
+      const displayLen =
+        measurementUnit === 'cm' ? len * 100 : len * 1000;
+      labelRef.current.textContent = `${Math.round(displayLen)} ${measurementUnit}`;
       labelRef.current.style.display = 'block';
     };
 
@@ -479,7 +482,9 @@ const RoomBuilder: React.FC<Props> = ({ threeRef }) => {
       if (!startRef.current) return;
       if (e.key >= '0' && e.key <= '9') {
         inputRef.current += e.key;
-        const len = parseFloat(inputRef.current) / 1000;
+        const len =
+          parseFloat(inputRef.current) /
+          (measurementUnit === 'cm' ? 100 : 1000);
         updatePreview(len);
       } else if (e.key === 'Enter') {
         const { x: sx, y: sy } = startRef.current;

--- a/src/ui/build/RoomDrawBoard.tsx
+++ b/src/ui/build/RoomDrawBoard.tsx
@@ -241,7 +241,8 @@ const RoomDrawBoard: React.FC<Props> = ({
   const parseInput = (str: string) => {
     const cleaned = str.replace(/°/g, '').trim();
     const [lenStr, angleStr] = cleaned.split(/\s+/);
-    const length = parseFloat(lenStr);
+    const raw = parseFloat(lenStr);
+    const length = measurementUnit === 'cm' ? raw * 10 : raw;
     let angle: number | undefined = undefined;
     if (angleStr !== undefined) {
       const a = parseFloat(angleStr);

--- a/tests/roomBuilder.units.test.tsx
+++ b/tests/roomBuilder.units.test.tsx
@@ -1,0 +1,117 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+vi.mock('../src/utils/uuid', () => ({
+  default: () => 'test-uuid',
+  uuid: () => 'test-uuid',
+}));
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (s: string) => s }),
+}));
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { act } from 'react';
+import * as THREE from 'three';
+import RoomBuilder from '../src/ui/build/RoomBuilder';
+import { usePlannerStore } from '../src/state/store';
+
+beforeEach(() => {
+  (global as any).PointerEvent = MouseEvent;
+  HTMLCanvasElement.prototype.getContext = () => ({ clearRect: () => {} }) as any;
+  HTMLCanvasElement.prototype.getBoundingClientRect = () => ({
+    left: 0,
+    top: 0,
+    width: 100,
+    height: 100,
+    right: 100,
+    bottom: 100,
+    x: 0,
+    y: 0,
+    toJSON() {},
+  });
+  HTMLCanvasElement.prototype.setPointerCapture = () => {};
+  HTMLCanvasElement.prototype.releasePointerCapture = () => {};
+  usePlannerStore.setState({
+    room: { height: 2700, origin: { x: 0, y: 0 }, walls: [], windows: [], doors: [] },
+    selectedTool: 'wall',
+    selectedWall: { thickness: 0.1 },
+    measurementUnit: 'mm',
+  });
+});
+
+describe('RoomBuilder measurement units', () => {
+  const setup = () => {
+    const canvas = document.createElement('canvas');
+    const camera = new THREE.PerspectiveCamera(75, 1, 0.1, 1000);
+    camera.position.set(0, 5, 5);
+    camera.lookAt(0, 0, 0);
+    const threeRef: any = {
+      current: {
+        renderer: { domElement: canvas },
+        camera,
+        group: { children: [], add: () => {}, remove: () => {} },
+      },
+    };
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = ReactDOM.createRoot(container);
+    act(() => root.render(<RoomBuilder threeRef={threeRef} />));
+    return { container, root };
+  };
+
+  it('interprets keyboard length in millimeters', () => {
+    const { container, root } = setup();
+    const label = container.querySelector('div')!;
+
+    act(() => {
+      window.dispatchEvent(
+        new PointerEvent('pointerdown', { bubbles: true, clientX: 50, clientY: 50 }),
+      );
+    });
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: '5' }));
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: '0' }));
+    });
+
+    expect(label.textContent).toBe('50 mm');
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+    });
+
+    const wall = usePlannerStore.getState().room.walls[0];
+    const len = Math.hypot(wall.end.x - wall.start.x, wall.end.y - wall.start.y);
+    expect(len).toBeCloseTo(0.05);
+
+    root.unmount();
+    container.remove();
+  });
+
+  it('interprets keyboard length in centimeters', () => {
+    usePlannerStore.setState({ measurementUnit: 'cm', selectedTool: 'wall' });
+    const { container, root } = setup();
+    const label = container.querySelector('div')!;
+
+    act(() => {
+      window.dispatchEvent(
+        new PointerEvent('pointerdown', { bubbles: true, clientX: 50, clientY: 50 }),
+      );
+    });
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: '5' }));
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: '0' }));
+    });
+
+    expect(label.textContent).toBe('50 cm');
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+    });
+
+    const wall = usePlannerStore.getState().room.walls[0];
+    const len = Math.hypot(wall.end.x - wall.start.x, wall.end.y - wall.start.y);
+    expect(len).toBeCloseTo(0.5);
+
+    root.unmount();
+    container.remove();
+  });
+});

--- a/tests/roomDrawBoard.edit.test.tsx
+++ b/tests/roomDrawBoard.edit.test.tsx
@@ -50,6 +50,7 @@ beforeEach(() => {
     },
     roomShape: { points: [], segments: [] },
     snapToGrid: false,
+    measurementUnit: 'mm',
   });
 });
 
@@ -218,6 +219,89 @@ describe('RoomDrawBoard editing', () => {
     const pt = usePlannerStore.getState().roomShape.points[0];
     expect(pt.x).toBe(100);
     expect(pt.y).toBe(100);
+
+    root.unmount();
+    container.remove();
+  });
+
+  it('uses millimeters for keyboard input', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = ReactDOM.createRoot(container);
+    act(() => root.render(<RoomDrawBoard width={200} height={100} />));
+    const canvas = container.querySelector('canvas')!;
+    const label = container.querySelector('[data-testid="draw-label"]')!;
+
+    act(() => {
+      canvas.dispatchEvent(
+        new PointerEvent('pointerdown', {
+          bubbles: true,
+          clientX: 10,
+          clientY: 10,
+          pointerId: 1,
+        }),
+      );
+    });
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: '5' }));
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: '0' }));
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: ' ' }));
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: '9' }));
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: '0' }));
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: '°' }));
+    });
+
+    expect(label.textContent).toBe('50 mm / 90°');
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+    });
+
+    const seg = usePlannerStore.getState().roomShape.segments[0];
+    expect(seg.end.y).toBeCloseTo(60);
+
+    root.unmount();
+    container.remove();
+  });
+
+  it('uses centimeters for keyboard input', () => {
+    usePlannerStore.setState({ measurementUnit: 'cm' });
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = ReactDOM.createRoot(container);
+    act(() => root.render(<RoomDrawBoard width={200} height={100} />));
+    const canvas = container.querySelector('canvas')!;
+    const label = container.querySelector('[data-testid="draw-label"]')!;
+
+    act(() => {
+      canvas.dispatchEvent(
+        new PointerEvent('pointerdown', {
+          bubbles: true,
+          clientX: 10,
+          clientY: 10,
+          pointerId: 1,
+        }),
+      );
+    });
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: '5' }));
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: '0' }));
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: ' ' }));
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: '9' }));
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: '0' }));
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: '°' }));
+    });
+
+    expect(label.textContent).toBe('50 cm / 90°');
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+    });
+
+    const seg = usePlannerStore.getState().roomShape.segments[0];
+    expect(seg.end.y).toBeCloseTo(510);
 
     root.unmount();
     container.remove();


### PR DESCRIPTION
## Summary
- read measurement unit from the store in RoomBuilder
- convert keyboard input and labels between mm and cm
- add unit switching tests for RoomDrawBoard and RoomBuilder

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1858899208322aee121fcfe19e5e7