### PR TITLE
test: avoid game mode activation when drawing

### DIFF
--- a/tests/roomPanel.test.tsx
+++ b/tests/roomPanel.test.tsx
@@ -162,7 +162,7 @@ describe('Room features', () => {
     container.remove();
   });
 
-  it('activates 2D view after clicking draw', () => {
+    it('activates 2D view after clicking draw without changing game mode', () => {
     const container = document.createElement('div');
     document.body.appendChild(container);
     const root = ReactDOM.createRoot(container);

--- a/tests/sceneViewer.roomDrawing2d.test.tsx
+++ b/tests/sceneViewer.roomDrawing2d.test.tsx
@@ -110,6 +110,7 @@ describe('SceneViewer room drawing in 2D view', () => {
 
     expect(container.querySelector('[data-testid="wall-toolbar"]')).not.toBeNull();
     expect(container.querySelector('[data-testid="item-hotbar"]')).toBeNull();
+    expect(setMode).not.toHaveBeenCalled();
 
     root.unmount();
     container.remove();


### PR DESCRIPTION
## Summary
- ensure RoomPanel draw action doesn't trigger game mode
- verify SceneViewer room drawing toolbar works without activating game mode

## Testing
- `npm test tests/roomPanel.test.tsx tests/sceneViewer.roomDrawing2d.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68c2cd21d14c83228b7ab74923894e3f