### PR TITLE
feat: split segments with alt click

### DIFF
--- a/src/ui/build/RoomDrawBoard.tsx
+++ b/src/ui/build/RoomDrawBoard.tsx
@@ -411,10 +411,26 @@ const RoomDrawBoard: React.FC<Props> = ({
     }
     const seg = segmentAt(p);
     if (seg) {
-      setSelectedSegment(seg);
-      setSelectedPoint(null);
-      movingSegmentRef.current = { segment: seg, last: p };
-      pushHistory();
+      if (e.altKey || e.detail > 1) {
+        pushHistory();
+        const newPoint: ShapePoint = { id: uuid(), x: p.x, y: p.y };
+        const segments = roomShape.segments.flatMap((s) =>
+          s === seg
+            ? [
+                { start: seg.start, end: newPoint },
+                { start: newPoint, end: seg.end },
+              ]
+            : [s],
+        );
+        setRoomShape({ points: [...roomShape.points, newPoint], segments });
+        setSelectedPoint(newPoint);
+        setSelectedSegment(null);
+      } else {
+        setSelectedSegment(seg);
+        setSelectedPoint(null);
+        movingSegmentRef.current = { segment: seg, last: p };
+        pushHistory();
+      }
       return;
     }
 

--- a/tests/roomDrawBoard.edit.test.tsx
+++ b/tests/roomDrawBoard.edit.test.tsx
@@ -405,6 +405,47 @@ describe('RoomDrawBoard editing', () => {
     container.remove();
   });
 
+  it('inserts a point on segment alt-click', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = ReactDOM.createRoot(container);
+    act(() => root.render(<RoomDrawBoard width={200} height={100} />));
+    const canvas = container.querySelector('canvas')!;
+
+    drawSegment(canvas, 10, 10, 110, 10);
+    const shape = usePlannerStore.getState().roomShape;
+    expect(shape.points.length).toBe(2);
+    expect(shape.segments.length).toBe(1);
+
+    act(() => {
+      canvas.dispatchEvent(
+        new PointerEvent('pointerdown', {
+          bubbles: true,
+          clientX: 60,
+          clientY: 10,
+          altKey: true,
+          pointerId: 1,
+        }),
+      );
+      canvas.dispatchEvent(
+        new PointerEvent('pointerup', {
+          bubbles: true,
+          clientX: 60,
+          clientY: 10,
+          altKey: true,
+          pointerId: 1,
+        }),
+      );
+    });
+
+    const updated = usePlannerStore.getState().roomShape;
+    expect(updated.points.length).toBe(3);
+    expect(updated.segments.length).toBe(2);
+
+    root.unmount();
+    container.remove();
+  });
+
   it('merges points when moved onto another', () => {
     const container = document.createElement('div');
     document.body.appendChild(container);


### PR DESCRIPTION
## Summary
- allow adding a new point on an existing segment via Alt-click or double-click
- ensure segment is split into two at the inserted point
- cover segment splitting with a regression test

## Testing
- `npm test tests/roomDrawBoard.edit.test.tsx`
- `ESLINT_USE_FLAT_CONFIG=false npx eslint src/ui/build/RoomDrawBoard.tsx tests/roomDrawBoard.edit.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c186ebc5dc8322ad59d9201af231d6