### PR TITLE
feat: log walls in history

### DIFF
--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -156,6 +156,7 @@ type Store = {
     room: Room;
     roomShape: RoomShape;
   }[];
+  history: string[];
   room: Room;
   roomShape: RoomShape;
   snapAngle: number;
@@ -204,6 +205,7 @@ type Store = {
   setSelectedItemSlot: (slot: number) => void;
   setSelectedTool: (tool: string | null) => void;
   addWallSegment: (start: ShapePoint, end: ShapePoint) => void;
+  addWallWithHistory: (start: ShapePoint, end: ShapePoint) => void;
   drawWalls: (height: number, thickness: number) => void;
   selectWindow: (type: 'single' | 'double' | 'triple') => void;
   selectDoor: (type: 'single' | 'double' | 'sliding') => void;
@@ -219,6 +221,7 @@ export const usePlannerStore = create<Store>((set, get) => ({
   items: persisted?.items || [],
   past: [],
   future: [],
+  history: [],
   room: persisted?.room
     ? {
         ...persisted.room,
@@ -516,6 +519,15 @@ export const usePlannerStore = create<Store>((set, get) => ({
       roomShape: addSegmentToShape(s.roomShape, { start, end }),
       future: [],
     })),
+  addWallWithHistory: (start, end) => {
+    get().addWallSegment(start, end);
+    set((s) => ({
+      history: [
+        ...s.history,
+        `Added wall from (${start.x}, ${start.y}) to (${end.x}, ${end.y})`,
+      ],
+    }));
+  },
   drawWalls: (height, thickness) =>
     set((s) => ({
       selectedTool: 'wall',

--- a/src/viewer/WallDrawer.ts
+++ b/src/viewer/WallDrawer.ts
@@ -8,7 +8,7 @@ interface PlannerStore {
   snapToGrid: boolean;
   snapLength: number;
   wallDefaults: { height: number; thickness: number };
-  addWallSegment: (start: ShapePoint, end: ShapePoint) => void;
+  addWallWithHistory: (start: ShapePoint, end: ShapePoint) => void;
 }
 
 export default class WallDrawer {
@@ -170,7 +170,7 @@ export default class WallDrawer {
     }
     const start = { x: this.start.x, y: this.start.y };
     const end = { x: point.x, y: point.y };
-    this.store.getState().addWallSegment(start, end);
+    this.store.getState().addWallWithHistory(start, end);
     this.start = null;
     this.disposePreview();
     if (this.cursor) {


### PR DESCRIPTION
## Summary
- log every added wall segment to a new history stack
- use new addWallWithHistory action when finalizing wall draws

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c47a3eaa9c8322945e9c9493799f7d