### PR TITLE
Allow toggling 3D view in room tab

### DIFF
--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -116,6 +116,8 @@ export default function App() {
             setMode={setMode}
             startMode={startMode}
             setStartMode={setStartMode}
+            viewMode={viewMode}
+            toggleViewMode={toggleViewMode}
           />
         </div>
       )}

--- a/src/ui/MainTabs.tsx
+++ b/src/ui/MainTabs.tsx
@@ -47,6 +47,8 @@ interface MainTabsProps {
   setMode: (v: PlayerMode) => void;
   startMode: Exclude<PlayerMode, null>;
   setStartMode: (v: Exclude<PlayerMode, null>) => void;
+  viewMode: '3d' | '2d';
+  toggleViewMode: () => void;
 }
 
 export default function MainTabs({
@@ -80,6 +82,8 @@ export default function MainTabs({
   setMode,
   startMode,
   setStartMode,
+  viewMode,
+  toggleViewMode,
 }: MainTabsProps) {
   const toggleTab = (
     name: 'cab' | 'costs' | 'cut' | 'room' | 'global' | 'play',
@@ -209,7 +213,9 @@ export default function MainTabs({
             setBoardHasGrain={setBoardHasGrain}
           />
         )}
-        {tab === 'room' && <RoomTab />}
+        {tab === 'room' && (
+          <RoomTab viewMode={viewMode} toggleViewMode={toggleViewMode} />
+        )}
         {tab === 'global' && <GlobalSettings />}
         {tab === 'play' && (
           <PlayPanel

--- a/src/ui/panels/RoomTab.tsx
+++ b/src/ui/panels/RoomTab.tsx
@@ -4,7 +4,12 @@ import { Pencil, Hammer, Eraser } from 'lucide-react';
 import SingleMMInput from '../components/SingleMMInput';
 import { usePlannerStore } from '../../state/store';
 
-export default function RoomTab() {
+interface RoomTabProps {
+  viewMode: '3d' | '2d';
+  toggleViewMode: () => void;
+}
+
+export default function RoomTab({ viewMode, toggleViewMode }: RoomTabProps) {
   const { t } = useTranslation();
   const store = usePlannerStore();
 
@@ -22,6 +27,15 @@ export default function RoomTab() {
 
   return (
     <>
+      <div style={{ display: 'flex', justifyContent: 'flex-end', marginBottom: 8 }}>
+        <button
+          className="btnGhost"
+          onClick={toggleViewMode}
+          data-testid="room-view-toggle"
+        >
+          {t(viewMode === '3d' ? 'app.view2D' : 'app.view3D')}
+        </button>
+      </div>
       <div className="section">
         <div className="hd"><div><div className="h1">{t('room.walls')}</div></div></div>
         <div className="bd">

--- a/tests/roomTab.viewMode.test.tsx
+++ b/tests/roomTab.viewMode.test.tsx
@@ -1,0 +1,37 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import React from 'react';
+import { act } from 'react';
+import ReactDOM from 'react-dom/client';
+import RoomTab from '../src/ui/panels/RoomTab';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+vi.mock('../src/state/store', () => ({
+  usePlannerStore: () => ({
+    drawWalls: vi.fn(),
+    selectWindow: vi.fn(),
+    selectDoor: vi.fn(),
+    insertOpening: vi.fn(),
+    placeDropCeiling: vi.fn(),
+  }),
+}));
+
+describe('RoomTab view toggle', () => {
+  it('invokes toggleViewMode on button click', () => {
+    const toggle = vi.fn();
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = ReactDOM.createRoot(container);
+
+    act(() => {
+      root.render(<RoomTab viewMode="2d" toggleViewMode={toggle} />);
+    });
+    const btn = container.querySelector('[data-testid="room-view-toggle"]') as HTMLButtonElement;
+    btn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(toggle).toHaveBeenCalled();
+
+    root.unmount();
+  });
+});


### PR DESCRIPTION
## Summary
- expose view mode controls to Room tab
- test Room tab view toggle

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c3dffbe37c832283c6a9457d5a5fad