### PR TITLE
feat: add draw tool menu

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -220,7 +220,10 @@
     "insert": "Insert",
     "dropCeiling": "Drop ceiling",
     "length": "Length",
-    "place": "Place"
+    "place": "Place",
+    "pencil": "Pencil",
+    "hammer": "Hammer",
+    "eraser": "Eraser"
   },
   "items": {
     "cup": "Cup",

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -220,7 +220,10 @@
     "insert": "Wstaw",
     "dropCeiling": "Sufit opuszczany",
     "length": "Długość",
-    "place": "Umieść"
+    "place": "Umieść",
+    "pencil": "Ołówek",
+    "hammer": "Młotek",
+    "eraser": "Gumka"
   },
   "items": {
     "cup": "Kubek",

--- a/src/ui/panels/RoomTab.tsx
+++ b/src/ui/panels/RoomTab.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { Pencil, Hammer, Eraser } from 'lucide-react';
 import SingleMMInput from '../components/SingleMMInput';
 import { usePlannerStore } from '../../state/store';
 
@@ -13,6 +14,7 @@ export default function RoomTab() {
   const [openH, setOpenH] = useState(1000);
   const [openW, setOpenW] = useState(1000);
   const [openF, setOpenF] = useState(0);
+  const [showDrawMenu, setShowDrawMenu] = useState(false);
 
   const [ceilL, setCeilL] = useState(1000);
   const [ceilW, setCeilW] = useState(1000);
@@ -32,15 +34,56 @@ export default function RoomTab() {
               <div className="small">{t('room.thickness')}</div>
               <SingleMMInput value={wallT} onChange={setWallT} />
             </div>
-            <div style={{ display: 'flex', alignItems: 'flex-end' }}>
+            <div style={{ display: 'flex', alignItems: 'flex-end', position: 'relative' }}>
               <button
                 className="btn"
                 onClick={() => {
-                  store.drawWalls(wallH, wallT);
+                  setShowDrawMenu((m) => !m);
                 }}
               >
                 {t('room.drawWalls')}
               </button>
+              {showDrawMenu && (
+                <div
+                  style={{
+                    position: 'absolute',
+                    top: '100%',
+                    left: 0,
+                    marginTop: 8,
+                    display: 'flex',
+                    gap: 4,
+                    background: 'var(--white)',
+                    border: '1px solid var(--border)',
+                    borderRadius: 8,
+                    padding: 4,
+                  }}
+                >
+                  <button
+                    className="btnGhost"
+                    title={t('room.pencil')}
+                    onClick={() => {
+                      store.drawWalls(wallH, wallT);
+                      setShowDrawMenu(false);
+                    }}
+                  >
+                    <Pencil size={16} />
+                  </button>
+                  <button
+                    className="btnGhost"
+                    title={t('room.hammer')}
+                    onClick={() => setShowDrawMenu(false)}
+                  >
+                    <Hammer size={16} />
+                  </button>
+                  <button
+                    className="btnGhost"
+                    title={t('room.eraser')}
+                    onClick={() => setShowDrawMenu(false)}
+                  >
+                    <Eraser size={16} />
+                  </button>
+                </div>
+              )}
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- show a mini menu with pencil, hammer, and eraser icons when drawing walls
- add i18n strings for new tool icons

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c3dd69b9388322a57e9b359457deb8