### PR TITLE
Handle pointer lock for play mode

### DIFF
--- a/src/ui/SceneViewer.tsx
+++ b/src/ui/SceneViewer.tsx
@@ -301,9 +301,21 @@ const SceneViewer: React.FC<Props> = ({
     (threeRef.current as any).setMode = setMode;
     const pc = threeRef.current.playerControls;
     const onUnlock = () => setMode(null);
+    const onLock = () => {
+      // pointer lock acquired
+      return;
+    };
+    const onPointerlockError = () => {
+      setMode(null);
+      alert('Pointer lock failed');
+    };
     pc.addEventListener('unlock', onUnlock);
+    pc.addEventListener('lock', onLock);
+    pc.addEventListener('pointerlockerror', onPointerlockError);
     return () => {
       pc.removeEventListener('unlock', onUnlock);
+      pc.removeEventListener('lock', onLock);
+      pc.removeEventListener('pointerlockerror', onPointerlockError);
       threeRef.current?.dispose?.();
     };
   }, [threeRef]);
@@ -320,13 +332,11 @@ const SceneViewer: React.FC<Props> = ({
     if (mode === 'furnish') {
       three.controls.enabled = false;
       three.cabinetDragger.enable();
-      three.playerControls.lock();
       three.camera.position.y = store.playerHeight;
     } else {
       three.cabinetDragger.disable();
       if (mode) {
         three.controls.enabled = false;
-        three.playerControls.lock();
         three.camera.position.y = store.playerHeight;
       } else {
         three.playerControls.unlock();

--- a/src/ui/panels/PlayPanel.tsx
+++ b/src/ui/panels/PlayPanel.tsx
@@ -83,6 +83,7 @@ export default function PlayPanel({
           <button
             className="btnGhost"
             onClick={() => {
+              threeRef.current?.playerControls.lock();
               setMode(startMode);
               onClose();
             }}


### PR DESCRIPTION
## Summary
- request pointer lock from the play mode button before switching modes
- watch pointer lock events and revert on errors
- stop automatically locking controls when mode changes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c314dd0a2c832285330167d9993e10