### PR TITLE
Guard wall creation during room drawing

### DIFF
--- a/src/ui/SceneViewer.tsx
+++ b/src/ui/SceneViewer.tsx
@@ -103,6 +103,13 @@ const SceneViewer: React.FC<Props> = ({
   const wallStartRef = useRef<{ x: number; y: number } | null>(null);
   const savedView = useRef<{ pos: THREE.Vector3; target: THREE.Vector3 } | null>(null);
 
+  // reset wall creation state when room drawing mode is active
+  useEffect(() => {
+    if (store.isRoomDrawing) {
+      wallStartRef.current = null;
+    }
+  }, [store.isRoomDrawing]);
+
   const radialItems =
     mode === 'build'
       ? buildHotbarItems()
@@ -579,7 +586,12 @@ const SceneViewer: React.FC<Props> = ({
     const raycaster = new THREE.Raycaster();
     const handlePointer = (event: PointerEvent) => {
       if (mode) {
-        if (event.button === 0 && mode === 'build' && store.selectedTool === 'wall') {
+        if (
+          event.button === 0 &&
+          mode === 'build' &&
+          store.selectedTool === 'wall' &&
+          !store.isRoomDrawing
+        ) {
           const rect = renderer.domElement.getBoundingClientRect();
           const mouse = new THREE.Vector2(
             ((event.clientX - rect.left) / rect.width) * 2 - 1,
@@ -746,6 +758,7 @@ const SceneViewer: React.FC<Props> = ({
     updateGhost,
     store.selectedTool,
     store.selectedWall,
+    store.isRoomDrawing,
     store.room,
   ]);
 


### PR DESCRIPTION
## Summary
- prevent SceneViewer from creating walls while room drawing mode is active
- include room drawing state in pointer handler effect dependencies
- clear any pending wall start when room drawing begins to avoid stray wall placement

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c2d20b9fd88322b858f8016ba6b45e