### PR TITLE
Fix wall preview rotation with inverted Z axis

### DIFF
--- a/src/viewer/WallDrawer.ts
+++ b/src/viewer/WallDrawer.ts
@@ -141,8 +141,10 @@ export default class WallDrawer {
     }
     if (this.dragging && this.start && this.preview) {
       const dx = point.x - this.start.x;
-      const dz = point.z - this.start.z;
-      const dist = Math.sqrt(dx * dx + dz * dz);
+      const dz = this.start.z - point.z; // reverse Z axis
+      const distX = Math.abs(dx);
+      const distZ = Math.abs(dz);
+      const dist = Math.sqrt(distX * distX + distZ * distZ);
       this.preview.scale.x = dist;
       this.preview.position.set(
         this.start.x,


### PR DESCRIPTION
## Summary
- reverse Z-axis delta when computing wall preview angle
- compute distance using positive delta values for stable scaling

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c4b3fd1d34832286fb9c426fa4195d