### PR TITLE
Extend single-click walls to snap length

### DIFF
--- a/src/viewer/WallDrawer.ts
+++ b/src/viewer/WallDrawer.ts
@@ -168,9 +168,34 @@ export default class WallDrawer {
       this.disposePreview();
       return;
     }
+    const state = this.store.getState();
+    let endX = point.x;
+    let endY = point.y;
+    const dx = endX - this.start.x;
+    const dy = endY - this.start.y;
+    const dist = Math.sqrt(dx * dx + dy * dy);
+    if (dist < 0.001) {
+      const step = state.snapLength / 1000;
+      let dirX = dx;
+      let dirY = dy;
+      if (dirX === 0 && dirY === 0 && this.lastPoint) {
+        dirX = this.lastPoint.x - this.start.x;
+        dirY = this.lastPoint.y - this.start.y;
+      }
+      if (dirX === 0 && dirY === 0) {
+        dirX = 1;
+        dirY = 0;
+      }
+      const len = Math.sqrt(dirX * dirX + dirY * dirY);
+      dirX /= len;
+      dirY /= len;
+      endX = this.start.x + dirX * step;
+      endY = this.start.y + dirY * step;
+      point.set(endX, endY, point.z);
+    }
     const start = { x: this.start.x, y: this.start.y };
-    const end = { x: point.x, y: point.y };
-    this.store.getState().addWallWithHistory(start, end);
+    const end = { x: endX, y: endY };
+    state.addWallWithHistory(start, end);
     this.start = null;
     this.disposePreview();
     if (this.cursor) {


### PR DESCRIPTION
## Summary
- compute start/end distance and extend very short walls
- use snapLength/1000 along last pointer direction or default axis
- drop fixed-length wall segment on single click

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c48163e8848322bf461cccf96350af