### PR TITLE
Keep wall start cursor fixed during drawing

### DIFF
--- a/src/viewer/WallDrawer.ts
+++ b/src/viewer/WallDrawer.ts
@@ -138,8 +138,6 @@ export default class WallDrawer {
     this.lastPoint = point;
     if (!this.dragging) {
       this.cursorTarget = point.clone();
-    } else if (this.cursor && this.start) {
-      this.cursor.position.set(this.start.x, 0.001, this.start.z);
     }
     if (this.dragging && this.start && this.preview) {
       const dx = point.x - this.start.x;
@@ -167,6 +165,10 @@ export default class WallDrawer {
     this.pointerId = e.pointerId;
     this.dragging = true;
     this.start = point.clone();
+    if (this.cursor) {
+      this.cursor.position.copy(point).setY(0.001);
+      this.cursorTarget = this.cursor.position.clone();
+    }
     const state = this.store.getState();
     const height = state.wallDefaults.height / 1000;
     const geom = new THREE.BoxGeometry(1, height, this.thickness);


### PR DESCRIPTION
## Summary
- Fix wall cursor position to stay at initial click
- Stop updating cursor target while dragging so animation doesn't shift start

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c4acf1da548322b8fad1565eb713d1