### PR TITLE
Prevent raycast on disposed wall preview

### DIFF
--- a/src/viewer/WallDrawer.ts
+++ b/src/viewer/WallDrawer.ts
@@ -97,9 +97,17 @@ export default class WallDrawer {
 
   private disposePreview() {
     if (!this.preview) return;
-    this.group.remove(this.preview);
-    this.preview.geometry.dispose();
-    (this.preview.material as THREE.Material).dispose();
+    const mesh = this.preview;
+    // prevent any further intersections
+    mesh.visible = false;
+    mesh.raycast = () => null;
+    this.group.remove(mesh);
+    const geom = mesh.geometry;
+    const mat = mesh.material as THREE.Material;
+    queueMicrotask(() => {
+      geom.dispose();
+      mat.dispose();
+    });
     this.preview = null;
   }
 
@@ -137,6 +145,10 @@ export default class WallDrawer {
       const midY = (this.start.y + point.y) / 2;
       this.preview.position.set(midX, midY, this.preview.position.z);
       this.preview.rotation.z = Math.atan2(dy, dx);
+      const geometry = this.preview.geometry as THREE.BufferGeometry;
+      geometry.computeBoundingBox();
+      geometry.computeBoundingSphere();
+      geometry.computeVertexNormals();
     }
   };
 
@@ -235,4 +247,3 @@ export default class WallDrawer {
     this.animationId = requestAnimationFrame(this.animateCursor);
   };
 }
-


### PR DESCRIPTION
## Summary
- Hide and disable wall preview meshes before removal to avoid raycasts on disposed geometries
- Dispose preview geometry asynchronously to prevent concurrent raycasting issues
- Recompute preview bounding volumes and normals after scaling for accurate intersections

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c48a774a448322bc2ed6da3bb20ff1