### PR TITLE
Handle invalid wall segments

### DIFF
--- a/src/utils/roomShape.ts
+++ b/src/utils/roomShape.ts
@@ -74,12 +74,12 @@ const segmentsIntersect = (s1: SegmentLike, s2: SegmentLike) => {
 export const addSegmentToShape = (
   shape: RoomShape,
   segment: ShapeSegment,
-): RoomShape => {
+): RoomShape | null => {
   if (pointsEqual(segment.start, segment.end)) {
-    return shape;
+    return null;
   }
   if (shape.segments.some((s) => segmentsIntersect(s, segment))) {
-    return shape;
+    return null;
   }
 
   const findPoint = (p: ShapePoint) =>

--- a/tests/roomShape.test.ts
+++ b/tests/roomShape.test.ts
@@ -10,9 +10,12 @@ vi.mock('../src/utils/uuid', () => ({
 describe('addSegmentToShape', () => {
   it('avoids storing duplicate points when segments share endpoints', () => {
     let shape: RoomShape = { points: [], segments: [] };
-    shape = addSegmentToShape(shape, { start: { x: 0, y: 0 }, end: { x: 1, y: 0 } });
-    shape = addSegmentToShape(shape, { start: { x: 1, y: 0 }, end: { x: 1, y: 1 } });
-    shape = addSegmentToShape(shape, { start: { x: 1, y: 1 }, end: { x: 0, y: 0 } });
+    let res = addSegmentToShape(shape, { start: { x: 0, y: 0 }, end: { x: 1, y: 0 } });
+    if (res) shape = res;
+    res = addSegmentToShape(shape, { start: { x: 1, y: 0 }, end: { x: 1, y: 1 } });
+    if (res) shape = res;
+    res = addSegmentToShape(shape, { start: { x: 1, y: 1 }, end: { x: 0, y: 0 } });
+    if (res) shape = res;
 
     expect(shape.points.length).toBe(3);
     const coords = shape.points.map((p) => `${p.x},${p.y}`);
@@ -23,24 +26,27 @@ describe('addSegmentToShape', () => {
 
   it('rejects segments that intersect existing ones', () => {
     let shape: RoomShape = { points: [], segments: [] };
-    shape = addSegmentToShape(shape, { start: { x: 0, y: 0 }, end: { x: 2, y: 0 } });
+    const first = addSegmentToShape(shape, { start: { x: 0, y: 0 }, end: { x: 2, y: 0 } });
+    if (first) shape = first;
     const result = addSegmentToShape(shape, {
       start: { x: 1, y: -1 },
       end: { x: 1, y: 1 },
     });
 
-    expect(result).toBe(shape);
+    expect(result).toBeNull();
     expect(shape.segments.length).toBe(1);
   });
 
   it('allows segments that only meet at endpoints', () => {
     let shape: RoomShape = { points: [], segments: [] };
-    shape = addSegmentToShape(shape, { start: { x: 0, y: 0 }, end: { x: 1, y: 0 } });
+    const first = addSegmentToShape(shape, { start: { x: 0, y: 0 }, end: { x: 1, y: 0 } });
+    if (first) shape = first;
     const result = addSegmentToShape(shape, {
       start: { x: 1, y: 0 },
       end: { x: 1, y: 1 },
     });
 
-    expect(result.segments.length).toBe(2);
+    expect(result).not.toBeNull();
+    expect(result!.segments.length).toBe(2);
   });
 });


### PR DESCRIPTION
## Summary
- make `addSegmentToShape` signal failure by returning `null`
- propagate result so `addWallSegment` returns a success flag
- only record history when a wall segment is successfully added

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c5875d9f50832295722bd41b778181