### PR TITLE
feat: drag cabinets on XZ plane

### DIFF
--- a/src/viewer/CabinetDragger.ts
+++ b/src/viewer/CabinetDragger.ts
@@ -3,6 +3,7 @@ import type { WebGLRenderer, Camera } from 'three';
 import type { UseBoundStore, StoreApi } from 'zustand';
 import { usePlannerStore } from '../state/store';
 import type { Module3D } from '../types';
+import { convertAxis, screenAxes, worldAxes } from '../utils/coordinateSystem';
 
 interface PlannerStore {
   modules: Module3D[];
@@ -15,7 +16,7 @@ export default class CabinetDragger {
   private group: THREE.Group;
   private store: UseBoundStore<StoreApi<PlannerStore>>;
   private raycaster = new THREE.Raycaster();
-  private plane = new THREE.Plane(new THREE.Vector3(0, 0, 1), 0);
+  private plane = new THREE.Plane(new THREE.Vector3(0, 1, 0), 0);
   private draggingId: string | null = null;
   private offset = new THREE.Vector3();
 
@@ -49,7 +50,8 @@ export default class CabinetDragger {
   private getPoint(event: PointerEvent): THREE.Vector3 | null {
     const rect = this.renderer.domElement.getBoundingClientRect();
     const x = ((event.clientX - rect.left) / rect.width) * 2 - 1;
-    const y = -((event.clientY - rect.top) / rect.height) * 2 + 1;
+    const yScreen = ((event.clientY - rect.top) / rect.height) * 2 - 1;
+    const y = convertAxis(yScreen, screenAxes, 'y', worldAxes, 'z');
     const cam = this.getCamera();
     this.raycaster.setFromCamera(new THREE.Vector2(x, y), cam);
     const point = new THREE.Vector3();
@@ -61,7 +63,8 @@ export default class CabinetDragger {
     this.renderer.domElement.setPointerCapture(e.pointerId);
     const rect = this.renderer.domElement.getBoundingClientRect();
     const x = ((e.clientX - rect.left) / rect.width) * 2 - 1;
-    const y = -((e.clientY - rect.top) / rect.height) * 2 + 1;
+    const yScreen = ((e.clientY - rect.top) / rect.height) * 2 - 1;
+    const y = convertAxis(yScreen, screenAxes, 'y', worldAxes, 'z');
     const cam = this.getCamera();
     this.raycaster.setFromCamera(new THREE.Vector2(x, y), cam);
     const intersects = this.raycaster.intersectObjects(this.group.children, true);
@@ -80,7 +83,8 @@ export default class CabinetDragger {
     const point = this.getPoint(e);
     if (!point) return;
     this.draggingId = mod.id;
-    this.offset.set(mod.position[0], mod.position[1], 0).sub(point);
+    const pointXZ = new THREE.Vector3(point.x, point.z, 0);
+    this.offset.set(mod.position[0], mod.position[2], 0).sub(pointXZ);
   };
 
   private onMove = (e: PointerEvent) => {
@@ -91,9 +95,9 @@ export default class CabinetDragger {
     const current = mods.find((m) => m.id === this.draggingId);
     if (!current) return;
     const newX = point.x + this.offset.x;
-    const newY = point.y + this.offset.y;
+    const newZ = point.z + this.offset.y;
     this.store.getState().updateModule(this.draggingId, {
-      position: [newX, newY, current.position[2]],
+      position: [newX, current.position[1], newZ],
     });
   };
 

--- a/tests/cabinetDragger.pointerCapture.test.ts
+++ b/tests/cabinetDragger.pointerCapture.test.ts
@@ -64,5 +64,65 @@ describe('CabinetDragger pointer capture', () => {
     expect(canvas.releasePointerCapture).toHaveBeenCalledWith(1);
     expect((dragger as any).draggingId).toBeNull();
   });
+
+  it('updates module position along XZ plane when dragging', () => {
+    const canvas = document.createElement('canvas');
+    canvas.getBoundingClientRect = () => ({
+      left: 0,
+      top: 0,
+      width: 100,
+      height: 100,
+      right: 100,
+      bottom: 100,
+      x: 0,
+      y: 0,
+      toJSON() {},
+    });
+    canvas.setPointerCapture = vi.fn();
+
+    const renderer = { domElement: canvas } as unknown as THREE.WebGLRenderer;
+    const camera = new THREE.PerspectiveCamera();
+    const getCamera = () => camera;
+
+    const group = new THREE.Group();
+    const obj = new THREE.Object3D();
+    obj.userData.kind = 'cab';
+    group.add(obj);
+
+    const module = { id: '1', position: [0, 5, 0] } as Module3D;
+    const updateModule = vi.fn();
+    const store = {
+      getState: () => ({
+        modules: [module],
+        updateModule,
+      }),
+    } as any;
+
+    const dragger = new CabinetDragger(renderer, getCamera, group, store);
+
+    (dragger as any).raycaster.intersectObjects = () => [{ object: obj }];
+
+    (dragger as any).getPoint = () => new THREE.Vector3(0, 0, 0);
+    const down = {
+      clientX: 0,
+      clientY: 0,
+      pointerId: 1,
+      button: 0,
+    } as PointerEvent;
+    (dragger as any).onDown(down);
+
+    (dragger as any).getPoint = () => new THREE.Vector3(10, 0, 20);
+    const move = {
+      clientX: 10,
+      clientY: 10,
+      pointerId: 1,
+      button: 0,
+    } as PointerEvent;
+    (dragger as any).onMove(move);
+
+    expect(updateModule).toHaveBeenCalledWith('1', {
+      position: [10, 5, 20],
+    });
+  });
 });
 


### PR DESCRIPTION
## Summary
- drag cabinets across XZ plane using Y-normal picking plane
- convert screen Y to world Z with coordinateSystem helper
- test cabinet dragging updates XZ coordinates

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c5998f5a448322a11d977978b1fc52