### PR TITLE
Guard wall creation during room drawing

### DIFF
--- a/src/ui/SceneViewer.tsx
+++ b/src/ui/SceneViewer.tsx
@@ -579,7 +579,12 @@ const SceneViewer: React.FC<Props> = ({
     const raycaster = new THREE.Raycaster();
     const handlePointer = (event: PointerEvent) => {
       if (mode) {
-        if (event.button === 0 && mode === 'build' && store.selectedTool === 'wall') {
+        if (
+          event.button === 0 &&
+          mode === 'build' &&
+          store.selectedTool === 'wall' &&
+          !store.isRoomDrawing
+        ) {
           const rect = renderer.domElement.getBoundingClientRect();
           const mouse = new THREE.Vector2(
             ((event.clientX - rect.left) / rect.width) * 2 - 1,
@@ -746,6 +751,7 @@ const SceneViewer: React.FC<Props> = ({
     updateGhost,
     store.selectedTool,
     store.selectedWall,
+    store.isRoomDrawing,
     store.room,
   ]);
 


### PR DESCRIPTION
## Summary
- prevent SceneViewer from creating walls while room drawing mode is active
- include room drawing state in pointer handler effect dependencies

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c2d20b9fd88322b858f8016ba6b45e