### PR TITLE
Handle missing queueMicrotask in WallDrawer preview disposal

### DIFF
--- a/src/viewer/WallDrawer.ts
+++ b/src/viewer/WallDrawer.ts
@@ -117,10 +117,17 @@ export default class WallDrawer {
     this.group.remove(mesh);
     const geom = mesh.geometry;
     const mat = mesh.material as THREE.Material;
-    queueMicrotask(() => {
+    const dispose = () => {
       geom.dispose();
       mat.dispose();
-    });
+    };
+    if (typeof queueMicrotask === 'function') {
+      queueMicrotask(dispose);
+    } else if (typeof Promise !== 'undefined') {
+      Promise.resolve().then(dispose);
+    } else {
+      dispose();
+    }
     this.preview = null;
   }
 

--- a/tests/viewer/WallDrawer.test.ts
+++ b/tests/viewer/WallDrawer.test.ts
@@ -266,6 +266,22 @@ describe('WallDrawer', () => {
     drawer.disable();
   });
 
+  it('disposes preview when queueMicrotask is unavailable', async () => {
+    vi.stubGlobal('queueMicrotask', undefined as any);
+    const { drawer, point } = createDrawer();
+    point.set(0, 0, 0);
+    (drawer as any).onDown({ pointerId: 1, button: 0 } as PointerEvent);
+    const preview = (drawer as any).preview as THREE.Mesh;
+    const geomDispose = vi.spyOn(preview.geometry, 'dispose');
+    const matDispose = vi.spyOn(preview.material as THREE.Material, 'dispose');
+    point.set(1, 0, 0);
+    (drawer as any).onUp({ pointerId: 1, button: 0 } as PointerEvent);
+    await Promise.resolve();
+    expect(geomDispose).toHaveBeenCalled();
+    expect(matDispose).toHaveBeenCalled();
+    drawer.disable();
+  });
+
   it('finalized wall pushes history entry', () => {
     const { drawer, point, history } = createDrawer();
     point.set(0, 0, 0);


### PR DESCRIPTION
## Summary
- Fallback to Promise or synchronous cleanup when `queueMicrotask` is missing in `disposePreview`
- Test `WallDrawer` preview disposal with `queueMicrotask` undefined

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c58bd2bc5c83229f36d8036f915cf9