### PR TITLE
feat: stop forcing build mode when drawing

### DIFF
--- a/src/ui/panels/RoomPanel.tsx
+++ b/src/ui/panels/RoomPanel.tsx
@@ -58,7 +58,6 @@ export default function RoomPanel({ setViewMode, setMode }: Props) {
   };
 
   const startDrawing = () => {
-    setMode('build');
     setViewMode('2d');
     setIsRoomDrawing(true);
     setWallTool('draw');

--- a/tests/roomPanel.test.tsx
+++ b/tests/roomPanel.test.tsx
@@ -194,7 +194,7 @@ describe('Room features', () => {
       btn?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
 
-    expect(setMode).toHaveBeenCalledWith('build');
+    expect(setMode).not.toHaveBeenCalled();
     expect(setViewMode).toHaveBeenCalledWith('2d');
     expect(usePlannerStore.getState().isRoomDrawing).toBe(true);
     expect(usePlannerStore.getState().wallTool).toBe('draw');

--- a/tests/sceneViewer.viewMode.test.tsx
+++ b/tests/sceneViewer.viewMode.test.tsx
@@ -12,6 +12,8 @@ vi.mock('three/examples/jsm/controls/OrbitControls.js', () => ({
     enableRotate: true,
     update: vi.fn(),
     dispose: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
   })),
 }));
 


### PR DESCRIPTION
## Summary
- stop switching to build mode when starting room drawing
- update room panel test to match the new behavior
- add missing OrbitControls event listener mocks in SceneViewer view mode tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c2bf47cc948322958a37f5127e8509