### PR TITLE
Add snapRightAngles flag to WallDrawer for optional axis locking

### DIFF
--- a/src/viewer/WallDrawer.ts
+++ b/src/viewer/WallDrawer.ts
@@ -10,6 +10,7 @@ interface PlannerStore {
   addWallWithHistory: (start: ShapePoint, end: ShapePoint) => void;
   snapToGrid: boolean;
   gridSize: number;
+  snapRightAngles: boolean;
 }
 
 export default class WallDrawer {
@@ -145,7 +146,8 @@ export default class WallDrawer {
   }
 
   private constrainPoint(point: THREE.Vector3) {
-    if (!this.start) return point;
+    const { snapRightAngles } = this.store.getState();
+    if (!this.start || !snapRightAngles) return point;
     const dx = Math.abs(point.x - this.start.x);
     const dz = Math.abs(point.z - this.start.z);
     if (dx > dz) {

--- a/tests/viewer/WallDrawer.test.ts
+++ b/tests/viewer/WallDrawer.test.ts
@@ -36,6 +36,7 @@ function createDrawer(overrides: Partial<any> = {}) {
     gridSize: 100,
     snapLength: SNAP,
     wallDefaults: { height: HEIGHT, thickness: THICKNESS },
+    snapRightAngles: true,
     addWallWithHistory,
     ...overrides,
   };
@@ -167,7 +168,7 @@ describe('WallDrawer', () => {
     expect(endZ).toBeCloseTo(0);
     drawer.disable();
   });
-  it('locks to vertical direction when dragging mostly vertically', () => {
+  it('locks to vertical direction when snapRightAngles is enabled', () => {
     const { drawer, point, addWallWithHistory } = createDrawer();
     point.set(0, 0, 0);
     (drawer as any).onDown({ pointerId: 1, button: 0 } as PointerEvent);
@@ -184,6 +185,21 @@ describe('WallDrawer', () => {
     expect(addWallWithHistory).toHaveBeenCalledWith(
       { x: 0, y: 0 },
       { x: 0, y: -2 },
+    );
+    drawer.disable();
+  });
+
+  it('allows free angles when snapRightAngles is disabled', () => {
+    const { drawer, point, addWallWithHistory } = createDrawer({
+      snapRightAngles: false,
+    });
+    point.set(0, 0, 0);
+    (drawer as any).onDown({ pointerId: 1, button: 0 } as PointerEvent);
+    point.set(2, 0, 1);
+    (drawer as any).onUp({ pointerId: 1, button: 0 } as PointerEvent);
+    expect(addWallWithHistory).toHaveBeenCalledWith(
+      { x: 0, y: 0 },
+      { x: 2, y: -1 },
     );
     drawer.disable();
   });


### PR DESCRIPTION
## Summary
- Use planner store's `snapRightAngles` flag in `WallDrawer` to toggle axis locking
- Cover locked and free-angle drawing in `WallDrawer` tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c57b9abec483229f7779092bfadfb5