### PR TITLE
Add pushHistory option for room updates

### DIFF
--- a/src/ui/build/RoomBuilder.tsx
+++ b/src/ui/build/RoomBuilder.tsx
@@ -176,29 +176,38 @@ const RoomBuilder: React.FC<Props> = ({ threeRef }) => {
     const onMove = (e: PointerEvent) => {
       if (!drag) return;
       const p = getPoint(e);
-      setRoom({
-        walls: roomRef.current.walls.map((w) => {
-          if (w.id !== drag!.wallId) return w;
-          if (drag!.handle === 'start') {
-            return { ...w, start: { x: p.x, y: p.y } };
-          }
-          if (drag!.handle === 'end') {
-            return { ...w, end: { x: p.x, y: p.y } };
-          }
-          const midx = (w.start.x + w.end.x) / 2;
-          const midy = (w.start.y + w.end.y) / 2;
-          const dx = p.x - midx;
-          const dy = p.y - midy;
-          return {
-            ...w,
-            start: { x: w.start.x + dx, y: w.start.y + dy },
-            end: { x: w.end.x + dx, y: w.end.y + dy },
-          };
-        }),
-      });
+      setRoom(
+        {
+          walls: roomRef.current.walls.map((w) => {
+            if (w.id !== drag!.wallId) return w;
+            if (drag!.handle === 'start') {
+              return { ...w, start: { x: p.x, y: p.y } };
+            }
+            if (drag!.handle === 'end') {
+              return { ...w, end: { x: p.x, y: p.y } };
+            }
+            const midx = (w.start.x + w.end.x) / 2;
+            const midy = (w.start.y + w.end.y) / 2;
+            const dx = p.x - midx;
+            const dy = p.y - midy;
+            return {
+              ...w,
+              start: { x: w.start.x + dx, y: w.start.y + dy },
+              end: { x: w.end.x + dx, y: w.end.y + dy },
+            };
+          }),
+        },
+        { pushHistory: false },
+      );
     };
 
     const onUp = () => {
+      if (drag) {
+        setRoom(
+          { walls: [...roomRef.current.walls] },
+          { pushHistory: true },
+        );
+      }
       drag = null;
       window.removeEventListener('pointermove', onMove);
       window.removeEventListener('pointerup', onUp);

--- a/src/ui/build/RoomDrawBoard.tsx
+++ b/src/ui/build/RoomDrawBoard.tsx
@@ -448,10 +448,13 @@ const RoomDrawBoard: React.FC<Props> = ({
       movingPointRef.current.x = p.x;
       movingPointRef.current.y = p.y;
       const points = mergePointIfNeeded(movingPointRef.current);
-      setRoomShape({
-        points: [...points],
-        segments: [...roomShape.segments],
-      });
+      setRoomShape(
+        {
+          points: [...points],
+          segments: [...roomShape.segments],
+        },
+        { pushHistory: false },
+      );
       return;
     }
     if (movingSegmentRef.current) {
@@ -464,10 +467,13 @@ const RoomDrawBoard: React.FC<Props> = ({
       segment.end.x += dx;
       segment.end.y += dy;
       movingSegmentRef.current.last = p;
-      setRoomShape({
-        points: [...roomShape.points],
-        segments: [...roomShape.segments],
-      });
+      setRoomShape(
+        {
+          points: [...roomShape.points],
+          segments: [...roomShape.segments],
+        },
+        { pushHistory: false },
+      );
       return;
     }
     if (!drawingRef.current || !start) {
@@ -489,14 +495,24 @@ const RoomDrawBoard: React.FC<Props> = ({
     }
     if (movingPointRef.current) {
       const points = mergePointIfNeeded(movingPointRef.current);
-      setRoomShape({
-        points: [...points],
-        segments: [...roomShape.segments],
-      });
+      setRoomShape(
+        {
+          points: [...points],
+          segments: [...roomShape.segments],
+        },
+        { pushHistory: true },
+      );
       movingPointRef.current = null;
       return;
     }
     if (movingSegmentRef.current) {
+      setRoomShape(
+        {
+          points: [...roomShape.points],
+          segments: [...roomShape.segments],
+        },
+        { pushHistory: true },
+      );
       movingSegmentRef.current = null;
       return;
     }

--- a/tests/dragHistory.test.ts
+++ b/tests/dragHistory.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { usePlannerStore } from '../src/state/store';
+
+beforeEach(() => {
+  usePlannerStore.setState({
+    modules: [],
+    items: [],
+    past: [],
+    future: [],
+    room: {
+      height: 2700,
+      origin: { x: 0, y: 0 },
+      walls: [
+        { id: 'w1', start: { x: 0, y: 0 }, end: { x: 1, y: 0 }, thickness: 0.1 },
+      ],
+      windows: [],
+      doors: [],
+    },
+    roomShape: { points: [], segments: [] },
+  });
+});
+
+describe('drag history', () => {
+  it('creates only one undo entry for a drag', () => {
+    const { setRoom, undo } = usePlannerStore.getState();
+
+    // simulate dragging wall endpoint several times
+    setRoom(
+      {
+        walls: [
+          { id: 'w1', start: { x: 0, y: 0 }, end: { x: 2, y: 0 }, thickness: 0.1 },
+        ],
+      },
+      { pushHistory: false },
+    );
+    setRoom(
+      {
+        walls: [
+          { id: 'w1', start: { x: 0, y: 0 }, end: { x: 3, y: 0 }, thickness: 0.1 },
+        ],
+      },
+      { pushHistory: false },
+    );
+    setRoom(
+      {
+        walls: [
+          { id: 'w1', start: { x: 0, y: 0 }, end: { x: 4, y: 0 }, thickness: 0.1 },
+        ],
+      },
+      { pushHistory: true },
+    );
+
+    expect(usePlannerStore.getState().past).toHaveLength(1);
+
+    undo();
+
+    const end = usePlannerStore.getState().room.walls[0].end.x;
+    expect(end).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary
- allow setRoom and setRoomShape to skip history with `pushHistory`
- avoid cluttering undo stack during drags in RoomDrawBoard and RoomBuilder
- test that dragging only adds one undo entry

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1e1a7f18c8322bb54125021be7750