### PR TITLE
Scope wall tool effects to active mode

### DIFF
--- a/src/ui/build/RoomBuilder.tsx
+++ b/src/ui/build/RoomBuilder.tsx
@@ -327,7 +327,7 @@ const RoomBuilder: React.FC<Props> = ({ threeRef }) => {
 
   useEffect(() => {
     const three = threeRef.current;
-    if (!three) return;
+    if (!three || wallTool !== 'draw') return;
     const dom: HTMLElement = three.renderer.domElement;
     const raycaster = new THREE.Raycaster();
     const plane = new THREE.Plane(new THREE.Vector3(0, 1, 0), 0);

--- a/tests/roomPanel.test.tsx
+++ b/tests/roomPanel.test.tsx
@@ -202,5 +202,19 @@ describe('Room features', () => {
     root.unmount();
     container.remove();
   });
+
+  it('switches wall tools exclusively', () => {
+    usePlannerStore.setState({ wallTool: 'draw' });
+    const setWallTool = usePlannerStore.getState().setWallTool;
+
+    act(() => setWallTool('edit'));
+    expect(usePlannerStore.getState().wallTool).toBe('edit');
+
+    act(() => setWallTool('erase'));
+    expect(usePlannerStore.getState().wallTool).toBe('erase');
+
+    act(() => setWallTool('draw'));
+    expect(usePlannerStore.getState().wallTool).toBe('draw');
+  });
 });
 

--- a/tests/wallDrawToolbar.test.tsx
+++ b/tests/wallDrawToolbar.test.tsx
@@ -13,6 +13,12 @@ vi.mock('react-i18next', () => ({
   }),
 }));
 
+vi.mock('lucide-react', () => ({
+  Pencil: () => null,
+  Hammer: () => null,
+  Eraser: () => null,
+}));
+
 import WallDrawToolbar from '../src/ui/components/WallDrawToolbar';
 import { usePlannerStore } from '../src/state/store';
 
@@ -32,17 +38,27 @@ describe('WallDrawToolbar', () => {
       root.render(<WallDrawToolbar />);
     });
 
+    const drawBtn = container.querySelector('button[aria-label="Draw wall"]');
     const eraseBtn = container.querySelector('button[aria-label="Erase wall"]');
+    const editBtn = container.querySelector('button[aria-label="Edit wall"]');
+
     act(() => {
       eraseBtn?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
     expect(usePlannerStore.getState().wallTool).toBe('erase');
+    expect(usePlannerStore.getState().wallTool).not.toBe('draw');
 
-    const editBtn = container.querySelector('button[aria-label="Edit wall"]');
     act(() => {
       editBtn?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
     expect(usePlannerStore.getState().wallTool).toBe('edit');
+    expect(usePlannerStore.getState().wallTool).not.toBe('erase');
+
+    act(() => {
+      drawBtn?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(usePlannerStore.getState().wallTool).toBe('draw');
+    expect(usePlannerStore.getState().wallTool).not.toBe('edit');
 
     root.unmount();
     container.remove();


### PR DESCRIPTION
## Summary
- gate RoomBuilder drawing effect behind active wall tool
- test wall tool switching and exclusivity

## Testing
- `npm test tests/roomPanel.test.tsx tests/wallDrawToolbar.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c2b3e1310883228347d477b9f88110