### PR TITLE
Handle undefined objects when clearing RoomBuilder meshes

### DIFF
--- a/src/ui/build/RoomBuilder.tsx
+++ b/src/ui/build/RoomBuilder.tsx
@@ -50,8 +50,8 @@ const RoomBuilder: React.FC<Props> = ({ threeRef }) => {
     }
     const g = groupRef.current;
     // clear previous meshes
-    while (g.children.length > 0) {
-      const c = g.children.pop() as THREE.Object3D;
+    for (const c of [...g.children]) {
+      if (!c || !(c instanceof THREE.Object3D)) continue;
       g.remove(c);
       c.traverse((o) => {
         if (o instanceof THREE.Mesh) {

--- a/tests/roomBuilder.add-remove.test.tsx
+++ b/tests/roomBuilder.add-remove.test.tsx
@@ -1,0 +1,83 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+vi.mock('../src/utils/uuid', () => ({
+  default: () => 'test-uuid',
+  uuid: () => 'test-uuid',
+}));
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (s: string) => s }),
+}));
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { act } from 'react';
+import * as THREE from 'three';
+import RoomBuilder from '../src/ui/build/RoomBuilder';
+import { usePlannerStore } from '../src/state/store';
+
+beforeEach(() => {
+  (global as any).PointerEvent = MouseEvent;
+  HTMLCanvasElement.prototype.getContext = () => ({ clearRect: () => {} }) as any;
+  HTMLCanvasElement.prototype.getBoundingClientRect = () => ({
+    left: 0,
+    top: 0,
+    width: 100,
+    height: 100,
+    right: 100,
+    bottom: 100,
+    x: 0,
+    y: 0,
+    toJSON() {},
+  });
+  HTMLCanvasElement.prototype.setPointerCapture = () => {};
+  HTMLCanvasElement.prototype.releasePointerCapture = () => {};
+  usePlannerStore.setState({
+    room: { height: 2700, origin: { x: 0, y: 0 }, walls: [], windows: [], doors: [] },
+  });
+});
+
+describe('RoomBuilder wall add/remove', () => {
+  it('adds and removes a wall without error', () => {
+    const canvas = document.createElement('canvas');
+    const camera = new THREE.PerspectiveCamera(75, 1, 0.1, 1000);
+    camera.position.set(0, 5, 5);
+    camera.lookAt(0, 0, 0);
+    const threeRef: any = {
+      current: {
+        renderer: { domElement: canvas },
+        camera,
+        group: { children: [], add: () => {}, remove: () => {} },
+      },
+    };
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = ReactDOM.createRoot(container);
+
+    expect(() => {
+      act(() => root.render(<RoomBuilder threeRef={threeRef} />));
+      act(() => {
+        usePlannerStore.setState((s) => ({
+          room: {
+            ...s.room,
+            walls: [
+              {
+                id: 'w1',
+                start: { x: 0, y: 0 },
+                end: { x: 1, y: 0 },
+                height: 2.7,
+                thickness: 0.1,
+              },
+            ],
+          },
+        }));
+      });
+      act(() => {
+        usePlannerStore.setState((s) => ({
+          room: { ...s.room, walls: [] },
+        }));
+      });
+    }).not.toThrow();
+
+    root.unmount();
+    container.remove();
+  });
+});


### PR DESCRIPTION
## Summary
- Replace mesh-clearing loop with safer iteration that verifies each child is an Object3D
- Add regression test to ensure adding and removing walls doesn't throw errors

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c2fc60fb4c83228ea2e22ffe145713