### PR TITLE
Render room drawing UI independent of mode

### DIFF
--- a/src/ui/SceneViewer.tsx
+++ b/src/ui/SceneViewer.tsx
@@ -922,7 +922,7 @@ const SceneViewer: React.FC<Props> = ({
           {mode ? 'Tryb edycji' : 'Tryb gracza'}
         </button>
       </div>
-      {mode === 'build' && isRoomDrawing && (
+      {isRoomDrawing && (
         <>
           <RoomBuilder threeRef={threeRef} />
           <WallDrawToolbar />
@@ -934,7 +934,7 @@ const SceneViewer: React.FC<Props> = ({
           <RoomPanel setViewMode={setViewMode} setMode={setMode} />
         </div>
       )}
-      {mode && <ItemHotbar mode={mode} />}
+      {mode && !isRoomDrawing && <ItemHotbar mode={mode} />}
       {mode && isMobile && (
         <>
           <TouchJoystick

--- a/tests/sceneViewer.roomDrawing2d.test.tsx
+++ b/tests/sceneViewer.roomDrawing2d.test.tsx
@@ -1,0 +1,118 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import React from 'react';
+import { act } from 'react';
+import ReactDOM from 'react-dom/client';
+import * as THREE from 'three';
+import SceneViewer from '../src/ui/SceneViewer';
+import { usePlannerStore } from '../src/state/store';
+
+vi.mock('three/examples/jsm/controls/OrbitControls.js', () => ({
+  OrbitControls: vi.fn().mockImplementation(() => ({
+    target: new THREE.Vector3(),
+    enableRotate: true,
+    update: vi.fn(),
+    dispose: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  })),
+}));
+
+vi.mock('../src/scene/engine', () => {
+  return {
+    setupThree: () => {
+      const dom = document.createElement('canvas');
+      dom.getBoundingClientRect = () => ({
+        left: 0,
+        top: 0,
+        width: 100,
+        height: 100,
+        right: 100,
+        bottom: 100,
+        x: 0,
+        y: 0,
+        toJSON() {},
+      });
+      const perspectiveCamera = new THREE.PerspectiveCamera();
+      const orthographicCamera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0.1, 100);
+      const three: any = {
+        scene: {},
+        camera: perspectiveCamera,
+        renderer: { domElement: dom },
+        controls: {
+          enabled: true,
+          target: new THREE.Vector3(),
+          enableRotate: true,
+          update: () => {},
+          dispose: () => {},
+          dollyIn: () => {},
+          dollyOut: () => {},
+        },
+        playerControls: {
+          lock: vi.fn(),
+          unlock: vi.fn(),
+          addEventListener: vi.fn(),
+          removeEventListener: vi.fn(),
+          isLocked: false,
+        },
+        group: { children: [], add: () => {}, remove: () => {} },
+        cabinetDragger: { enable: vi.fn(), disable: vi.fn() },
+        perspectiveCamera,
+        orthographicCamera,
+      };
+      three.setCamera = (cam: THREE.Camera) => {
+        three.camera = cam;
+      };
+      three.setControls = (c: any) => {
+        three.controls = c;
+      };
+      return three;
+    },
+  };
+});
+
+vi.mock('../src/ui/components/ItemHotbar', () => ({
+  default: (props: any) => <div data-testid="item-hotbar" data-mode={props.mode}></div>,
+  hotbarItems: [],
+  buildHotbarItems: () => [],
+  furnishHotbarItems: [],
+}));
+vi.mock('../src/ui/components/TouchJoystick', () => ({ default: () => null }));
+vi.mock('../src/ui/build/RoomBuilder', () => ({ default: () => null }));
+vi.mock('../src/ui/components/WallDrawToolbar', () => ({
+  default: () => <div data-testid="wall-toolbar" />,
+}));
+
+describe('SceneViewer room drawing in 2D view', () => {
+  it('shows wall drawing toolbar without entering game mode', () => {
+    const threeRef: any = { current: null };
+    const setMode = vi.fn();
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = ReactDOM.createRoot(container);
+
+    usePlannerStore.setState({ isRoomDrawing: true });
+
+    act(() => {
+      root.render(
+        <SceneViewer
+          threeRef={threeRef}
+          addCountertop={false}
+          mode={null}
+          setMode={setMode}
+          viewMode="2d"
+        />,
+      );
+    });
+
+    expect(threeRef.current.camera).toBe(threeRef.current.orthographicCamera);
+    expect(threeRef.current.controls.enableRotate).toBe(false);
+
+    expect(container.querySelector('[data-testid="wall-toolbar"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="item-hotbar"]')).toBeNull();
+
+    root.unmount();
+    container.remove();
+  });
+});
+


### PR DESCRIPTION
## Summary
- Show RoomBuilder and WallDrawToolbar whenever room drawing is active
- Hide ItemHotbar during room drawing
- Test that wall drawing toolbar appears in 2D view without entering game mode

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c2c570765c8322b1a59633dcaeb2c0