### PR TITLE
feat: reposition top bar and adjust styles

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -1,7 +1,8 @@
 :root{--bg:#F9FAFB;--border:#E5E7EB;--ink:#111827;--muted:#6B7280;--accent:#111827;--white:#fff}
 .app{display:flex;flex-direction:column;height:100vh;width:100vw;color:var(--ink);position:relative}
 .canvasWrap{flex:1;position:relative;background:#F3F4F6}
-.topbar{position:absolute;top:12px;left:12px;z-index:10;display:flex;gap:8px;background:rgba(255,255,255,.85);border:1px solid var(--border);border-radius:10px;padding:8px;backdrop-filter:blur(6px)}
+.topbar{z-index:10;display:flex;gap:8px;background:rgba(255,255,255,.85);border:1px solid var(--border);border-radius:10px;padding:8px;backdrop-filter:blur(6px);margin:12px}
+.topBarWrap{border-top:1px solid var(--border)}
 .bottombar{position:absolute;bottom:12px;left:12px;z-index:10;display:flex;gap:8px;background:rgba(255,255,255,.85);border:1px solid var(--border);border-radius:10px;padding:8px;backdrop-filter:blur(6px)}
 .zoomControls{position:absolute;bottom:12px;right:12px;z-index:10;display:flex;flex-direction:column;gap:8px;background:rgba(255,255,255,.85);border:1px solid var(--border);border-radius:10px;padding:8px;backdrop-filter:blur(6px)}
 .h1{font-size:18px;font-weight:700}

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -121,17 +121,8 @@ export default function App() {
           />
         </div>
       )}
-      <div className="canvasWrap">
-        <SceneViewer
-          threeRef={threeRef}
-          addCountertop={addCountertop}
-          mode={mode}
-          setMode={setMode}
-          startMode={startMode}
-          viewMode={viewMode}
-          setViewMode={handleSetViewMode}
-        />
-        {mode === null && (
+      {mode === null && (
+        <div className="topBarWrap">
           <TopBar
             t={t}
             store={store}
@@ -142,7 +133,18 @@ export default function App() {
             viewMode={viewMode}
             toggleViewMode={toggleViewMode}
           />
-        )}
+        </div>
+      )}
+      <div className="canvasWrap">
+        <SceneViewer
+          threeRef={threeRef}
+          addCountertop={addCountertop}
+          mode={mode}
+          setMode={setMode}
+          startMode={startMode}
+          viewMode={viewMode}
+          setViewMode={handleSetViewMode}
+        />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- render `TopBar` below the main tabs and outside the canvas
- add `topBarWrap` container with separating border
- drop absolute positioning from `.topbar` and add spacing

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c3ecec79f08322a1d9705d01d5a57c