### PR TITLE
Allow wall drawing tools in normal mode

### DIFF
--- a/src/ui/SceneViewer.tsx
+++ b/src/ui/SceneViewer.tsx
@@ -945,13 +945,13 @@ const SceneViewer: React.FC<Props> = ({
           {mode ? 'Tryb edycji' : 'Tryb gracza'}
         </button>
       </div>
-      {mode === 'build' && isRoomDrawing && (
+      {isRoomDrawing && (
         <>
           <RoomBuilder threeRef={threeRef} />
           <WallDrawToolbar />
         </>
       )}
-      {mode === 'build' && !isRoomDrawing && <WallToolSelector />}
+      {!isRoomDrawing && mode === null && <WallToolSelector />}
       {mode === 'build' && (
         <div style={{ position: 'absolute', top: 60, left: 10 }}>
           <RoomPanel setViewMode={setViewMode} />


### PR DESCRIPTION
## Summary
- Render RoomBuilder and WallDrawToolbar whenever room drawing is active, regardless of mode
- Show WallToolSelector in normal mode when not drawing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c30a9f7b548322949096661124ccf5