### PR TITLE
Fix wall drawing orientation

### DIFF
--- a/src/viewer/WallDrawer.ts
+++ b/src/viewer/WallDrawer.ts
@@ -126,9 +126,12 @@ export default class WallDrawer {
     const intersection = this.raycaster.ray.intersectPlane(this.plane, point);
     if (!intersection) return null;
     if (!isFinite(intersection.x) || !isFinite(intersection.z)) return null;
+    // Flip the Z axis so dragging downwards on screen translates to
+    // increasing coordinates in our floor plan space.
+    point.set(intersection.x, 0, -intersection.z);
     // Return raw coordinates without snapping to grid so the wall can be drawn
     // at any angle. This enables free rotation of the segment during preview.
-    return new THREE.Vector3(intersection.x, 0, intersection.z);
+    return point;
   }
 
   private onMove = (e: PointerEvent) => {
@@ -136,11 +139,11 @@ export default class WallDrawer {
     if (!point) return;
     point.y = 0.001;
     this.lastPoint = point;
+    if (this.cursor) {
+      this.cursor.position.copy(point).setY(0.001);
+    }
     this.cursorTarget = point.clone();
     if (this.dragging && this.start && this.preview) {
-      if (this.cursor) {
-        this.cursor.position.copy(point).setY(0.001);
-      }
       const dx = point.x - this.start.x;
       const dz = point.z - this.start.z;
       const distX = Math.abs(dx);

--- a/tests/viewer/WallDrawer.test.ts
+++ b/tests/viewer/WallDrawer.test.ts
@@ -65,7 +65,7 @@ describe('WallDrawer', () => {
     drawer.disable();
   });
 
-  it('returns raw intersection coordinates without rounding', () => {
+  it('returns intersection coordinates with Z flipped', () => {
     const canvas = document.createElement('canvas');
     canvas.getBoundingClientRect = () => ({
       left: 0,
@@ -106,7 +106,17 @@ describe('WallDrawer', () => {
       clientY: 0,
     } as PointerEvent);
     expect(result?.x).toBe(intersection.x);
-    expect(result?.z).toBe(intersection.z);
+    expect(result?.z).toBe(-intersection.z);
+    drawer.disable();
+  });
+
+  it('moves cursor to pointer on move', () => {
+    const { drawer, point } = createDrawer();
+    point.set(1, 0, 2);
+    (drawer as any).onMove({} as PointerEvent);
+    const cursor = (drawer as any).cursor as THREE.Mesh;
+    expect(cursor.position.x).toBeCloseTo(1);
+    expect(cursor.position.z).toBeCloseTo(2);
     drawer.disable();
   });
 


### PR DESCRIPTION
## Summary
- flip raycast Z axis so walls draw in the same direction as the cursor
- move wall drawer cursor directly to pointer and test its tracking

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c55ada16c08322920b6f1912b4ffae