### PR TITLE
refactor: move room tools to toolbar

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -220,7 +220,8 @@
     "place": "Place",
     "pencil": "Pencil",
     "hammer": "Hammer",
-    "group": "Group"
+    "group": "Group",
+    "eraser": "Eraser"
   },
   "items": {
     "cup": "Cup",

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -220,7 +220,8 @@
     "place": "Umieść",
     "pencil": "Ołówek",
     "hammer": "Młotek",
-    "group": "Grupuj"
+    "group": "Grupuj",
+    "eraser": "Gumka"
   },
   "items": {
     "cup": "Kubek",

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -145,6 +145,7 @@ export default function App() {
           setMode={setMode}
           viewMode={viewMode}
           setViewMode={handleSetViewMode}
+          roomTabOpen={tab === 'room'}
         />
       </div>
     </div>

--- a/src/ui/SceneViewer.tsx
+++ b/src/ui/SceneViewer.tsx
@@ -13,6 +13,7 @@ import ItemHotbar, {
   hotbarItems,
   furnishHotbarItems,
 } from './components/ItemHotbar';
+import RoomToolBar from './components/RoomToolBar';
 import TouchJoystick from './components/TouchJoystick';
 import { PlayerMode, PlayerSubMode, PLAYER_MODES } from './types';
 import RadialMenu from './components/RadialMenu';
@@ -53,6 +54,7 @@ interface Props {
   setMode: React.Dispatch<React.SetStateAction<PlayerMode>>;
   viewMode: '3d' | '2d';
   setViewMode: (v: '3d' | '2d') => void;
+  roomTabOpen?: boolean;
 }
 
 const INTERACT_DISTANCE = 1.5;
@@ -77,6 +79,7 @@ const SceneViewer: React.FC<Props> = ({
   setMode,
   viewMode = '3d',
   setViewMode,
+  roomTabOpen,
 }) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const store = usePlannerStore();
@@ -874,6 +877,7 @@ const SceneViewer: React.FC<Props> = ({
         </div>
       )}
       {mode && <ItemHotbar mode={mode} />}
+      {roomTabOpen && <RoomToolBar />}
       {mode && isMobile && (
         <>
           <TouchJoystick

--- a/src/ui/components/RoomToolBar.tsx
+++ b/src/ui/components/RoomToolBar.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { Pencil, Hammer, Eraser } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { usePlannerStore } from '../../state/store';
+
+const RoomToolBar: React.FC = () => {
+  const { t } = useTranslation();
+  const drawWalls = usePlannerStore((s) => s.drawWalls);
+  const wallDefaults = usePlannerStore((s) => s.wallDefaults);
+  const setSelectedTool = usePlannerStore((s) => s.setSelectedTool);
+
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        top: 0,
+        left: '50%',
+        transform: 'translateX(-50%)',
+        display: 'flex',
+        gap: 4,
+        padding: 4,
+      }}
+    >
+      <button
+        className="btnGhost"
+        title={t('room.pencil')}
+        onClick={() => drawWalls(wallDefaults.height, wallDefaults.thickness)}
+      >
+        <Pencil size={16} />
+      </button>
+      <button
+        className="btnGhost"
+        title={t('room.hammer')}
+        onClick={() => setSelectedTool('hammer')}
+      >
+        <Hammer size={16} />
+      </button>
+      <button
+        className="btnGhost"
+        title={t('room.eraser')}
+        onClick={() => setSelectedTool('eraser')}
+      >
+        <Eraser size={16} />
+      </button>
+    </div>
+  );
+};
+
+export default RoomToolBar;

--- a/src/ui/panels/RoomTab.tsx
+++ b/src/ui/panels/RoomTab.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Pencil, Hammer, Users } from 'lucide-react';
 import SingleMMInput from '../components/SingleMMInput';
 import { usePlannerStore } from '../../state/store';
 
@@ -32,29 +31,6 @@ export default function RoomTab() {
             <div>
               <div className="small">{t('room.thickness')}</div>
               <SingleMMInput value={wallT} onChange={setWallT} />
-            </div>
-            <div style={{ display: 'flex', alignItems: 'flex-end', gap: 4 }}>
-              <button
-                className="btnGhost"
-                title={t('room.pencil')}
-                onClick={() => store.drawWalls(wallH, wallT)}
-              >
-                <Pencil size={16} />
-              </button>
-              <button
-                className="btnGhost"
-                title={t('room.hammer')}
-                onClick={() => store.setSelectedTool('hammer')}
-              >
-                <Hammer size={16} />
-              </button>
-              <button
-                className="btnGhost"
-                title={t('room.group')}
-                onClick={() => store.setSelectedTool('group')}
-              >
-                <Users size={16} />
-              </button>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- remove wall/hammer/group buttons from RoomTab
- introduce top-centered RoomToolBar for room drawing tools
- render RoomToolBar when room tab is open and wire up prop

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c4429f40c083229c5f9fea2dfc4bf2