### PR TITLE
Validate wall drawing parameters

### DIFF
--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -129,6 +129,9 @@ const persisted = (() => {
   }
 })();
 
+const DEFAULT_SNAP_LENGTH = 10;
+const DEFAULT_GRID_SIZE = 100;
+
 export interface Item {
   id: string;
   type: string;
@@ -233,11 +236,11 @@ export const usePlannerStore = create<Store>((set, get) => ({
       },
   roomShape: persisted?.roomShape || { points: [], segments: [] },
   snapAngle: persisted?.snapAngle ?? 90,
-  snapLength: persisted?.snapLength ?? 10,
+  snapLength: persisted?.snapLength > 0 ? persisted.snapLength : DEFAULT_SNAP_LENGTH,
   snapRightAngles: true,
   angleToPrev: persisted?.angleToPrev ?? 0,
   defaultSquareAngle: persisted?.defaultSquareAngle ?? 0,
-  gridSize: persisted?.gridSize ?? 100,
+  gridSize: persisted?.gridSize > 0 ? persisted.gridSize : DEFAULT_GRID_SIZE,
   snapToGrid: persisted?.snapToGrid ?? false,
   measurementUnit: persisted?.measurementUnit || 'mm',
   playerHeight: persisted?.playerHeight ?? 1.6,
@@ -494,11 +497,11 @@ export const usePlannerStore = create<Store>((set, get) => ({
     }),
   setShowFronts: (v) => set({ showFronts: v }),
   setSnapAngle: (v) => set({ snapAngle: v }),
-  setSnapLength: (v) => set({ snapLength: v }),
+  setSnapLength: (v) => set({ snapLength: v > 0 ? v : DEFAULT_SNAP_LENGTH }),
   setSnapRightAngles: (v) => set({ snapRightAngles: v, snapAngle: v ? 90 : 0 }),
   setAngleToPrev: (v) => set({ angleToPrev: clamp(v, 0, 360) }),
   setDefaultSquareAngle: (v) => set({ defaultSquareAngle: clamp(v, 0, 360) }),
-  setGridSize: (v) => set({ gridSize: v }),
+  setGridSize: (v) => set({ gridSize: v > 0 ? v : DEFAULT_GRID_SIZE }),
   setSnapToGrid: (v) => set({ snapToGrid: v }),
   setMeasurementUnit: (v) => set({ measurementUnit: v }),
   setPlayerHeight: (v) => set({ playerHeight: v }),

--- a/src/viewer/WallDrawer.ts
+++ b/src/viewer/WallDrawer.ts
@@ -138,7 +138,7 @@ export default class WallDrawer {
     // intersection's Z value to world coordinates.
     point.set(intersection.x, 0, screenToWorldZ(intersection.z));
     const { snapToGrid, gridSize } = this.store.getState();
-    if (snapToGrid) {
+    if (snapToGrid && gridSize > 0) {
       const step = gridSize / 1000;
       point.x = Math.round(point.x / step) * step;
       point.z = Math.round(point.z / step) * step;
@@ -238,7 +238,8 @@ export default class WallDrawer {
     const dz = endZ - this.start.z;
     const dist = Math.sqrt(dx * dx + dz * dz);
     if (dist < 0.001) {
-      const step = state.snapLength / 1000;
+      const snapLength = state.snapLength > 0 ? state.snapLength : 10;
+      const step = snapLength / 1000;
       let dirX = dx;
       let dirZ = dz;
       if (dirX === 0 && dirZ === 0 && this.lastPoint) {
@@ -258,7 +259,7 @@ export default class WallDrawer {
     }
     let startX = this.start.x;
     let startZ = this.start.z;
-    if (state.snapToGrid) {
+    if (state.snapToGrid && state.gridSize > 0) {
       const stepSize = state.gridSize / 1000;
       startX = Math.round(startX / stepSize) * stepSize;
       startZ = Math.round(startZ / stepSize) * stepSize;


### PR DESCRIPTION
## Summary
- skip grid snapping when gridSize is not positive
- ensure snapLength uses a positive value with a fallback
- validate gridSize and snapLength when setting store values

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c5889cf84c8322a7753a2c8815ee59