### PR TITLE
RoomPanel controls viewer mode

### DIFF
--- a/src/ui/MainTabs.tsx
+++ b/src/ui/MainTabs.tsx
@@ -221,7 +221,9 @@ export default function MainTabs({
             onClose={() => setTab(null)}
           />
         )}
-        {tab === 'room' && <RoomPanel setViewMode={setViewMode} />}
+        {tab === 'room' && (
+          <RoomPanel setViewMode={setViewMode} setMode={setMode} />
+        )}
       </SlidingPanel>
     </>
   );

--- a/src/ui/SceneViewer.tsx
+++ b/src/ui/SceneViewer.tsx
@@ -931,7 +931,7 @@ const SceneViewer: React.FC<Props> = ({
       {mode === 'build' && !isRoomDrawing && <WallToolSelector />}
       {mode === 'build' && (
         <div style={{ position: 'absolute', top: 60, left: 10 }}>
-          <RoomPanel setViewMode={setViewMode} />
+          <RoomPanel setViewMode={setViewMode} setMode={setMode} />
         </div>
       )}
       {mode && <ItemHotbar mode={mode} />}

--- a/src/ui/panels/RoomPanel.tsx
+++ b/src/ui/panels/RoomPanel.tsx
@@ -1,12 +1,14 @@
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { usePlannerStore } from '../../state/store';
+import { PlayerMode } from '../types';
 
 interface Props {
   setViewMode: (v: '3d' | '2d') => void;
+  setMode: React.Dispatch<React.SetStateAction<PlayerMode>>;
 }
 
-export default function RoomPanel({ setViewMode }: Props) {
+export default function RoomPanel({ setViewMode, setMode }: Props) {
   const { t } = useTranslation();
   const [wallsOpen, setWallsOpen] = useState(false);
   const [windowsOpen, setWindowsOpen] = useState(false);
@@ -56,6 +58,7 @@ export default function RoomPanel({ setViewMode }: Props) {
   };
 
   const startDrawing = () => {
+    setMode('build');
     setViewMode('2d');
     setIsRoomDrawing(true);
     setWallTool('draw');

--- a/tests/roomPanel.test.tsx
+++ b/tests/roomPanel.test.tsx
@@ -134,7 +134,9 @@ describe('Room features', () => {
     });
 
     act(() => {
-      root.render(<RoomPanel setViewMode={() => {}} />);
+      root.render(
+        <RoomPanel setViewMode={() => {}} setMode={() => {}} />,
+      );
     });
 
     const header = container.querySelector('.section .hd');
@@ -173,8 +175,11 @@ describe('Room features', () => {
     });
 
     const setViewMode = vi.fn();
+    const setMode = vi.fn();
     act(() => {
-      root.render(<RoomPanel setViewMode={setViewMode} />);
+      root.render(
+        <RoomPanel setViewMode={setViewMode} setMode={setMode} />,
+      );
     });
 
     const header = container.querySelector('.section .hd');
@@ -189,6 +194,7 @@ describe('Room features', () => {
       btn?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
 
+    expect(setMode).toHaveBeenCalledWith('build');
     expect(setViewMode).toHaveBeenCalledWith('2d');
     expect(usePlannerStore.getState().isRoomDrawing).toBe(true);
     expect(usePlannerStore.getState().wallTool).toBe('draw');


### PR DESCRIPTION
## Summary
- Allow RoomPanel to update the player's mode and switch view to 2D when drawing starts
- Pass setMode to RoomPanel from MainTabs and SceneViewer overlays
- Extend room panel tests to mock and assert mode changes

## Testing
- `npm test tests/roomPanel.test.tsx`
- `npm test` *(fails: TypeError: c.addEventListener is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68c2aeaeda7083228bc1735bb6f2b7b4