### PR TITLE
feat: center room toolbar with bordered icons

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -220,8 +220,7 @@
     "place": "Place",
     "pencil": "Pencil",
     "hammer": "Hammer",
-    "group": "Group",
-    "eraser": "Eraser"
+    "group": "Group"
   },
   "items": {
     "cup": "Cup",

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -220,8 +220,7 @@
     "place": "Umieść",
     "pencil": "Ołówek",
     "hammer": "Młotek",
-    "group": "Grupuj",
-    "eraser": "Gumka"
+    "group": "Grupuj"
   },
   "items": {
     "cup": "Kubek",

--- a/src/ui/components/RoomToolBar.tsx
+++ b/src/ui/components/RoomToolBar.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Pencil, Hammer, Eraser } from 'lucide-react';
+import { Pencil, Hammer, Users } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { usePlannerStore } from '../../state/store';
 
@@ -19,6 +19,9 @@ const RoomToolBar: React.FC = () => {
         display: 'flex',
         gap: 4,
         padding: 4,
+        background: 'var(--white)',
+        border: '1px solid var(--border)',
+        borderRadius: 8,
       }}
     >
       <button
@@ -37,10 +40,10 @@ const RoomToolBar: React.FC = () => {
       </button>
       <button
         className="btnGhost"
-        title={t('room.eraser')}
-        onClick={() => setSelectedTool('eraser')}
+        title={t('room.group')}
+        onClick={() => setSelectedTool('group')}
       >
-        <Eraser size={16} />
+        <Users size={16} />
       </button>
     </div>
   );


### PR DESCRIPTION
## Summary
- replace eraser with group icon in room toolbar
- add white background and border around room tool icons
- drop unused `room.eraser` translation keys

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c42a0895748322983b67fed400ad8b