### PR TITLE
Allow drawing walls during build mode

### DIFF
--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -72,12 +72,9 @@ export default function App() {
     if (mode !== null) setStartMode(mode);
   }, [mode]);
 
-  useEffect(() => {
-    if (mode !== null && store.isRoomDrawing) {
-      setViewMode('3d');
-      store.setIsRoomDrawing(false);
-    }
-  }, [mode, store]);
+  // allow drawing to continue even when a play mode is active
+  // drawing will now be terminated only when the user explicitly exits
+  // drawing mode (e.g. via the "Finish" action in SceneViewer)
 
   const handleSetViewMode = (v: '3d' | '2d') => {
     setViewMode(v);

--- a/tests/sceneViewer.roomDrawing2d.test.tsx
+++ b/tests/sceneViewer.roomDrawing2d.test.tsx
@@ -84,7 +84,7 @@ vi.mock('../src/ui/components/WallDrawToolbar', () => ({
 }));
 
 describe('SceneViewer room drawing in 2D view', () => {
-  it('shows wall drawing toolbar only in build mode', () => {
+  it('continues drawing when switching to build mode', () => {
     const threeRef: any = { current: null };
     const setMode = vi.fn();
     const setViewMode = vi.fn();
@@ -94,6 +94,24 @@ describe('SceneViewer room drawing in 2D view', () => {
 
     usePlannerStore.setState({ isRoomDrawing: true, wallTool: 'draw' });
 
+    // start with no active play mode
+    act(() => {
+      root.render(
+        <SceneViewer
+          threeRef={threeRef}
+          addCountertop={false}
+          mode={null}
+          setMode={setMode}
+          viewMode="2d"
+          setViewMode={setViewMode}
+        />,
+      );
+    });
+
+    expect(container.querySelector('[data-testid="wall-toolbar"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="item-hotbar"]')).toBeNull();
+
+    // switching to build mode should not terminate drawing
     act(() => {
       root.render(
         <SceneViewer
@@ -109,7 +127,6 @@ describe('SceneViewer room drawing in 2D view', () => {
 
     expect(threeRef.current.camera).toBe(threeRef.current.orthographicCamera);
     expect(threeRef.current.controls.enableRotate).toBe(false);
-
     expect(container.querySelector('[data-testid="wall-toolbar"]')).not.toBeNull();
     expect(container.querySelector('[data-testid="item-hotbar"]')).toBeNull();
     expect(setMode).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- Remove effect that forced 3D view and exited drawing when play mode activated
- Add regression test ensuring wall drawing persists in 2D when switching to build mode

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c32e39c5448322af03724e6a1956c8