### PR TITLE
Fix wall preview end position

### DIFF
--- a/src/viewer/WallDrawer.ts
+++ b/src/viewer/WallDrawer.ts
@@ -142,17 +142,15 @@ export default class WallDrawer {
         this.cursor.position.copy(point).setY(0.001);
       }
       const dx = point.x - this.start.x;
-      const dz = this.start.z - point.z; // reverse Z axis
-      const distX = Math.abs(dx);
-      const distZ = Math.abs(dz);
-      const dist = Math.sqrt(distX * distX + distZ * distZ);
+      const dz = point.z - this.start.z;
+      const dist = Math.sqrt(dx * dx + dz * dz);
       this.preview.scale.x = dist;
       this.preview.position.set(
         this.start.x,
         this.preview.position.y,
         this.start.z,
       );
-      this.preview.rotation.y = Math.atan2(dz, dx);
+      this.preview.rotation.y = Math.atan2(-dz, dx);
       const geometry = this.preview.geometry as THREE.BufferGeometry;
       geometry.computeBoundingBox();
       geometry.computeBoundingSphere();

--- a/src/viewer/WallDrawer.ts
+++ b/src/viewer/WallDrawer.ts
@@ -166,6 +166,7 @@ export default class WallDrawer {
     this.pointerId = e.pointerId;
     this.dragging = true;
     this.start = point.clone();
+    this.lastPoint = point.clone();
     if (this.cursor) {
       this.cursor.position.copy(point).setY(0.001);
       this.cursorTarget = this.cursor.position.clone();
@@ -194,7 +195,7 @@ export default class WallDrawer {
     if (!this.dragging) return;
     this.dragging = false;
     if (!this.start) return;
-    const point = this.getPoint(e);
+    const point = this.lastPoint ? this.lastPoint.clone().setY(0) : this.getPoint(e);
     if (!point) {
       this.start = null;
       this.disposePreview();

--- a/tests/viewer/WallDrawer.test.ts
+++ b/tests/viewer/WallDrawer.test.ts
@@ -134,6 +134,33 @@ describe('WallDrawer', () => {
     expect(preview.position.x).toBeCloseTo(0);
     drawer.disable();
   });
+  it('preview end matches cursor position (positive z)', () => {
+    const { drawer, point } = createDrawer();
+    point.set(0, 0, 0);
+    (drawer as any).onDown({ pointerId: 1, button: 0 } as PointerEvent);
+    point.set(2, 0, 1);
+    (drawer as any).onMove({} as PointerEvent);
+    const preview = (drawer as any).preview as THREE.Mesh;
+    preview.updateMatrixWorld();
+    const end = new THREE.Vector3(1, 0, 0).applyMatrix4(preview.matrixWorld);
+    expect(end.x).toBeCloseTo(point.x);
+    expect(end.z).toBeCloseTo(point.z);
+    drawer.disable();
+  });
+  it('preview end matches cursor position (negative z)', () => {
+    const { drawer, point } = createDrawer();
+    point.set(0, 0, 0);
+    (drawer as any).onDown({ pointerId: 1, button: 0 } as PointerEvent);
+    point.set(2, 0, -1);
+    (drawer as any).onMove({} as PointerEvent);
+    const preview = (drawer as any).preview as THREE.Mesh;
+    preview.updateMatrixWorld();
+    const end = new THREE.Vector3(1, 0, 0).applyMatrix4(preview.matrixWorld);
+    expect(end.x).toBeCloseTo(point.x);
+    expect(end.z).toBeCloseTo(point.z);
+    drawer.disable();
+  });
+
 
   it('Escape cancels drag without adding wall', () => {
     const { drawer, point, addWallWithHistory } = createDrawer();

--- a/tests/viewer/WallDrawer.test.ts
+++ b/tests/viewer/WallDrawer.test.ts
@@ -161,6 +161,21 @@ describe('WallDrawer', () => {
     drawer.disable();
   });
 
+  it('finalized wall uses last cursor position', () => {
+    const { drawer, point, addWallWithHistory } = createDrawer();
+    point.set(0, 0, 0);
+    (drawer as any).onDown({ pointerId: 1, button: 0 } as PointerEvent);
+    point.set(2, 0, 1);
+    (drawer as any).onMove({} as PointerEvent);
+    point.set(5, 0, 5);
+    (drawer as any).onUp({ pointerId: 1, button: 0 } as PointerEvent);
+    expect(addWallWithHistory).toHaveBeenCalledWith(
+      { x: 0, y: 0 },
+      { x: 2, y: 1 },
+    );
+    drawer.disable();
+  });
+
 
   it('Escape cancels drag without adding wall', () => {
     const { drawer, point, addWallWithHistory } = createDrawer();


### PR DESCRIPTION
## Summary
- correct wall preview orientation so end follows cursor
- add tests for preview endpoint including negative Z

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c5551d37848322aca675f2c9b8d058