### PR TITLE
Require build mode for 2D room drawing

### DIFF
--- a/src/ui/SceneViewer.tsx
+++ b/src/ui/SceneViewer.tsx
@@ -939,7 +939,7 @@ const SceneViewer: React.FC<Props> = ({
           {mode ? 'Tryb edycji' : 'Tryb gracza'}
         </button>
       </div>
-      {isRoomDrawing && (
+      {mode === 'build' && isRoomDrawing && (
         <>
           <RoomBuilder threeRef={threeRef} />
           <WallDrawToolbar />

--- a/src/ui/panels/RoomPanel.tsx
+++ b/src/ui/panels/RoomPanel.tsx
@@ -58,6 +58,7 @@ export default function RoomPanel({ setViewMode, setMode }: Props) {
   };
 
   const startDrawing = () => {
+    setMode('build');
     setViewMode('2d');
     setIsRoomDrawing(true);
     setWallTool('draw');

--- a/tests/roomPanel.test.tsx
+++ b/tests/roomPanel.test.tsx
@@ -194,7 +194,7 @@ describe('Room features', () => {
       btn?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
 
-    expect(setMode).not.toHaveBeenCalled();
+    expect(setMode).toHaveBeenCalledWith('build');
     expect(setViewMode).toHaveBeenCalledWith('2d');
     expect(usePlannerStore.getState().isRoomDrawing).toBe(true);
     expect(usePlannerStore.getState().wallTool).toBe('draw');

--- a/tests/sceneViewer.roomDrawing2d.test.tsx
+++ b/tests/sceneViewer.roomDrawing2d.test.tsx
@@ -84,7 +84,7 @@ vi.mock('../src/ui/components/WallDrawToolbar', () => ({
 }));
 
 describe('SceneViewer room drawing in 2D view', () => {
-  it('shows wall drawing toolbar without entering game mode', () => {
+  it('shows wall drawing toolbar only in build mode', () => {
     const threeRef: any = { current: null };
     const setMode = vi.fn();
     const container = document.createElement('div');
@@ -98,7 +98,7 @@ describe('SceneViewer room drawing in 2D view', () => {
         <SceneViewer
           threeRef={threeRef}
           addCountertop={false}
-          mode={null}
+          mode="build"
           setMode={setMode}
           viewMode="2d"
         />,


### PR DESCRIPTION
## Summary
- Switch to build mode before starting room drawing
- Render 2D room builder only when in build mode
- Update tests for new build-mode room drawing behavior

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c3032a56a483229267a169f208c756