### PR TITLE
Center draw tools menu above toggle

### DIFF
--- a/src/ui/panels/RoomTab.tsx
+++ b/src/ui/panels/RoomTab.tsx
@@ -61,9 +61,10 @@ export default function RoomTab({ viewMode, toggleViewMode }: RoomTabProps) {
                 <div
                   style={{
                     position: 'absolute',
-                    top: '100%',
-                    left: 0,
-                    marginTop: 8,
+                    bottom: '100%',
+                    left: '50%',
+                    transform: 'translateX(-50%)',
+                    marginBottom: 8,
                     display: 'flex',
                     gap: 4,
                     background: 'var(--white)',


### PR DESCRIPTION
## Summary
- center the draw tools menu above the wall drawing toggle button

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c3e4926214832281a5edb7fbd81edb