### PR TITLE
Arrange wall dimension inputs

### DIFF
--- a/src/ui/components/RoomToolBar.tsx
+++ b/src/ui/components/RoomToolBar.tsx
@@ -83,23 +83,33 @@ const RoomToolBar: React.FC = () => {
             borderRadius: 8,
           }}
         >
-          <div>
-            <div className="small">{t('room.height')}</div>
-            <SingleMMInput
-              value={wallDefaults.height}
-              onChange={(v) => drawWalls(v, wallDefaults.thickness)}
-            />
-          </div>
-          <div>
-            <div className="small">{t('room.thickness')}</div>
-            <SingleMMInput
-              value={wallDefaults.thickness}
-              onChange={(v) => drawWalls(wallDefaults.height, v)}
-            />
+          <div style={{ display: 'flex', gap: 4 }}>
+            <div>
+              <div className="small">{t('room.height')}</div>
+              <SingleMMInput
+                value={wallDefaults.height}
+                onChange={(v) => drawWalls(v, wallDefaults.thickness)}
+                maxLength={4}
+              />
+            </div>
+            <div>
+              <div className="small">{t('room.thickness')}</div>
+              <SingleMMInput
+                value={wallDefaults.thickness}
+                onChange={(v) => drawWalls(wallDefaults.height, v)}
+                maxLength={3}
+                max={999}
+              />
+            </div>
           </div>
           <div>
             <div className="small">{t('room.length')}</div>
-            <SingleMMInput value={snapLength} onChange={setSnapLength} />
+            <SingleMMInput
+              value={snapLength}
+              onChange={setSnapLength}
+              maxLength={4}
+              max={9999}
+            />
           </div>
         </div>
       )}

--- a/src/ui/components/SingleMMInput.tsx
+++ b/src/ui/components/SingleMMInput.tsx
@@ -5,24 +5,28 @@ type Props = {
   onChange: (v:number)=>void
   min?: number
   max?: number
-  step?: number
+  maxLength?: number
 }
 
-export default function SingleMMInput({ value, onChange, min=0, max=4000, step=1 }: Props){
+export default function SingleMMInput({ value, onChange, min=0, max=4000, maxLength }: Props){
   const clamp = (v:number) => Math.max(min, Math.min(max, v))
-  const val = Number.isFinite(value) ? value : 0
+  const val = Number.isFinite(value) ? String(value) : ''
+  const widthStyle = maxLength ? { width: `${maxLength + 1}ch` } : undefined
   return (
     <input
       className="input"
-      type="number"
-      min={min}
-      max={max}
-      step={step}
-      value={val}
+      type="text"
+      inputMode="numeric"
+      pattern="[0-9]*"
+      value={maxLength ? val.slice(0, maxLength) : val}
+      maxLength={maxLength}
       onChange={(e)=>{
-        const v = Number((e.target as HTMLInputElement).value)
-        onChange(clamp(Number.isFinite(v) ? v : 0))
+        const digits = (e.target as HTMLInputElement).value.replace(/\D/g, '')
+        const sliced = maxLength ? digits.slice(0, maxLength) : digits
+        const num = Number(sliced)
+        onChange(clamp(Number.isFinite(num) ? num : 0))
       }}
+      style={widthStyle}
     />
   )
 }


### PR DESCRIPTION
## Summary
- remove input spinners and support digit limits in SingleMMInput
- align wall height and thickness side-by-side with length below

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c553c9403883229d5f583a724e127e