### PR TITLE
Fix inverted vertical wall endpoint

### DIFF
--- a/src/viewer/WallDrawer.ts
+++ b/src/viewer/WallDrawer.ts
@@ -261,8 +261,11 @@ export default class WallDrawer {
       endZ = Math.round(endZ / stepSize) * stepSize;
       point.set(endX, 0, endZ);
     }
-    const start = { x: startX, y: startZ };
-    const end = { x: endX, y: endZ };
+    // Convert 3D coordinates (x, z) to 2D room shape coordinates (x, y).
+    // The camera in top-down mode uses a flipped Z axis, so we need to
+    // invert the Z value to obtain the correct Y coordinate in the plan.
+    const start = { x: startX, y: startZ === 0 ? 0 : -startZ };
+    const end = { x: endX, y: endZ === 0 ? 0 : -endZ };
     state.addWallWithHistory(start, end);
     this.start = null;
     this.disposePreview();

--- a/tests/viewer/WallDrawer.test.ts
+++ b/tests/viewer/WallDrawer.test.ts
@@ -182,6 +182,19 @@ describe('WallDrawer', () => {
     (drawer as any).onUp({ pointerId: 1, button: 0 } as PointerEvent);
     expect(addWallWithHistory).toHaveBeenCalledWith(
       { x: 0, y: 0 },
+      { x: 0, y: -2 },
+    );
+    drawer.disable();
+  });
+
+  it('converts negative z to positive y coordinates', () => {
+    const { drawer, point, addWallWithHistory } = createDrawer();
+    point.set(0, 0, 0);
+    (drawer as any).onDown({ pointerId: 1, button: 0 } as PointerEvent);
+    point.set(0, 0, -2);
+    (drawer as any).onUp({ pointerId: 1, button: 0 } as PointerEvent);
+    expect(addWallWithHistory).toHaveBeenCalledWith(
+      { x: 0, y: 0 },
       { x: 0, y: 2 },
     );
     drawer.disable();


### PR DESCRIPTION
## Summary
- fix wall drawer to flip z -> y when converting world coordinates to room plan
- add test for negative z orientation and update existing expectations

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c56e118c1483228b8eb797492c9c14