### PR TITLE
Keep wall tool active after drawing

### DIFF
--- a/src/ui/build/RoomBuilder.tsx
+++ b/src/ui/build/RoomBuilder.tsx
@@ -461,7 +461,10 @@ const RoomBuilder: React.FC<Props> = ({ threeRef }) => {
         color: '#ffffff',
       };
       setRoom({ walls: [...room.walls, newWall] });
-      setSelectedTool(null);
+      // Keep wall tool active to allow drawing consecutive walls
+      if (selectedTool !== 'wall') {
+        setSelectedTool(null);
+      }
       cleanup();
     }
 


### PR DESCRIPTION
## Summary
- allow drawing consecutive walls without reselecting the tool by keeping wall tool selected after finalize

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1ed235fd0832290a5a74811c15ee1