### PR TITLE
Reset room drawing state on escape

### DIFF
--- a/src/ui/build/RoomBuilder.tsx
+++ b/src/ui/build/RoomBuilder.tsx
@@ -21,6 +21,7 @@ const RoomBuilder: React.FC<Props> = ({ threeRef }) => {
   const setSelectedTool = usePlannerStore((s) => s.setSelectedTool);
   const wallTool = usePlannerStore((s) => s.wallTool);
   const setWallTool = usePlannerStore((s) => s.setWallTool);
+  const setIsRoomDrawing = usePlannerStore((s) => s.setIsRoomDrawing);
   const snapAngle = usePlannerStore((s) => s.snapAngle);
   const snapLength = usePlannerStore((s) => s.snapLength);
   const snapRightAngles = usePlannerStore((s) => s.snapRightAngles);
@@ -434,6 +435,7 @@ const RoomBuilder: React.FC<Props> = ({ threeRef }) => {
     };
 
     function cleanup() {
+      setIsRoomDrawing(false);
       if (previewRef.current) {
         groupRef.current?.remove(previewRef.current);
         previewRef.current.geometry.dispose();
@@ -512,6 +514,7 @@ const RoomBuilder: React.FC<Props> = ({ threeRef }) => {
         finalize(end);
       } else if (e.key === 'Escape') {
         setWallTool('edit');
+        setIsRoomDrawing(false);
         cleanup();
       }
     }
@@ -543,6 +546,7 @@ const RoomBuilder: React.FC<Props> = ({ threeRef }) => {
     snapLength,
     snapRightAngles,
     setWallTool,
+    setIsRoomDrawing,
   ]);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- track room drawing status in RoomBuilder via setIsRoomDrawing
- stop room drawing when escape is pressed and during cleanup

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c312973b748322ba5414eeb326d9e2