### PR TITLE
Fix vertical movement direction for wall drawing

### DIFF
--- a/src/viewer/WallDrawer.ts
+++ b/src/viewer/WallDrawer.ts
@@ -132,9 +132,7 @@ export default class WallDrawer {
     const intersection = this.raycaster.ray.intersectPlane(this.plane, point);
     if (!intersection) return null;
     if (!isFinite(intersection.x) || !isFinite(intersection.z)) return null;
-    // Flip the Z axis so dragging downwards on screen translates to
-    // increasing coordinates in our floor plan space.
-    point.set(intersection.x, 0, -intersection.z);
+    point.set(intersection.x, 0, intersection.z);
     const { snapToGrid, gridSize } = this.store.getState();
     if (snapToGrid) {
       const step = gridSize / 1000;

--- a/tests/viewer/WallDrawer.test.ts
+++ b/tests/viewer/WallDrawer.test.ts
@@ -67,7 +67,7 @@ describe('WallDrawer', () => {
     drawer.disable();
   });
 
-  it('returns intersection coordinates with Z flipped', () => {
+  it('returns intersection coordinates', () => {
     const canvas = document.createElement('canvas');
     canvas.getBoundingClientRect = () => ({
       left: 0,
@@ -96,7 +96,7 @@ describe('WallDrawer', () => {
     const drawer = new WallDrawer(renderer, () => camera, group, store);
     drawer.enable(state.wallDefaults.thickness);
 
-    const intersection = new THREE.Vector3(1.2345, 0, -2.3456);
+    const intersection = new THREE.Vector3(1.2345, 0, 2.3456);
     (drawer as any).raycaster.ray.intersectPlane = vi.fn(
       (_plane: THREE.Plane, point: THREE.Vector3) => {
         point.copy(intersection);
@@ -109,7 +109,7 @@ describe('WallDrawer', () => {
       clientY: 0,
     } as PointerEvent);
     expect(result?.x).toBe(intersection.x);
-    expect(result?.z).toBe(-intersection.z);
+    expect(result?.z).toBe(intersection.z);
     drawer.disable();
   });
 


### PR DESCRIPTION
## Summary
- Remove Z-axis inversion when mapping pointer coordinates in `WallDrawer`
- Update WallDrawer test to expect unflipped Z coordinate

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c567938c6c83229c4f1849eb0f18d0