### PR TITLE
Keep cursor anchored while drawing walls

### DIFF
--- a/src/viewer/WallDrawer.ts
+++ b/src/viewer/WallDrawer.ts
@@ -143,7 +143,11 @@ export default class WallDrawer {
     if (!point) return;
     point.y = 0.001;
     this.lastPoint = point;
-    this.cursorTarget = point.clone();
+    if (!this.dragging) {
+      this.cursorTarget = point.clone();
+    } else if (this.cursor && this.start) {
+      this.cursor.position.set(this.start.x, 0.001, this.start.z);
+    }
     if (this.dragging && this.start && this.preview) {
       const dx = point.x - this.start.x;
       const dz = point.z - this.start.z;


### PR DESCRIPTION
## Summary
- Prevent cursor from moving during wall drawing by updating cursor target only when not dragging
- Ensure wall preview still scales from a fixed start point while cursor remains anchored

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c4a65190d88322bb442bcf2d6e3b0a