### PR TITLE
Fix WallDrawer Z-axis orientation

### DIFF
--- a/src/viewer/WallDrawer.ts
+++ b/src/viewer/WallDrawer.ts
@@ -132,7 +132,9 @@ export default class WallDrawer {
     const intersection = this.raycaster.ray.intersectPlane(this.plane, point);
     if (!intersection) return null;
     if (!isFinite(intersection.x) || !isFinite(intersection.z)) return null;
-    point.set(intersection.x, 0, intersection.z);
+    // The camera uses a flipped Z axis in top-down mode, so negate the
+    // intersection's Z value to align with the application's coordinate system.
+    point.set(intersection.x, 0, -intersection.z);
     const { snapToGrid, gridSize } = this.store.getState();
     if (snapToGrid) {
       const step = gridSize / 1000;
@@ -262,10 +264,9 @@ export default class WallDrawer {
       point.set(endX, 0, endZ);
     }
     // Convert 3D coordinates (x, z) to 2D room shape coordinates (x, y).
-    // The camera in top-down mode uses a flipped Z axis, so we need to
-    // invert the Z value to obtain the correct Y coordinate in the plan.
-    const start = { x: startX, y: startZ === 0 ? 0 : -startZ };
-    const end = { x: endX, y: endZ === 0 ? 0 : -endZ };
+    // Negate the stored Z values to match the planner's Y axis direction.
+    const start = { x: startX, y: -startZ || 0 };
+    const end = { x: endX, y: -endZ || 0 };
     state.addWallWithHistory(start, end);
     this.start = null;
     this.disposePreview();

--- a/tests/viewer/WallDrawer.test.ts
+++ b/tests/viewer/WallDrawer.test.ts
@@ -109,7 +109,8 @@ describe('WallDrawer', () => {
       clientY: 0,
     } as PointerEvent);
     expect(result?.x).toBe(intersection.x);
-    expect(result?.z).toBe(intersection.z);
+    // getPoint flips the intersection's Z axis
+    expect(result?.z).toBe(-intersection.z);
     drawer.disable();
   });
 


### PR DESCRIPTION
## Summary
- Flip intersection Z axis when projecting cursor to ground
- Negate stored Z values when converting to 2D wall coordinates
- Adjust WallDrawer tests for new axis orientation

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c57a531b708322b9d78f1a25028f9a