### PR TITLE
feat: replace toolbar emojis with icons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "i18next": "^25.4.2",
         "jspdf": "^2.5.1",
+        "lucide-react": "^0.544.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-i18next": "^15.7.3",
@@ -3432,6 +3433,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.544.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.544.0.tgz",
+      "integrity": "sha512-t5tS44bqd825zAW45UQxpG2CvcC4urOwn2TrwSH8u+MjeE+1NnWl6QqeQ/6NdjMqdOygyiT9p3Ev0p1NJykxjw==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/magic-string": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "i18next": "^25.4.2",
     "jspdf": "^2.5.1",
+    "lucide-react": "^0.544.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-i18next": "^15.7.3",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1,4 +1,7 @@
 {
+  "drawWall": "Draw wall",
+  "editWall": "Edit wall",
+  "eraseWall": "Erase wall",
   "app": {
     "mode": "Mode",
     "roles": {

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -1,4 +1,7 @@
 {
+  "drawWall": "Rysuj ścianę",
+  "editWall": "Edytuj ścianę",
+  "eraseWall": "Wymaż ścianę",
   "app": {
     "mode": "Tryb",
     "roles": {

--- a/src/ui/components/WallDrawToolbar.tsx
+++ b/src/ui/components/WallDrawToolbar.tsx
@@ -1,14 +1,17 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Pencil, Hammer, Eraser } from 'lucide-react';
 import { usePlannerStore } from '../../state/store';
 
 const WallDrawToolbar: React.FC = () => {
   const wallTool = usePlannerStore((s) => s.wallTool);
   const setWallTool = usePlannerStore((s) => s.setWallTool);
+  const { t } = useTranslation();
 
-  const tools: { id: 'draw' | 'erase' | 'edit'; icon: string }[] = [
-    { id: 'draw', icon: '✏️' },
-    { id: 'erase', icon: '🧽' },
-    { id: 'edit', icon: '🔨' },
+  const tools: { id: 'draw' | 'edit' | 'erase'; icon: React.ReactNode; label: string }[] = [
+    { id: 'draw', icon: <Pencil size={16} />, label: t('drawWall') },
+    { id: 'edit', icon: <Hammer size={16} />, label: t('editWall') },
+    { id: 'erase', icon: <Eraser size={16} />, label: t('eraseWall') },
   ];
 
   return (
@@ -32,6 +35,8 @@ const WallDrawToolbar: React.FC = () => {
           key={t.id}
           data-tool={t.id}
           className="btnGhost"
+          aria-label={t.label}
+          title={t.label}
           style={
             wallTool === t.id
               ? { background: 'var(--accent)', color: 'var(--white)' }

--- a/tests/wallDrawToolbar.test.tsx
+++ b/tests/wallDrawToolbar.test.tsx
@@ -1,8 +1,17 @@
 // @vitest-environment jsdom
-import { describe, it, expect, beforeAll } from 'vitest';
+import { describe, it, expect, beforeAll, vi } from 'vitest';
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { act } from 'react';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (s: string) =>
+      ({ drawWall: 'Draw wall', editWall: 'Edit wall', eraseWall: 'Erase wall' }[
+        s
+      ] || s),
+  }),
+}));
 
 import WallDrawToolbar from '../src/ui/components/WallDrawToolbar';
 import { usePlannerStore } from '../src/state/store';
@@ -23,13 +32,13 @@ describe('WallDrawToolbar', () => {
       root.render(<WallDrawToolbar />);
     });
 
-    const eraseBtn = container.querySelector('button[data-tool="erase"]');
+    const eraseBtn = container.querySelector('button[aria-label="Erase wall"]');
     act(() => {
       eraseBtn?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
     expect(usePlannerStore.getState().wallTool).toBe('erase');
 
-    const editBtn = container.querySelector('button[data-tool="edit"]');
+    const editBtn = container.querySelector('button[aria-label="Edit wall"]');
     act(() => {
       editBtn?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
@@ -69,7 +78,7 @@ describe('WallDrawToolbar', () => {
       root.render(<WallDrawToolbar />);
     });
 
-    const eraseBtn = container.querySelector('button[data-tool="erase"]');
+    const eraseBtn = container.querySelector('button[aria-label="Erase wall"]');
     act(() => {
       eraseBtn?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
@@ -78,7 +87,7 @@ describe('WallDrawToolbar', () => {
     });
     expect(usePlannerStore.getState().room.walls.length).toBe(0);
 
-    const editBtn = container.querySelector('button[data-tool="edit"]');
+    const editBtn = container.querySelector('button[aria-label="Edit wall"]');
     act(() => {
       editBtn?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });


### PR DESCRIPTION
## Summary
- swap wall drawing toolbar emojis for lucide-react icons
- add translation keys for drawing, editing and erasing walls
- label toolbar buttons for accessibility and update tests to query by label

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c2a75c2eb483228ae7db266c1fb6d0