### PR TITLE
Attach sliding panel to board container

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -37,7 +37,7 @@
 .muted{color:#64748b}
 .card.danger{border-color:#ef4444;box-shadow:0 0 0 1px #ef4444 inset}
 .slidingPanelOverlay{position:fixed;inset:0;background:none;pointer-events:none}
-.slidingPanel{background:#fff;width:400px;max-width:100%;height:100%;box-shadow:2px 0 8px rgba(0,0,0,.2);padding:16px;overflow-y:auto;position:fixed;left:0;right:auto;top:0;transform:translateX(-100%);transition:transform .3s ease;z-index:50;pointer-events:auto}
+.slidingPanel{background:#fff;width:400px;max-width:100%;box-shadow:2px 0 8px rgba(0,0,0,.2);padding:16px;overflow-y:auto;position:absolute;left:0;right:auto;top:0;bottom:0;transform:translateX(-100%);transition:transform .3s ease;z-index:50;pointer-events:auto}
 .slidingPanel.open{transform:translateX(0)}
 .slidingPanel.bottom{left:0;right:0;top:auto;bottom:0;width:100%;height:auto;transform:translateY(100%);box-shadow:0 -2px 8px rgba(0,0,0,.2)}
 .slidingPanel.bottom.open{transform:translateY(0)}

--- a/src/ui/components/SlidingPanel.tsx
+++ b/src/ui/components/SlidingPanel.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 
 interface SlidingPanelProps {
   isOpen: boolean;
@@ -16,6 +17,12 @@ export default function SlidingPanel({
   locked = false,
 }: SlidingPanelProps) {
   const panelRef = useRef<HTMLDivElement>(null);
+  const [container, setContainer] = useState<HTMLElement | null>(null);
+
+  useEffect(() => {
+    const el = document.querySelector('.canvasWrap');
+    if (el instanceof HTMLElement) setContainer(el);
+  }, []);
 
   useEffect(() => {
     if (!isOpen || locked) return;
@@ -31,8 +38,7 @@ export default function SlidingPanel({
       document.removeEventListener('mousedown', handleMouseDown);
     };
   }, [isOpen, onClose, locked]);
-
-  return (
+  const panel = (
     <div ref={panelRef} className={`slidingPanel ${className}`}>
       {!locked && (
         <button className="slidingPanelClose" onClick={onClose}>
@@ -42,5 +48,7 @@ export default function SlidingPanel({
       {children}
     </div>
   );
+
+  return container ? createPortal(panel, container) : panel;
 }
 


### PR DESCRIPTION
## Summary
- Render SlidingPanel via portal into `.canvasWrap` so it positions relative to the board
- Use absolute positioning and stretch panel vertically within its parent container

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c40854945083229bfcef048b564bfd