### PR TITLE
Avoid creating zero-length walls

### DIFF
--- a/src/ui/build/RoomBuilder.tsx
+++ b/src/ui/build/RoomBuilder.tsx
@@ -455,6 +455,13 @@ const RoomBuilder: React.FC<Props> = ({ threeRef }) => {
     function finalize(end: { x: number; y: number }) {
       if (!startRef.current) return;
       const { x: sx, y: sy } = startRef.current;
+      const dx = end.x - sx;
+      const dy = end.y - sy;
+      const len = Math.hypot(dx, dy);
+      if (len < 1e-6) {
+        cleanup();
+        return;
+      }
       const wallHeight = room.height / 1000;
       const newWall: Wall = {
         id: uuid(),


### PR DESCRIPTION
## Summary
- Skip adding walls shorter than an epsilon when finalizing a wall draw

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68c311c79ffc832294b5ea59add9b8d9