### PR TITLE
Replace eraser tool with user icon in wall toolbar

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1,7 +1,6 @@
 {
   "drawWall": "Draw wall",
   "editWall": "Edit wall",
-  "eraseWall": "Erase wall",
   "app": {
     "mode": "Mode",
     "roles": {

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -1,7 +1,6 @@
 {
   "drawWall": "Rysuj ścianę",
   "editWall": "Edytuj ścianę",
-  "eraseWall": "Wymaż ścianę",
   "app": {
     "mode": "Tryb",
     "roles": {

--- a/src/ui/components/WallDrawToolbar.tsx
+++ b/src/ui/components/WallDrawToolbar.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { Pencil, Hammer, Eraser } from 'lucide-react';
+import { User, Hammer } from 'lucide-react';
 import { usePlannerStore } from '../../state/store';
 
 const WallDrawToolbar: React.FC = () => {
@@ -8,10 +8,9 @@ const WallDrawToolbar: React.FC = () => {
   const setWallTool = usePlannerStore((s) => s.setWallTool);
   const { t } = useTranslation();
 
-  const tools: { id: 'draw' | 'edit' | 'erase'; icon: React.ReactNode; label: string }[] = [
-    { id: 'draw', icon: <Pencil size={16} />, label: t('drawWall') },
+  const tools: { id: 'draw' | 'edit'; icon: React.ReactNode; label: string }[] = [
+    { id: 'draw', icon: <User size={16} />, label: t('drawWall') },
     { id: 'edit', icon: <Hammer size={16} />, label: t('editWall') },
-    { id: 'erase', icon: <Eraser size={16} />, label: t('eraseWall') },
   ];
 
   return (

--- a/tests/wallDrawToolbar.test.tsx
+++ b/tests/wallDrawToolbar.test.tsx
@@ -6,17 +6,13 @@ import { act } from 'react';
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
-    t: (s: string) =>
-      ({ drawWall: 'Draw wall', editWall: 'Edit wall', eraseWall: 'Erase wall' }[
-        s
-      ] || s),
+    t: (s: string) => ({ drawWall: 'Draw wall', editWall: 'Edit wall' }[s] || s),
   }),
 }));
 
 vi.mock('lucide-react', () => ({
-  Pencil: () => null,
   Hammer: () => null,
-  Eraser: () => null,
+  User: () => null,
 }));
 
 import WallDrawToolbar from '../src/ui/components/WallDrawToolbar';
@@ -39,20 +35,13 @@ describe('WallDrawToolbar', () => {
     });
 
     const drawBtn = container.querySelector('button[aria-label="Draw wall"]');
-    const eraseBtn = container.querySelector('button[aria-label="Erase wall"]');
     const editBtn = container.querySelector('button[aria-label="Edit wall"]');
-
-    act(() => {
-      eraseBtn?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-    });
-    expect(usePlannerStore.getState().wallTool).toBe('erase');
-    expect(usePlannerStore.getState().wallTool).not.toBe('draw');
 
     act(() => {
       editBtn?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
     expect(usePlannerStore.getState().wallTool).toBe('edit');
-    expect(usePlannerStore.getState().wallTool).not.toBe('erase');
+    expect(usePlannerStore.getState().wallTool).not.toBe('draw');
 
     act(() => {
       drawBtn?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
@@ -64,7 +53,7 @@ describe('WallDrawToolbar', () => {
     container.remove();
   });
 
-  it('erases walls and edits color via store actions', () => {
+  it('edits wall color via store actions', () => {
     usePlannerStore.setState({
       wallTool: 'draw',
       isRoomDrawing: true,
@@ -93,15 +82,6 @@ describe('WallDrawToolbar', () => {
     act(() => {
       root.render(<WallDrawToolbar />);
     });
-
-    const eraseBtn = container.querySelector('button[aria-label="Erase wall"]');
-    act(() => {
-      eraseBtn?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-    });
-    act(() => {
-      usePlannerStore.getState().setRoom({ walls: [] });
-    });
-    expect(usePlannerStore.getState().room.walls.length).toBe(0);
 
     const editBtn = container.querySelector('button[aria-label="Edit wall"]');
     act(() => {


### PR DESCRIPTION
## Summary
- replace Eraser with User icon for draw mode in `WallDrawToolbar`
- drop unused erase tool and translation strings
- adjust tests for new icon

## Testing
- `npm test` *(fails: SceneViewer view mode uses orthographic camera in 2d mode – TypeError: c.addEventListener is not a function)*
- `npx vitest run tests/wallDrawToolbar.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c2b92b58dc8322ad40b286cd772cae