### PR TITLE
Handle room drawing activation

### DIFF
--- a/src/ui/build/RoomBuilder.tsx
+++ b/src/ui/build/RoomBuilder.tsx
@@ -21,6 +21,7 @@ const RoomBuilder: React.FC<Props> = ({ threeRef }) => {
   const setSelectedTool = usePlannerStore((s) => s.setSelectedTool);
   const wallTool = usePlannerStore((s) => s.wallTool);
   const setWallTool = usePlannerStore((s) => s.setWallTool);
+  const isRoomDrawing = usePlannerStore((s) => s.isRoomDrawing);
   const setIsRoomDrawing = usePlannerStore((s) => s.setIsRoomDrawing);
   const snapAngle = usePlannerStore((s) => s.snapAngle);
   const snapLength = usePlannerStore((s) => s.snapLength);
@@ -226,7 +227,7 @@ const RoomBuilder: React.FC<Props> = ({ threeRef }) => {
 
   useEffect(() => {
     const three = threeRef.current;
-    if (!three || wallTool !== 'draw') return;
+    if (!three || wallTool !== 'draw' || !isRoomDrawing) return;
 
     const size = selectedWall?.thickness ?? 0.1;
     const geom = new THREE.BoxGeometry(size, 0.01, size);
@@ -269,7 +270,7 @@ const RoomBuilder: React.FC<Props> = ({ threeRef }) => {
         wallPreviewRef.current = null;
       }
     };
-  }, [wallTool, selectedWall?.thickness, threeRef]);
+  }, [wallTool, selectedWall?.thickness, threeRef, isRoomDrawing]);
 
   const addWall = () => {
     const wallHeight = roomRef.current.height / 1000;
@@ -330,7 +331,7 @@ const RoomBuilder: React.FC<Props> = ({ threeRef }) => {
 
   useEffect(() => {
     const three = threeRef.current;
-    if (!three || wallTool !== 'draw') return;
+    if (!three || wallTool !== 'draw' || !isRoomDrawing) return;
     const dom: HTMLElement = three.renderer.domElement;
     const raycaster = new THREE.Raycaster();
     const plane = new THREE.Plane(new THREE.Vector3(0, 1, 0), 0);
@@ -559,6 +560,7 @@ const RoomBuilder: React.FC<Props> = ({ threeRef }) => {
     snapRightAngles,
     setWallTool,
     setIsRoomDrawing,
+    isRoomDrawing,
   ]);
 
   useEffect(() => {

--- a/tests/roomBuilder.defaultThickness.test.tsx
+++ b/tests/roomBuilder.defaultThickness.test.tsx
@@ -34,6 +34,7 @@ beforeEach(() => {
     room: { height: 2700, origin: { x: 0, y: 0 }, walls: [], windows: [], doors: [] },
     selectedTool: 'wall',
     measurementUnit: 'mm',
+    isRoomDrawing: true,
   });
 });
 

--- a/tests/roomBuilder.snap.test.tsx
+++ b/tests/roomBuilder.snap.test.tsx
@@ -37,6 +37,7 @@ beforeEach(() => {
     snapLength: 1,
     snapAngle: 90,
     snapRightAngles: true,
+    isRoomDrawing: true,
   });
 });
 

--- a/tests/roomBuilder.units.test.tsx
+++ b/tests/roomBuilder.units.test.tsx
@@ -35,6 +35,7 @@ beforeEach(() => {
     selectedTool: 'wall',
     selectedWall: { thickness: 0.1 },
     measurementUnit: 'mm',
+    isRoomDrawing: true,
   });
 });
 

--- a/tests/sceneViewer.roomDrawing2d.test.tsx
+++ b/tests/sceneViewer.roomDrawing2d.test.tsx
@@ -159,5 +159,41 @@ describe('SceneViewer room drawing in 2D view', () => {
     root.unmount();
     container.remove();
   });
+
+  it('enables drawing when wall tool was already set to draw', () => {
+    const threeRef: any = { current: null };
+    const setMode = vi.fn();
+    const setViewMode = vi.fn();
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = ReactDOM.createRoot(container);
+
+    usePlannerStore.setState({ wallTool: 'draw', isRoomDrawing: false });
+
+    act(() => {
+      root.render(
+        <SceneViewer
+          threeRef={threeRef}
+          addCountertop={false}
+          mode="build"
+          setMode={setMode}
+          viewMode="2d"
+          setViewMode={setViewMode}
+        />, 
+      );
+    });
+
+    expect(container.querySelector('[data-testid="wall-toolbar"]')).toBeNull();
+
+    act(() => {
+      usePlannerStore.getState().setIsRoomDrawing(true);
+    });
+
+    expect(container.querySelector('[data-testid="wall-toolbar"]')).not.toBeNull();
+
+    root.unmount();
+    container.remove();
+    usePlannerStore.setState({ isRoomDrawing: false, wallTool: 'edit' });
+  });
 });
 


### PR DESCRIPTION
## Summary
- Track room drawing state in `RoomBuilder` and guard draw effects
- Ensure draw effects rerun when room drawing toggles
- Add regression test for enabling drawing when wall tool already active

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c325ae2010832280e61fe6d7165649