### PR TITLE
Keep mode unchanged while drawing rooms

### DIFF
--- a/src/ui/MainTabs.tsx
+++ b/src/ui/MainTabs.tsx
@@ -221,9 +221,7 @@ export default function MainTabs({
             onClose={() => setTab(null)}
           />
         )}
-        {tab === 'room' && (
-          <RoomPanel setViewMode={setViewMode} setMode={setMode} />
-        )}
+        {tab === 'room' && <RoomPanel setViewMode={setViewMode} />}
       </SlidingPanel>
     </>
   );

--- a/src/ui/SceneViewer.tsx
+++ b/src/ui/SceneViewer.tsx
@@ -115,6 +115,12 @@ const SceneViewer: React.FC<Props> = ({
     }
   }, [store.isRoomDrawing]);
 
+  useEffect(() => {
+    if (!store.isRoomDrawing && viewMode === '2d') {
+      setViewMode('3d');
+    }
+  }, [store.isRoomDrawing, viewMode, setViewMode]);
+
   const radialItems =
     mode === 'build'
       ? buildHotbarItems()
@@ -948,7 +954,7 @@ const SceneViewer: React.FC<Props> = ({
       {mode === 'build' && !isRoomDrawing && <WallToolSelector />}
       {mode === 'build' && (
         <div style={{ position: 'absolute', top: 60, left: 10 }}>
-          <RoomPanel setViewMode={setViewMode} setMode={setMode} />
+          <RoomPanel setViewMode={setViewMode} />
         </div>
       )}
       {mode && !isRoomDrawing && <ItemHotbar mode={mode} />}

--- a/src/ui/panels/RoomPanel.tsx
+++ b/src/ui/panels/RoomPanel.tsx
@@ -1,14 +1,12 @@
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { usePlannerStore } from '../../state/store';
-import { PlayerMode } from '../types';
 
 interface Props {
   setViewMode: (v: '3d' | '2d') => void;
-  setMode: React.Dispatch<React.SetStateAction<PlayerMode>>;
 }
 
-export default function RoomPanel({ setViewMode, setMode }: Props) {
+export default function RoomPanel({ setViewMode }: Props) {
   const { t } = useTranslation();
   const [wallsOpen, setWallsOpen] = useState(false);
   const [windowsOpen, setWindowsOpen] = useState(false);
@@ -58,7 +56,6 @@ export default function RoomPanel({ setViewMode, setMode }: Props) {
   };
 
   const startDrawing = () => {
-    setMode('build');
     setViewMode('2d');
     setIsRoomDrawing(true);
     setWallTool('draw');

--- a/tests/roomPanel.test.tsx
+++ b/tests/roomPanel.test.tsx
@@ -134,9 +134,7 @@ describe('Room features', () => {
     });
 
     act(() => {
-      root.render(
-        <RoomPanel setViewMode={() => {}} setMode={() => {}} />,
-      );
+      root.render(<RoomPanel setViewMode={() => {}} />);
     });
 
     const header = container.querySelector('.section .hd');
@@ -162,7 +160,7 @@ describe('Room features', () => {
     container.remove();
   });
 
-    it('activates 2D view after clicking draw without changing game mode', () => {
+  it('activates 2D view after clicking draw', () => {
     const container = document.createElement('div');
     document.body.appendChild(container);
     const root = ReactDOM.createRoot(container);
@@ -175,11 +173,8 @@ describe('Room features', () => {
     });
 
     const setViewMode = vi.fn();
-    const setMode = vi.fn();
     act(() => {
-      root.render(
-        <RoomPanel setViewMode={setViewMode} setMode={setMode} />,
-      );
+      root.render(<RoomPanel setViewMode={setViewMode} />);
     });
 
     const header = container.querySelector('.section .hd');
@@ -194,7 +189,6 @@ describe('Room features', () => {
       btn?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
 
-    expect(setMode).toHaveBeenCalledWith('build');
     expect(setViewMode).toHaveBeenCalledWith('2d');
     expect(usePlannerStore.getState().isRoomDrawing).toBe(true);
     expect(usePlannerStore.getState().wallTool).toBe('draw');

--- a/tests/sceneViewer.roomDrawing2d.test.tsx
+++ b/tests/sceneViewer.roomDrawing2d.test.tsx
@@ -87,6 +87,7 @@ describe('SceneViewer room drawing in 2D view', () => {
   it('shows wall drawing toolbar only in build mode', () => {
     const threeRef: any = { current: null };
     const setMode = vi.fn();
+    const setViewMode = vi.fn();
     const container = document.createElement('div');
     document.body.appendChild(container);
     const root = ReactDOM.createRoot(container);
@@ -101,6 +102,7 @@ describe('SceneViewer room drawing in 2D view', () => {
           mode="build"
           setMode={setMode}
           viewMode="2d"
+          setViewMode={setViewMode}
         />,
       );
     });
@@ -110,6 +112,40 @@ describe('SceneViewer room drawing in 2D view', () => {
 
     expect(container.querySelector('[data-testid="wall-toolbar"]')).not.toBeNull();
     expect(container.querySelector('[data-testid="item-hotbar"]')).toBeNull();
+    expect(setMode).not.toHaveBeenCalled();
+
+    root.unmount();
+    container.remove();
+  });
+
+  it('returns to 3d view when room drawing ends', () => {
+    const threeRef: any = { current: null };
+    const setMode = vi.fn();
+    const setViewMode = vi.fn();
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = ReactDOM.createRoot(container);
+
+    usePlannerStore.setState({ isRoomDrawing: true });
+
+    act(() => {
+      root.render(
+        <SceneViewer
+          threeRef={threeRef}
+          addCountertop={false}
+          mode="build"
+          setMode={setMode}
+          viewMode="2d"
+          setViewMode={setViewMode}
+        />,
+      );
+    });
+
+    act(() => {
+      usePlannerStore.getState().setIsRoomDrawing(false);
+    });
+
+    expect(setViewMode).toHaveBeenCalledWith('3d');
     expect(setMode).not.toHaveBeenCalled();
 
     root.unmount();

--- a/tests/sceneViewer.viewMode.test.tsx
+++ b/tests/sceneViewer.viewMode.test.tsx
@@ -74,6 +74,7 @@ describe('SceneViewer view mode', () => {
   it('uses orthographic camera in 2d mode', () => {
     const threeRef: any = { current: null };
     const setMode = vi.fn();
+    const setViewMode = vi.fn();
     const container = document.createElement('div');
     document.body.appendChild(container);
     const root = ReactDOM.createRoot(container);
@@ -86,6 +87,7 @@ describe('SceneViewer view mode', () => {
           mode="build"
           setMode={setMode}
           viewMode="2d"
+          setViewMode={setViewMode}
         />,
       );
     });
@@ -101,6 +103,7 @@ describe('SceneViewer view mode', () => {
           mode="build"
           setMode={setMode}
           viewMode="3d"
+          setViewMode={setViewMode}
         />,
       );
     });


### PR DESCRIPTION
## Summary
- Avoid switching to build mode when starting room drawing
- Restore the default 3D view after room drawing completes
- Adjust tests for the new drawing workflow

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c308bb65d88322870fa8b09137c6a8