### PR TITLE
Fix wall preview end position

### DIFF
--- a/src/viewer/WallDrawer.ts
+++ b/src/viewer/WallDrawer.ts
@@ -142,7 +142,7 @@ export default class WallDrawer {
         this.cursor.position.copy(point).setY(0.001);
       }
       const dx = point.x - this.start.x;
-      const dz = this.start.z - point.z; // reverse Z axis
+      const dz = point.z - this.start.z;
       const distX = Math.abs(dx);
       const distZ = Math.abs(dz);
       const dist = Math.sqrt(distX * distX + distZ * distZ);

--- a/tests/viewer/WallDrawer.test.ts
+++ b/tests/viewer/WallDrawer.test.ts
@@ -134,6 +134,22 @@ describe('WallDrawer', () => {
     expect(preview.position.x).toBeCloseTo(0);
     drawer.disable();
   });
+  it('preview end matches cursor position', () => {
+    const { drawer, point } = createDrawer();
+    point.set(0, 0, 0);
+    (drawer as any).onDown({ pointerId: 1, button: 0 } as PointerEvent);
+    point.set(2, 0, 1);
+    (drawer as any).onMove({} as PointerEvent);
+    const preview = (drawer as any).preview as THREE.Mesh;
+    const dist = preview.scale.x;
+    const angle = preview.rotation.y;
+    const endX = preview.position.x + dist * Math.cos(angle);
+    const endZ = preview.position.z + dist * Math.sin(angle);
+    expect(endX).toBeCloseTo(point.x);
+    expect(endZ).toBeCloseTo(point.z);
+    drawer.disable();
+  });
+
 
   it('Escape cancels drag without adding wall', () => {
     const { drawer, point, addWallWithHistory } = createDrawer();


### PR DESCRIPTION
## Summary
- correct wall preview orientation so end follows cursor
- add regression test for diagonal dragging

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c5551d37848322aca675f2c9b8d058