### PR TITLE
Prevent intersecting room segments

### DIFF
--- a/src/utils/roomShape.ts
+++ b/src/utils/roomShape.ts
@@ -6,6 +6,67 @@ export const EPSILON = 1e-6;
 export const pointsEqual = (pt: ShapePoint, p: ShapePoint, eps = EPSILON) =>
   Math.abs(pt.x - p.x) < eps && Math.abs(pt.y - p.y) < eps;
 
+interface SegmentLike {
+  start: ShapePoint;
+  end: ShapePoint;
+}
+
+const orientation = (a: ShapePoint, b: ShapePoint, c: ShapePoint) => {
+  const val = (b.x - a.x) * (c.y - a.y) - (b.y - a.y) * (c.x - a.x);
+  if (Math.abs(val) < EPSILON) return 0;
+  return val > 0 ? 1 : -1;
+};
+
+const onSegment = (a: ShapePoint, b: ShapePoint, c: ShapePoint) =>
+  b.x <= Math.max(a.x, c.x) + EPSILON &&
+  b.x + EPSILON >= Math.min(a.x, c.x) &&
+  b.y <= Math.max(a.y, c.y) + EPSILON &&
+  b.y + EPSILON >= Math.min(a.y, c.y);
+
+const segmentsIntersect = (s1: SegmentLike, s2: SegmentLike) => {
+  const { start: p1, end: q1 } = s1;
+  const { start: p2, end: q2 } = s2;
+
+  const o1 = orientation(p1, q1, p2);
+  const o2 = orientation(p1, q1, q2);
+  const o3 = orientation(p2, q2, p1);
+  const o4 = orientation(p2, q2, q1);
+
+  if (o1 !== 0 && o2 !== 0 && o3 !== 0 && o4 !== 0 && o1 !== o2 && o3 !== o4)
+    return true;
+
+  if (
+    o1 === 0 &&
+    onSegment(p1, p2, q1) &&
+    !pointsEqual(p2, p1) &&
+    !pointsEqual(p2, q1)
+  )
+    return true;
+  if (
+    o2 === 0 &&
+    onSegment(p1, q2, q1) &&
+    !pointsEqual(q2, p1) &&
+    !pointsEqual(q2, q1)
+  )
+    return true;
+  if (
+    o3 === 0 &&
+    onSegment(p2, p1, q2) &&
+    !pointsEqual(p1, p2) &&
+    !pointsEqual(p1, q2)
+  )
+    return true;
+  if (
+    o4 === 0 &&
+    onSegment(p2, q1, q2) &&
+    !pointsEqual(q1, p2) &&
+    !pointsEqual(q1, q2)
+  )
+    return true;
+
+  return false;
+};
+
 /**
  * Adds a segment to the given room shape, ensuring start/end points are unique.
  * If a point with the same coordinates already exists, it's reused instead of creating a duplicate.
@@ -14,6 +75,10 @@ export const addSegmentToShape = (
   shape: RoomShape,
   segment: ShapeSegment,
 ): RoomShape => {
+  if (shape.segments.some((s) => segmentsIntersect(s, segment))) {
+    return shape;
+  }
+
   const findPoint = (p: ShapePoint) =>
     shape.points.find((pt) => pointsEqual(pt, p));
 

--- a/tests/roomShape.test.ts
+++ b/tests/roomShape.test.ts
@@ -20,4 +20,27 @@ describe('addSegmentToShape', () => {
     const ids = shape.points.map((p) => p.id);
     expect(ids.every((id) => typeof id === 'string')).toBe(true);
   });
+
+  it('rejects segments that intersect existing ones', () => {
+    let shape: RoomShape = { points: [], segments: [] };
+    shape = addSegmentToShape(shape, { start: { x: 0, y: 0 }, end: { x: 2, y: 0 } });
+    const result = addSegmentToShape(shape, {
+      start: { x: 1, y: -1 },
+      end: { x: 1, y: 1 },
+    });
+
+    expect(result).toBe(shape);
+    expect(shape.segments.length).toBe(1);
+  });
+
+  it('allows segments that only meet at endpoints', () => {
+    let shape: RoomShape = { points: [], segments: [] };
+    shape = addSegmentToShape(shape, { start: { x: 0, y: 0 }, end: { x: 1, y: 0 } });
+    const result = addSegmentToShape(shape, {
+      start: { x: 1, y: 0 },
+      end: { x: 1, y: 1 },
+    });
+
+    expect(result.segments.length).toBe(2);
+  });
 });


### PR DESCRIPTION
## Summary
- add orientation-based intersection detection to room shapes
- skip adding segments that intersect existing ones except at shared endpoints
- test intersecting vs non-intersecting segment additions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c1e3e64158832281d62bfc8f417740