### PR TITLE
fix: check pointer before release

### DIFF
--- a/src/viewer/WallDrawer.ts
+++ b/src/viewer/WallDrawer.ts
@@ -182,8 +182,10 @@ export default class WallDrawer {
   };
 
   private onUp = (e: PointerEvent) => {
-    this.renderer.domElement.releasePointerCapture(e.pointerId);
-    this.pointerId = null;
+    if (this.pointerId === e.pointerId) {
+      this.renderer.domElement.releasePointerCapture(e.pointerId);
+      this.pointerId = null;
+    }
     if (!this.dragging) return;
     this.dragging = false;
     if (!this.start) return;


### PR DESCRIPTION
## Summary
- release pointer capture only when pointer IDs match in `WallDrawer.onUp`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c49d789f508322bff2d9342dec8686