### PR TITLE
Default wall tool to edit and update tests

### DIFF
--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -261,7 +261,7 @@ export const usePlannerStore = create<Store>((set, get) => ({
   selectedTool: null,
   selectedWall: { thickness: 0.1 },
   isRoomDrawing: false,
-  wallTool: 'draw',
+  wallTool: 'edit',
   showFronts: true,
   itemsByCabinet: (cabinetId) =>
     get().items.filter((it) => it.cabinetId === cabinetId),

--- a/tests/roomBuilder.defaultThickness.test.tsx
+++ b/tests/roomBuilder.defaultThickness.test.tsx
@@ -35,6 +35,7 @@ beforeEach(() => {
     selectedTool: 'wall',
     measurementUnit: 'mm',
     isRoomDrawing: true,
+    wallTool: 'draw',
   });
 });
 

--- a/tests/roomBuilder.direction.test.tsx
+++ b/tests/roomBuilder.direction.test.tsx
@@ -37,6 +37,7 @@ beforeEach(() => {
     selectedTool: 'wall',
     selectedWall: { thickness: 0.1 },
     isRoomDrawing: true,
+    wallTool: 'draw',
   });
 });
 

--- a/tests/roomBuilder.snap.test.tsx
+++ b/tests/roomBuilder.snap.test.tsx
@@ -38,6 +38,7 @@ beforeEach(() => {
     snapAngle: 90,
     snapRightAngles: true,
     isRoomDrawing: true,
+    wallTool: 'draw',
   });
 });
 

--- a/tests/roomBuilder.units.test.tsx
+++ b/tests/roomBuilder.units.test.tsx
@@ -36,6 +36,7 @@ beforeEach(() => {
     selectedWall: { thickness: 0.1 },
     measurementUnit: 'mm',
     isRoomDrawing: true,
+    wallTool: 'draw',
   });
 });
 

--- a/tests/roomPanel.test.tsx
+++ b/tests/roomPanel.test.tsx
@@ -131,6 +131,7 @@ describe('Room features', () => {
     usePlannerStore.setState({
       room: { height: 2700, origin: { x: 0, y: 0 }, walls: [], windows: [], doors: [] },
       selectedWall: { thickness: 0.1 },
+      wallTool: 'edit',
     });
 
     act(() => {

--- a/tests/sceneViewer.roomDrawing2d.test.tsx
+++ b/tests/sceneViewer.roomDrawing2d.test.tsx
@@ -92,7 +92,7 @@ describe('SceneViewer room drawing in 2D view', () => {
     document.body.appendChild(container);
     const root = ReactDOM.createRoot(container);
 
-    usePlannerStore.setState({ isRoomDrawing: true });
+    usePlannerStore.setState({ isRoomDrawing: true, wallTool: 'draw' });
 
     act(() => {
       root.render(
@@ -126,7 +126,7 @@ describe('SceneViewer room drawing in 2D view', () => {
     document.body.appendChild(container);
     const root = ReactDOM.createRoot(container);
 
-    usePlannerStore.setState({ isRoomDrawing: true });
+    usePlannerStore.setState({ isRoomDrawing: true, wallTool: 'draw' });
 
     act(() => {
       root.render(


### PR DESCRIPTION
## Summary
- Make wall editing the default tool instead of drawing
- Update RoomBuilder, SceneViewer, and RoomPanel tests to specify wallTool explicitly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c327f0f7d4832297f642e9d942a10f