### PR TITLE
feat: add manual exit from drawing

### DIFF
--- a/src/ui/SceneViewer.tsx
+++ b/src/ui/SceneViewer.tsx
@@ -115,11 +115,7 @@ const SceneViewer: React.FC<Props> = ({
     }
   }, [store.isRoomDrawing]);
 
-  useEffect(() => {
-    if (!store.isRoomDrawing && viewMode === '2d') {
-      setViewMode('3d');
-    }
-  }, [store.isRoomDrawing, viewMode, setViewMode]);
+  // Removed automatic switch to 3D when room drawing ends.
 
   const radialItems =
     mode === 'build'
@@ -955,6 +951,20 @@ const SceneViewer: React.FC<Props> = ({
           {mode ? 'Tryb edycji' : 'Tryb gracza'}
         </button>
       </div>
+      {viewMode === '2d' && (
+        <div style={{ position: 'absolute', top: 10, right: 10 }}>
+          <button
+            data-testid="finish-drawing"
+            className="btnGhost"
+            onClick={() => {
+              store.setIsRoomDrawing(false);
+              setViewMode('3d');
+            }}
+          >
+            Zakończ rysowanie
+          </button>
+        </div>
+      )}
       {isRoomDrawing && (
         <>
           <RoomBuilder threeRef={threeRef} />

--- a/tests/sceneViewer.roomDrawing2d.test.tsx
+++ b/tests/sceneViewer.roomDrawing2d.test.tsx
@@ -118,7 +118,7 @@ describe('SceneViewer room drawing in 2D view', () => {
     container.remove();
   });
 
-  it('returns to 3d view when room drawing ends', () => {
+  it('returns to 3d view only after finishing drawing manually', () => {
     const threeRef: any = { current: null };
     const setMode = vi.fn();
     const setViewMode = vi.fn();
@@ -140,13 +140,21 @@ describe('SceneViewer room drawing in 2D view', () => {
         />,
       );
     });
-
     act(() => {
       usePlannerStore.getState().setIsRoomDrawing(false);
     });
 
+    // view mode should not change automatically
+    expect(setViewMode).not.toHaveBeenCalled();
+
+    const finishBtn = container.querySelector('[data-testid="finish-drawing"]') as HTMLElement;
+    act(() => {
+      finishBtn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
     expect(setViewMode).toHaveBeenCalledWith('3d');
     expect(setMode).not.toHaveBeenCalled();
+    expect(usePlannerStore.getState().isRoomDrawing).toBe(false);
 
     root.unmount();
     container.remove();


### PR DESCRIPTION
## Summary
- remove auto switch to 3D when room drawing ends
- add "Finish drawing" control to exit 2D drawing mode
- adjust SceneViewer room drawing tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c318718bf883228dbd7fde4c452667