### PR TITLE
Force 2D view when switching to Room tab

### DIFF
--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -72,6 +72,10 @@ export default function App() {
     if (mode !== null) setStartMode(mode);
   }, [mode]);
 
+  useEffect(() => {
+    if (tab === 'room') handleSetViewMode('2d');
+  }, [tab]);
+
   const handleSetViewMode = (v: '3d' | '2d') => {
     setViewMode(v);
   };


### PR DESCRIPTION
## Summary
- switch to 2D view automatically when the Room tab is opened

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c41ecaae588322bc166c8aa91234d8