### PR TITLE
feat: track active tab for room tools

### DIFF
--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -39,6 +39,8 @@ export default function App() {
   } = useCabinetConfig(family, kind, variant, setVariant);
 
   const [tab, setTab] = useState<'cab' | 'costs' | 'cut' | 'room' | 'global' | 'play' | null>(null);
+  const [activeTab, setActiveTab] =
+    useState<'cab' | 'costs' | 'cut' | 'room' | 'global' | 'play' | null>(null);
   const [boardL, setBoardL] = useState(2800);
   const [boardW, setBoardW] = useState(2070);
   const [boardKerf, setBoardKerf] = useState(3);
@@ -93,6 +95,7 @@ export default function App() {
             t={t}
             tab={tab}
             setTab={setTab}
+            setActiveTab={setActiveTab}
             family={family}
             setFamily={setFamily}
             kind={kind}
@@ -145,7 +148,7 @@ export default function App() {
           setMode={setMode}
           viewMode={viewMode}
           setViewMode={handleSetViewMode}
-          roomTabOpen={tab === 'room'}
+          showRoomTools={activeTab === 'room'}
         />
       </div>
     </div>

--- a/src/ui/MainTabs.tsx
+++ b/src/ui/MainTabs.tsx
@@ -15,6 +15,7 @@ interface MainTabsProps {
   t: (key: string, opts?: any) => string;
   tab: 'cab' | 'costs' | 'cut' | 'room' | 'global' | 'play' | null;
   setTab: (t: 'cab' | 'costs' | 'cut' | 'room' | 'global' | 'play' | null) => void;
+  setActiveTab: (t: 'cab' | 'costs' | 'cut' | 'room' | 'global' | 'play') => void;
   family: FAMILY;
   setFamily: (f: FAMILY) => void;
   kind: Kind | null;
@@ -53,6 +54,7 @@ export default function MainTabs({
   t,
   tab,
   setTab,
+  setActiveTab,
   family,
   setFamily,
   kind,
@@ -85,6 +87,7 @@ export default function MainTabs({
     name: 'cab' | 'costs' | 'cut' | 'room' | 'global' | 'play',
   ) => {
     setTab(tab === name ? null : name);
+    setActiveTab(name);
   };
 
   return (

--- a/src/ui/SceneViewer.tsx
+++ b/src/ui/SceneViewer.tsx
@@ -54,7 +54,7 @@ interface Props {
   setMode: React.Dispatch<React.SetStateAction<PlayerMode>>;
   viewMode: '3d' | '2d';
   setViewMode: (v: '3d' | '2d') => void;
-  roomTabOpen?: boolean;
+  showRoomTools?: boolean;
 }
 
 const INTERACT_DISTANCE = 1.5;
@@ -79,7 +79,7 @@ const SceneViewer: React.FC<Props> = ({
   setMode,
   viewMode = '3d',
   setViewMode,
-  roomTabOpen,
+  showRoomTools,
 }) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const store = usePlannerStore();
@@ -877,7 +877,7 @@ const SceneViewer: React.FC<Props> = ({
         </div>
       )}
       {mode && <ItemHotbar mode={mode} />}
-      {roomTabOpen && <RoomToolBar />}
+      {showRoomTools && <RoomToolBar />}
       {mode && isMobile && (
         <>
           <TouchJoystick


### PR DESCRIPTION
## Summary
- track last active tab in App to drive room tools visibility
- ensure MainTabs reports chosen tab even when toggled closed
- SceneViewer now receives showRoomTools flag

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c445f384e08322bcf36d45ffe5e4db