### PR TITLE
Remove legacy wall functionality

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -182,30 +182,9 @@ export interface Module3D {
   openStates?: boolean[];
 }
 
-export interface Wall {
-  id: string;
-  start: { x: number; y: number };
-  end: { x: number; y: number };
-  height: number;
-  thickness: number;
-  color?: string;
-}
-
-export interface WallOpening {
-  id: string;
-  wallId: string;
-  offset: number;
-  width: number;
-  height: number;
-  bottom: number;
-}
-
 export interface Room {
   height: number;
   origin: { x: number; y: number };
-  walls: Wall[];
-  windows: WallOpening[];
-  doors: WallOpening[];
 }
 
 export interface PricingData {

--- a/src/ui/SceneViewer.tsx
+++ b/src/ui/SceneViewer.tsx
@@ -7,7 +7,7 @@ import { setupThree } from '../scene/engine';
 import { buildCabinetMesh } from '../scene/cabinetBuilder';
 import { FAMILY } from '../core/catalog';
 import { usePlannerStore, legCategories } from '../state/store';
-import { Module3D, ModuleAdv, Globals, Wall } from '../types';
+import { Module3D, ModuleAdv, Globals } from '../types';
 import { loadItemModel } from '../scene/itemLoader';
 import ItemHotbar, {
   hotbarItems,
@@ -471,8 +471,7 @@ const SceneViewer: React.FC<Props> = ({
       if (
         c.userData?.kind === 'cab' ||
         c.userData?.kind === 'top' ||
-        c.userData?.kind === 'item' ||
-        c.userData?.kind === 'wall'
+        c.userData?.kind === 'item'
       ) {
         group.remove(c);
         c.traverse((obj) => {
@@ -506,22 +505,6 @@ const SceneViewer: React.FC<Props> = ({
         top.userData.kind = 'top';
         group.add(top);
       }
-    });
-    // draw walls from room data
-    const walls = store.room.walls;
-    walls.forEach((w) => {
-      const len = Math.hypot(w.end.x - w.start.x, w.end.y - w.start.y);
-      const geom = new THREE.BoxGeometry(len, w.height, w.thickness);
-      const mat = new THREE.MeshStandardMaterial({ color: w.color || '#ffffff' });
-      const mesh = new THREE.Mesh(geom, mat);
-      const midx = (w.start.x + w.end.x) / 2;
-      const midy = (w.start.y + w.end.y) / 2;
-      mesh.position.set(midx, w.height / 2, midy);
-      const angle = Math.atan2(w.end.y - w.start.y, w.end.x - w.start.x);
-      mesh.rotation.y = -angle;
-      mesh.userData.kind = 'wall';
-      mesh.userData.wallId = w.id;
-      group.add(mesh);
     });
 
     store.items.forEach((it) => {
@@ -560,7 +543,6 @@ const SceneViewer: React.FC<Props> = ({
     addCountertop,
     showEdges,
     showFronts,
-    store.room.walls,
     store.room.height,
   ]);
 
@@ -822,7 +804,7 @@ const SceneViewer: React.FC<Props> = ({
         onSelect={(slot) => {
           store.setSelectedItemSlot(slot);
           const tool = radialItems[slot - 1];
-          if (tool === 'wall' || tool === 'window' || tool === 'door') {
+          if (tool === 'window' || tool === 'door') {
             store.setSelectedTool(tool);
           } else {
             store.setSelectedTool(null);

--- a/src/utils/roomShape.ts
+++ b/src/utils/roomShape.ts
@@ -1,4 +1,4 @@
-import type { RoomShape, ShapePoint, ShapeSegment, Wall } from '../types';
+import type { RoomShape, ShapePoint, ShapeSegment } from '../types';
 import uuid from './uuid';
 
 export const EPSILON = 1e-6;
@@ -118,18 +118,3 @@ export const removeSegmentFromShape = (
 };
 
 export default addSegmentToShape;
-
-/** Converts a room shape to an array of walls. */
-export const shapeToWalls = (
-  shape: RoomShape,
-  opts?: { height?: number; thickness?: number },
-): Wall[] => {
-  const { height = 2.7, thickness = 0.1 } = opts || {};
-  return shape.segments.map((seg) => ({
-    id: uuid(),
-    start: { x: seg.start.x, y: seg.start.y },
-    end: { x: seg.end.x, y: seg.end.y },
-    height,
-    thickness,
-  }));
-};


### PR DESCRIPTION
## Summary
- drop wall and wall-opening types in favor of minimal `Room` definition
- simplify planner store: remove wall state and history conversions, track `roomShape` directly
- eliminate wall rendering and tools from 3D scene viewer

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c33b7feb708322872221a91f1ab592