### PR TITLE
Guard against zero-length segments in room shape utility

### DIFF
--- a/src/utils/roomShape.ts
+++ b/src/utils/roomShape.ts
@@ -75,6 +75,9 @@ export const addSegmentToShape = (
   shape: RoomShape,
   segment: ShapeSegment,
 ): RoomShape => {
+  if (pointsEqual(segment.start, segment.end)) {
+    return shape;
+  }
   if (shape.segments.some((s) => segmentsIntersect(s, segment))) {
     return shape;
   }


### PR DESCRIPTION
## Summary
- Avoid adding zero-length segments to room shapes

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c4943b7f30832298dee8b6155fa4d4