### PR TITLE
Fix vertical wall drawing orientation

### DIFF
--- a/src/viewer/WallDrawer.ts
+++ b/src/viewer/WallDrawer.ts
@@ -132,7 +132,8 @@ export default class WallDrawer {
     const intersection = this.raycaster.ray.intersectPlane(this.plane, point);
     if (!intersection) return null;
     if (!isFinite(intersection.x) || !isFinite(intersection.z)) return null;
-    point.set(intersection.x, 0, intersection.z);
+    // Top-down camera uses a flipped Z axis; invert it to match planner coords.
+    point.set(intersection.x, 0, -intersection.z);
     const { snapToGrid, gridSize } = this.store.getState();
     if (snapToGrid) {
       const step = gridSize / 1000;
@@ -261,6 +262,7 @@ export default class WallDrawer {
       endZ = Math.round(endZ / stepSize) * stepSize;
       point.set(endX, 0, endZ);
     }
+    // Convert 3D coordinates (x, z) to 2D room shape coordinates (x, y).
     const start = { x: startX, y: startZ };
     const end = { x: endX, y: endZ };
     state.addWallWithHistory(start, end);

--- a/tests/viewer/WallDrawer.test.ts
+++ b/tests/viewer/WallDrawer.test.ts
@@ -109,7 +109,7 @@ describe('WallDrawer', () => {
       clientY: 0,
     } as PointerEvent);
     expect(result?.x).toBe(intersection.x);
-    expect(result?.z).toBe(intersection.z);
+    expect(result?.z).toBeCloseTo(-intersection.z);
     drawer.disable();
   });
 


### PR DESCRIPTION
## Summary
- flip Z axis when picking points so vertical walls align with planner coordinates
- simplify world-to-plan conversion without extra sign flip
- adjust wall drawer tests for new Z orientation

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c56e118c1483228b8eb797492c9c14