### PR TITLE
feat: add wall thickness selector

### DIFF
--- a/src/ui/panels/RoomTab.tsx
+++ b/src/ui/panels/RoomTab.tsx
@@ -3,6 +3,10 @@ import { useTranslation } from 'react-i18next';
 import SingleMMInput from '../components/SingleMMInput';
 import { usePlannerStore } from '../../state/store';
 
+const thicknessOptions = [
+  50, 60, 70, 80, 90, 100, 120, 130, 140, 150, 160, 170, 180, 190, 200, 210, 220, 230, 240, 250,
+];
+
 export default function RoomTab() {
   const { t } = useTranslation();
   const store = usePlannerStore();
@@ -30,7 +34,35 @@ export default function RoomTab() {
             </div>
             <div>
               <div className="small">{t('room.thickness')}</div>
-              <SingleMMInput value={wallT} onChange={setWallT} />
+              <div style={{ display: 'flex', gap: 4, alignItems: 'center' }}>
+                <button
+                  className="btn"
+                  onClick={() => setWallT((t) => Math.max(1, t - 1))}
+                  title="-"
+                >
+                  -
+                </button>
+                <select
+                  className="input"
+                  value={wallT}
+                  onChange={(e) => setWallT(Number(e.target.value))}
+                >
+                  {[...new Set([...thicknessOptions, wallT])]
+                    .sort((a, b) => a - b)
+                    .map((v) => (
+                      <option key={v} value={v}>
+                        {v}
+                      </option>
+                    ))}
+                </select>
+                <button
+                  className="btn"
+                  onClick={() => setWallT((t) => t + 1)}
+                  title="+"
+                >
+                  +
+                </button>
+              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- replace wall thickness input with dropdown options and +/- controls

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c44feb59888322aa5ccc9db3c82e4f