### PR TITLE
chore: remove unused drawWalls label

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -201,7 +201,6 @@
   },
   "room": {
     "walls": "Walls",
-    "drawWalls": "Draw",
     "windows": "Windows",
     "windowSingle": "Single window",
     "windowDouble": "Double window",

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -201,7 +201,6 @@
   },
   "room": {
     "walls": "Ściany",
-    "drawWalls": "Rysuj",
     "windows": "Okna",
     "windowSingle": "Okno jednoskrzydłowe",
     "windowDouble": "Okno dwuskrzydłowe",


### PR DESCRIPTION
## Summary
- remove unused `room.drawWalls` translations
- confirm no orphaned "Draw"/"Rysuj" references remain

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c4306188d48322adc95bd754f1620e