### PR TITLE
Propagate view mode setter to RoomPanel

### DIFF
--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -127,6 +127,7 @@ export default function App() {
           setMode={setMode}
           startMode={startMode}
           viewMode={viewMode}
+          setViewMode={handleSetViewMode}
         />
         {mode === null && (
           <TopBar

--- a/src/ui/SceneViewer.tsx
+++ b/src/ui/SceneViewer.tsx
@@ -57,6 +57,7 @@ interface Props {
   setMode: React.Dispatch<React.SetStateAction<PlayerMode>>;
   startMode: Exclude<PlayerMode, null>;
   viewMode: '3d' | '2d';
+  setViewMode: (v: '3d' | '2d') => void;
 }
 
 const INTERACT_DISTANCE = 1.5;
@@ -82,6 +83,7 @@ const SceneViewer: React.FC<Props> = ({
   setMode,
   startMode,
   viewMode = '3d',
+  setViewMode,
 }) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const store = usePlannerStore();
@@ -905,7 +907,7 @@ const SceneViewer: React.FC<Props> = ({
       {mode === 'build' && !isRoomDrawing && <WallToolSelector />}
       {mode === 'build' && (
         <div style={{ position: 'absolute', top: 60, left: 10 }}>
-          <RoomPanel />
+          <RoomPanel setViewMode={setViewMode} />
         </div>
       )}
       {mode && <ItemHotbar mode={mode} />}


### PR DESCRIPTION
## Summary
- allow SceneViewer to accept a `setViewMode` callback and forward it to `RoomPanel`
- wire App to pass its view mode handler into SceneViewer

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c29a21183c8322a92c4cf5662c0532