### PR TITLE
Use default wall thickness for wall preview

### DIFF
--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -255,7 +255,7 @@ export const usePlannerStore = create<Store>((set, get) => ({
   playerSpeed: persisted?.playerSpeed ?? 0.1,
   selectedItemSlot: 1,
   selectedTool: null,
-  selectedWall: null,
+  selectedWall: { thickness: 0.1 },
   isRoomDrawing: false,
   showFronts: true,
   itemsByCabinet: (cabinetId) =>

--- a/src/ui/build/RoomBuilder.tsx
+++ b/src/ui/build/RoomBuilder.tsx
@@ -223,10 +223,9 @@ const RoomBuilder: React.FC<Props> = ({ threeRef }) => {
 
   useEffect(() => {
     const three = threeRef.current;
-    if (!three || selectedTool !== 'wall' || !selectedWall?.thickness)
-      return;
+    if (!three || selectedTool !== 'wall') return;
 
-    const size = selectedWall.thickness;
+    const size = selectedWall?.thickness ?? 0.1;
     const geom = new THREE.BoxGeometry(size, 0.01, size);
     const mat = new THREE.MeshStandardMaterial({
       color: '#ffffff',

--- a/tests/roomBuilder.defaultThickness.test.tsx
+++ b/tests/roomBuilder.defaultThickness.test.tsx
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+vi.mock('../src/utils/uuid', () => ({
+  default: () => 'test-uuid',
+  uuid: () => 'test-uuid',
+}));
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (s: string) => s }),
+}));
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { act } from 'react';
+import * as THREE from 'three';
+import RoomBuilder from '../src/ui/build/RoomBuilder';
+import { usePlannerStore } from '../src/state/store';
+
+beforeEach(() => {
+  (global as any).PointerEvent = MouseEvent;
+  HTMLCanvasElement.prototype.getContext = () => ({ clearRect: () => {} }) as any;
+  HTMLCanvasElement.prototype.getBoundingClientRect = () => ({
+    left: 0,
+    top: 0,
+    width: 100,
+    height: 100,
+    right: 100,
+    bottom: 100,
+    x: 0,
+    y: 0,
+    toJSON() {},
+  });
+  HTMLCanvasElement.prototype.setPointerCapture = () => {};
+  HTMLCanvasElement.prototype.releasePointerCapture = () => {};
+  usePlannerStore.setState({
+    room: { height: 2700, origin: { x: 0, y: 0 }, walls: [], windows: [], doors: [] },
+    selectedTool: 'wall',
+    measurementUnit: 'mm',
+  });
+});
+
+describe('RoomBuilder default wall thickness', () => {
+  it('adds a wall using default thickness without adjusting slider', () => {
+    const canvas = document.createElement('canvas');
+    const camera = new THREE.PerspectiveCamera(75, 1, 0.1, 1000);
+    camera.position.set(0, 5, 5);
+    camera.lookAt(0, 0, 0);
+    const threeRef: any = {
+      current: {
+        renderer: { domElement: canvas },
+        camera,
+        group: { children: [], add: () => {}, remove: () => {} },
+      },
+    };
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = ReactDOM.createRoot(container);
+    act(() => root.render(<RoomBuilder threeRef={threeRef} />));
+    act(() => {
+      window.dispatchEvent(
+        new PointerEvent('pointerdown', { bubbles: true, clientX: 10, clientY: 10 }),
+      );
+    });
+    act(() => {
+      window.dispatchEvent(
+        new PointerEvent('pointermove', { bubbles: true, clientX: 10, clientY: 10 }),
+      );
+    });
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: '1' }));
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+    });
+    const wall = usePlannerStore.getState().room.walls[0];
+    expect(wall.thickness).toBe(0.1);
+    root.unmount();
+    container.remove();
+  });
+});


### PR DESCRIPTION
## Summary
- initialize `selectedWall` with default thickness
- allow wall preview without explicitly setting thickness
- test adding walls using default thickness

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1e8b8b76c8322ae776949b8c96934