### PR TITLE
fix: lock wall drawing to axes

### DIFF
--- a/src/viewer/WallDrawer.ts
+++ b/src/viewer/WallDrawer.ts
@@ -142,9 +142,22 @@ export default class WallDrawer {
     return point;
   }
 
+  private constrainPoint(point: THREE.Vector3) {
+    if (!this.start) return point;
+    const dx = Math.abs(point.x - this.start.x);
+    const dz = Math.abs(point.z - this.start.z);
+    if (dx > dz) {
+      point.z = this.start.z;
+    } else {
+      point.x = this.start.x;
+    }
+    return point;
+  }
+
   private onMove = (e: PointerEvent) => {
     const point = this.getPoint(e);
     if (!point) return;
+    this.constrainPoint(point);
     point.y = 0.001;
     this.lastPoint = point;
     this.cursorTarget = point.clone();
@@ -212,6 +225,7 @@ export default class WallDrawer {
       this.disposePreview();
       return;
     }
+    this.constrainPoint(point);
     const state = this.store.getState();
     let endX = point.x;
     let endZ = point.z;

--- a/tests/viewer/WallDrawer.test.ts
+++ b/tests/viewer/WallDrawer.test.ts
@@ -151,7 +151,7 @@ describe('WallDrawer', () => {
     expect(preview.position.x).toBeCloseTo(0);
     drawer.disable();
   });
-  it('preview end matches cursor position', () => {
+  it('preview end matches constrained cursor position', () => {
     const { drawer, point } = createDrawer();
     point.set(0, 0, 0);
     (drawer as any).onDown({ pointerId: 1, button: 0 } as PointerEvent);
@@ -162,8 +162,28 @@ describe('WallDrawer', () => {
     const angle = preview.rotation.y;
     const endX = preview.position.x + dist * Math.cos(angle);
     const endZ = preview.position.z + dist * Math.sin(angle);
-    expect(endX).toBeCloseTo(point.x);
-    expect(endZ).toBeCloseTo(point.z);
+    expect(endX).toBeCloseTo(2);
+    expect(endZ).toBeCloseTo(0);
+    drawer.disable();
+  });
+  it('locks to vertical direction when dragging mostly vertically', () => {
+    const { drawer, point, addWallWithHistory } = createDrawer();
+    point.set(0, 0, 0);
+    (drawer as any).onDown({ pointerId: 1, button: 0 } as PointerEvent);
+    point.set(0.1, 0, 2);
+    (drawer as any).onMove({} as PointerEvent);
+    const preview = (drawer as any).preview as THREE.Mesh;
+    const dist = preview.scale.x;
+    const angle = preview.rotation.y;
+    const endX = preview.position.x + dist * Math.cos(angle);
+    const endZ = preview.position.z + dist * Math.sin(angle);
+    expect(endX).toBeCloseTo(0);
+    expect(endZ).toBeCloseTo(2);
+    (drawer as any).onUp({ pointerId: 1, button: 0 } as PointerEvent);
+    expect(addWallWithHistory).toHaveBeenCalledWith(
+      { x: 0, y: 0 },
+      { x: 0, y: 2 },
+    );
     drawer.disable();
   });
   it('snaps points to grid when enabled', () => {


### PR DESCRIPTION
## Summary
- lock wall preview to nearest axis
- ensure final walls use constrained coordinates
- cover vertical locking with new tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c56a9a38a08322a98d8ce8b513d19e