### PR TITLE
Ensure single-click walls start in default direction

### DIFF
--- a/src/viewer/WallDrawer.ts
+++ b/src/viewer/WallDrawer.ts
@@ -167,6 +167,7 @@ export default class WallDrawer {
     this.pointerId = e.pointerId;
     this.dragging = true;
     this.start = point.clone();
+    this.lastPoint = this.start.clone();
     if (this.cursor) {
       this.cursor.position.copy(point).setY(0.001);
       this.cursorTarget = this.cursor.position.clone();

--- a/tests/viewer/WallDrawer.test.ts
+++ b/tests/viewer/WallDrawer.test.ts
@@ -123,6 +123,20 @@ describe('WallDrawer', () => {
     drawer.disable();
   });
 
+  it('single click after moving cursor starts in default direction', () => {
+    const { drawer, point, addWallWithHistory } = createDrawer();
+    point.set(0, 0, 1);
+    (drawer as any).onMove({} as PointerEvent);
+    point.set(0, 0, 0);
+    (drawer as any).onDown({ pointerId: 1, button: 0 } as PointerEvent);
+    (drawer as any).onUp({ pointerId: 1, button: 0 } as PointerEvent);
+    expect(addWallWithHistory).toHaveBeenCalledWith(
+      { x: 0, y: 0 },
+      { x: SNAP / 1000, y: 0 },
+    );
+    drawer.disable();
+  });
+
   it('dragging extends wall toward cursor', () => {
     const { drawer, point } = createDrawer();
     point.set(0, 0, 0);


### PR DESCRIPTION
## Summary
- Reset `lastPoint` on pointer down so single-click walls use a consistent initial direction
- Test single-click behavior after moving cursor to ensure the default +X direction

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c5607db7b083229921f57e1a244b66