### PR TITLE
Replace eraser tool with grouping action

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -220,9 +220,8 @@
     "length": "Length",
     "place": "Place",
     "pencil": "Pencil",
-    "group": "Group",
     "hammer": "Hammer",
-    "eraser": "Eraser"
+    "group": "Group"
   },
   "items": {
     "cup": "Cup",

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -220,9 +220,8 @@
     "length": "Długość",
     "place": "Umieść",
     "pencil": "Ołówek",
-    "group": "Grupuj",
     "hammer": "Młotek",
-    "eraser": "Gumka"
+    "group": "Grupuj"
   },
   "items": {
     "cup": "Kubek",

--- a/src/ui/panels/RoomTab.tsx
+++ b/src/ui/panels/RoomTab.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Pencil, Group, Hammer } from 'lucide-react';
+import { Pencil, Hammer, Users } from 'lucide-react';
 import SingleMMInput from '../components/SingleMMInput';
 import { usePlannerStore } from '../../state/store';
 
@@ -43,17 +43,17 @@ export default function RoomTab() {
               </button>
               <button
                 className="btnGhost"
-                title={t('room.group')}
-                onClick={() => store.setSelectedTool('group')}
-              >
-                <Group size={16} />
-              </button>
-              <button
-                className="btnGhost"
                 title={t('room.hammer')}
                 onClick={() => store.setSelectedTool('hammer')}
               >
                 <Hammer size={16} />
+              </button>
+              <button
+                className="btnGhost"
+                title={t('room.group')}
+                onClick={() => store.setSelectedTool('group')}
+              >
+                <Users size={16} />
               </button>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- switch wall tool to a grouping action using the Users icon
- remove unused `room.eraser` translations and add `room.group`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c42ec1210083229c32b014c8d23271