### PR TITLE
Refine view and room drawing transitions

### DIFF
--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -73,7 +73,7 @@ export default function App() {
   }, [mode]);
 
   useEffect(() => {
-    if (mode !== null) {
+    if (mode !== null && store.isRoomDrawing) {
       setViewMode('3d');
       store.setIsRoomDrawing(false);
     }
@@ -84,7 +84,11 @@ export default function App() {
   };
 
   const toggleViewMode = () => {
-    handleSetViewMode(viewMode === '3d' ? '2d' : '3d');
+    const next = viewMode === '3d' ? '2d' : '3d';
+    handleSetViewMode(next);
+    if (next === '3d' && store.isRoomDrawing) {
+      store.setIsRoomDrawing(false);
+    }
   };
 
   return (


### PR DESCRIPTION
## Summary
- Stop forcing 3D view on mode change unless leaving room drawing
- Toggle view mode exits drawing mode only when necessary

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c31a15fe108322830bc853afc42ecb