### PR TITLE
Handle pointer cancellation when drawing walls

### DIFF
--- a/src/viewer/WallDrawer.ts
+++ b/src/viewer/WallDrawer.ts
@@ -48,6 +48,8 @@ export default class WallDrawer {
     dom.addEventListener('pointermove', this.onMove);
     dom.addEventListener('pointerdown', this.onDown);
     dom.addEventListener('pointerup', this.onUp);
+    dom.addEventListener('pointercancel', this.onCancel);
+    dom.addEventListener('pointerleave', this.onCancel);
     window.addEventListener('keydown', this.onKeyDown);
     this.addCursor();
     this.animationId = requestAnimationFrame(this.animateCursor);
@@ -64,6 +66,8 @@ export default class WallDrawer {
     dom.removeEventListener('pointermove', this.onMove);
     dom.removeEventListener('pointerdown', this.onDown);
     dom.removeEventListener('pointerup', this.onUp);
+    dom.removeEventListener('pointercancel', this.onCancel);
+    dom.removeEventListener('pointerleave', this.onCancel);
     window.removeEventListener('keydown', this.onKeyDown);
     if (this.animationId !== null) {
       cancelAnimationFrame(this.animationId);
@@ -238,6 +242,10 @@ export default class WallDrawer {
       this.cursor.position.set(point.x, 0.001, point.z);
       this.cursorTarget = this.cursor.position.clone();
     }
+  };
+
+  private onCancel = (_e: PointerEvent) => {
+    this.onKeyDown({ key: 'Escape' } as KeyboardEvent);
   };
 
   private onKeyDown = (e: KeyboardEvent) => {

--- a/tests/scene/wallRendering.test.tsx
+++ b/tests/scene/wallRendering.test.tsx
@@ -176,14 +176,14 @@ describe('Scene wall rendering', () => {
       usePlannerStore.setState({ selectedTool: null });
     });
     const inactive = listeners();
-    expect(active.dom - inactive.dom).toBe(3);
+    expect(active.dom - inactive.dom).toBe(5);
     expect(active.win - inactive.win).toBe(1);
 
     act(() => {
       usePlannerStore.setState({ selectedTool: 'wall' });
     });
     const active2 = listeners();
-    expect(active2.dom - inactive.dom).toBe(3);
+    expect(active2.dom - inactive.dom).toBe(5);
     expect(active2.win - inactive.win).toBe(1);
 
     act(() => {

--- a/tests/viewer/WallDrawer.test.ts
+++ b/tests/viewer/WallDrawer.test.ts
@@ -179,6 +179,20 @@ describe('WallDrawer', () => {
     drawer.disable();
   });
 
+  it('pointer cancellation ends drag without adding wall', () => {
+    const { drawer, point, addWallWithHistory } = createDrawer();
+    point.set(0, 0, 0);
+    (drawer as any).onDown({ pointerId: 1, button: 0 } as PointerEvent);
+    point.set(1, 0, 0);
+    (drawer as any).onMove({} as PointerEvent);
+    (drawer as any).onCancel({} as PointerEvent);
+    expect((drawer as any).preview).toBeNull();
+    point.set(1, 0, 0);
+    (drawer as any).onUp({ pointerId: 1, button: 0 } as PointerEvent);
+    expect(addWallWithHistory).not.toHaveBeenCalled();
+    drawer.disable();
+  });
+
   it('finalized wall pushes history entry', () => {
     const { drawer, point, history } = createDrawer();
     point.set(0, 0, 0);


### PR DESCRIPTION
## Summary
- cancel wall drawing when pointer leaves or is cancelled
- test pointer cancellation and update listener expectations

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c56182abf88322add2ba71ca35b6c5