### PR TITLE
Use startDrawing action in RoomPanel

### DIFF
--- a/src/ui/panels/RoomPanel.tsx
+++ b/src/ui/panels/RoomPanel.tsx
@@ -44,8 +44,6 @@ export default function RoomPanel({ setViewMode }: Props) {
   const wallThickness =
     usePlannerStore((s) => s.selectedWall?.thickness) ?? 0.1;
   const setThickness = usePlannerStore((s) => s.setSelectedWallThickness);
-  const setIsRoomDrawing = usePlannerStore((s) => s.setIsRoomDrawing);
-  const setWallTool = usePlannerStore((s) => s.setWallTool);
 
   const handleHeightChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setRoom({ height: parseInt(e.target.value, 10) });
@@ -57,8 +55,7 @@ export default function RoomPanel({ setViewMode }: Props) {
 
   const startDrawing = () => {
     setViewMode('2d');
-    setIsRoomDrawing(true);
-    setWallTool('draw');
+    usePlannerStore.getState().startDrawing();
   };
 
   return (

--- a/tests/roomPanel.test.tsx
+++ b/tests/roomPanel.test.tsx
@@ -166,11 +166,12 @@ describe('Room features', () => {
     document.body.appendChild(container);
     const root = ReactDOM.createRoot(container);
 
+    const startDrawing = vi.fn();
     usePlannerStore.setState({
       room: { height: 2700, origin: { x: 0, y: 0 }, walls: [], windows: [], doors: [] },
       selectedWall: { thickness: 0.1 },
-      isRoomDrawing: false,
       wallTool: 'edit',
+      startDrawing,
     });
 
     const setViewMode = vi.fn();
@@ -191,8 +192,7 @@ describe('Room features', () => {
     });
 
     expect(setViewMode).toHaveBeenCalledWith('2d');
-    expect(usePlannerStore.getState().isRoomDrawing).toBe(true);
-    expect(usePlannerStore.getState().wallTool).toBe('draw');
+    expect(startDrawing).toHaveBeenCalled();
 
     root.unmount();
     container.remove();


### PR DESCRIPTION
## Summary
- Invoke centralized `startDrawing` action when initiating room drawing
- Update RoomPanel tests to expect `startDrawing` action

## Testing
- `npm test tests/roomPanel.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c329e6f36c83229450e30810067182