### PR TITLE
Prevent toolbar interactions from placing walls

### DIFF
--- a/src/ui/components/WallDrawToolbar.tsx
+++ b/src/ui/components/WallDrawToolbar.tsx
@@ -16,6 +16,7 @@ const WallDrawToolbar: React.FC = () => {
 
   return (
     <div
+      onPointerDown={(e) => e.stopPropagation()}
       style={{
         position: 'absolute',
         top: 10,
@@ -32,6 +33,7 @@ const WallDrawToolbar: React.FC = () => {
     >
       {tools.map((t) => (
         <button
+          onPointerDown={(e) => e.stopPropagation()}
           key={t.id}
           data-tool={t.id}
           className="btnGhost"

--- a/src/ui/components/WallToolSelector.tsx
+++ b/src/ui/components/WallToolSelector.tsx
@@ -8,6 +8,7 @@ const WallToolSelector: React.FC = () => {
 
   return (
     <div
+      onPointerDown={(e) => e.stopPropagation()}
       style={{
         position: 'absolute',
         bottom: 50,
@@ -22,6 +23,7 @@ const WallToolSelector: React.FC = () => {
     >
       <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
         <input
+          onPointerDown={(e) => e.stopPropagation()}
           type="range"
           min={0.08}
           max={0.25}

--- a/tests/wallDrawToolbar.test.tsx
+++ b/tests/wallDrawToolbar.test.tsx
@@ -110,4 +110,32 @@ describe('WallDrawToolbar', () => {
     root.unmount();
     container.remove();
   });
+
+  it('does not trigger wall placement when clicking toolbar buttons', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = ReactDOM.createRoot(container);
+
+    usePlannerStore.setState({ wallTool: 'draw', isRoomDrawing: true });
+
+    act(() => {
+      root.render(<WallDrawToolbar />);
+    });
+
+    const handler = vi.fn();
+    document.addEventListener('pointerdown', handler);
+
+    const drawBtn = container.querySelector('button[aria-label="Draw wall"]');
+    act(() => {
+      drawBtn?.dispatchEvent(
+        new PointerEvent('pointerdown', { bubbles: true })
+      );
+    });
+
+    expect(handler).not.toHaveBeenCalled();
+
+    document.removeEventListener('pointerdown', handler);
+    root.unmount();
+    container.remove();
+  });
 });


### PR DESCRIPTION
## Summary
- stop pointer events on wall drawing toolbar buttons so canvas doesn't receive them
- keep wall thickness slider from propagating pointer events
- add regression test to ensure toolbar button clicks don't invoke wall placement

## Testing
- `npm test` *(fails: TypeError: c.addEventListener is not a function)*
- `npx vitest run tests/wallDrawToolbar.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68c2b262454c8322b954b0a79416b52e