### PR TITLE
refactor: remove legacy player mode toggle

### DIFF
--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -139,7 +139,6 @@ export default function App() {
           addCountertop={addCountertop}
           mode={mode}
           setMode={setMode}
-          startMode={startMode}
           viewMode={viewMode}
           setViewMode={handleSetViewMode}
         />

--- a/src/ui/SceneViewer.tsx
+++ b/src/ui/SceneViewer.tsx
@@ -51,7 +51,6 @@ interface Props {
   addCountertop: boolean;
   mode: PlayerMode;
   setMode: React.Dispatch<React.SetStateAction<PlayerMode>>;
-  startMode: Exclude<PlayerMode, null>;
   viewMode: '3d' | '2d';
   setViewMode: (v: '3d' | '2d') => void;
 }
@@ -76,7 +75,6 @@ const SceneViewer: React.FC<Props> = ({
   addCountertop,
   mode,
   setMode,
-  startMode,
   viewMode = '3d',
   setViewMode,
 }) => {
@@ -856,11 +854,6 @@ const SceneViewer: React.FC<Props> = ({
           {pointerLockError}
         </div>
       )}
-      <div style={{ position: 'absolute', top: 10, left: 10 }}>
-        <button className="btnGhost" onClick={() => setMode((m) => (m ? null : startMode || 'furnish'))}>
-          {mode ? 'Tryb edycji' : 'Tryb gracza'}
-        </button>
-      </div>
       {viewMode === '2d' && (
         <div
           style={{

--- a/tests/sceneViewer.pointerLock.test.tsx
+++ b/tests/sceneViewer.pointerLock.test.tsx
@@ -126,7 +126,6 @@ describe('pointer lock handling', () => {
             addCountertop={false}
             mode={mode}
             setMode={setMode}
-            startMode={'furnish'}
             viewMode="3d"
             setViewMode={() => {}}
           />
@@ -166,7 +165,6 @@ describe('pointer lock handling', () => {
             addCountertop={false}
             mode={mode}
             setMode={setMode}
-            startMode={'furnish'}
             viewMode="3d"
             setViewMode={() => {}}
           />


### PR DESCRIPTION
## Summary
- remove obsolete player mode switch and related state
- clean up pointer lock tests accordingly

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c419e6c7a88322b9ccd0ce7763dd4c