### PR TITLE
fix: release pointer capture on disable

### DIFF
--- a/src/viewer/WallDrawer.ts
+++ b/src/viewer/WallDrawer.ts
@@ -56,6 +56,10 @@ export default class WallDrawer {
 
   disable() {
     if (!this.enabled) return;
+    if (this.pointerId !== null) {
+      this.renderer.domElement.releasePointerCapture(this.pointerId);
+      this.pointerId = null;
+    }
     this.enabled = false;
     const dom = this.renderer.domElement;
     dom.removeEventListener('pointermove', this.onMove);
@@ -69,6 +73,7 @@ export default class WallDrawer {
     this.removeCursor();
     this.disposePreview();
     this.start = null;
+    this.lastPoint = null;
     this.dragging = false;
   }
 


### PR DESCRIPTION
## Summary
- properly release pointer capture and reset direction state when disabling wall drawing

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c491dad2b883229335de2bf27bbad1