### PR TITLE
Stop auto-switching to 3D after room drawing

### DIFF
--- a/src/ui/SceneViewer.tsx
+++ b/src/ui/SceneViewer.tsx
@@ -978,16 +978,30 @@ const SceneViewer: React.FC<Props> = ({
         </button>
       </div>
       {viewMode === '2d' && (
-        <div style={{ position: 'absolute', top: 10, right: 10 }}>
+        <div
+          style={{
+            position: 'absolute',
+            top: 10,
+            right: 10,
+            display: 'flex',
+            gap: 8,
+          }}
+        >
           <button
             data-testid="finish-drawing"
             className="btnGhost"
             onClick={() => {
               store.finishDrawing();
-              setViewMode('3d');
             }}
           >
             Zakończ rysowanie
+          </button>
+          <button
+            data-testid="switch-3d"
+            className="btnGhost"
+            onClick={() => setViewMode('3d')}
+          >
+            Widok 3D
           </button>
         </div>
       )}

--- a/tests/sceneViewer.roomDrawing2d.test.tsx
+++ b/tests/sceneViewer.roomDrawing2d.test.tsx
@@ -135,7 +135,7 @@ describe('SceneViewer room drawing in 2D view', () => {
     container.remove();
   });
 
-  it('returns to 3d view only after finishing drawing manually', () => {
+  it('stays in 2d after finishing drawing until manually switched', () => {
     const threeRef: any = { current: null };
     const setMode = vi.fn();
     const setViewMode = vi.fn();
@@ -157,21 +157,22 @@ describe('SceneViewer room drawing in 2D view', () => {
         />,
       );
     });
-    act(() => {
-      usePlannerStore.getState().finishDrawing();
-    });
-
-    // view mode should not change automatically
-    expect(setViewMode).not.toHaveBeenCalled();
 
     const finishBtn = container.querySelector('[data-testid="finish-drawing"]') as HTMLElement;
     act(() => {
       finishBtn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
 
+    expect(setViewMode).not.toHaveBeenCalled();
+    expect(usePlannerStore.getState().isRoomDrawing).toBe(false);
+
+    const switchBtn = container.querySelector('[data-testid="switch-3d"]') as HTMLElement;
+    act(() => {
+      switchBtn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
     expect(setViewMode).toHaveBeenCalledWith('3d');
     expect(setMode).not.toHaveBeenCalled();
-    expect(usePlannerStore.getState().isRoomDrawing).toBe(false);
 
     root.unmount();
     container.remove();


### PR DESCRIPTION
## Summary
- Finish drawing without forcing 3D view and add a manual "Widok 3D" switch
- Update room drawing tests to require manual toggle back to 3D

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c3310b0fd483229a15f1a855709edc