### PR TITLE
Map wall drawing to XZ ground plane

### DIFF
--- a/tests/viewer/WallDrawer.test.ts
+++ b/tests/viewer/WallDrawer.test.ts
@@ -97,7 +97,7 @@ describe('WallDrawer', () => {
     const drawer = new WallDrawer(renderer, () => camera, group, store);
     drawer.enable(state.wallDefaults.thickness);
 
-    const intersection = new THREE.Vector3(1.2345, 2.3456, 0);
+    const intersection = new THREE.Vector3(1.2345, 0, 2.3456);
     (drawer as any).raycaster.ray.intersectPlane = vi.fn(
       (_plane: THREE.Plane, point: THREE.Vector3) => {
         point.copy(intersection);
@@ -110,7 +110,7 @@ describe('WallDrawer', () => {
       clientY: 0,
     } as PointerEvent);
     expect(result?.x).toBe(intersection.x);
-    expect(result?.y).toBe(intersection.y);
+    expect(result?.z).toBe(intersection.z);
     drawer.disable();
   });
 
@@ -129,7 +129,7 @@ describe('WallDrawer', () => {
 
   it('single click after moving cursor starts in default direction', () => {
     const { drawer, point, addWallWithHistory } = createDrawer();
-    point.set(0, 1, 0);
+    point.set(0, 0, 1);
     (drawer as any).onMove({} as PointerEvent);
     point.set(0, 0, 0);
     (drawer as any).onDown({ pointerId: 1, button: 0 } as PointerEvent);
@@ -156,30 +156,30 @@ describe('WallDrawer', () => {
     const { drawer, point } = createDrawer();
     point.set(0, 0, 0);
     (drawer as any).onDown({ pointerId: 1, button: 0 } as PointerEvent);
-    point.set(2, 1, 0);
+    point.set(2, 0, 1);
     (drawer as any).onMove({} as PointerEvent);
     const preview = (drawer as any).preview as THREE.Mesh;
     const dist = preview.scale.x;
-    const angle = preview.rotation.z;
+    const angle = preview.rotation.y;
     const endX = preview.position.x + dist * Math.cos(angle);
-    const endY = preview.position.y + dist * Math.sin(angle);
+    const endZ = preview.position.z + dist * Math.sin(angle);
     expect(endX).toBeCloseTo(2);
-    expect(endY).toBeCloseTo(0);
+    expect(endZ).toBeCloseTo(0);
     drawer.disable();
   });
   it('locks to vertical direction when snapRightAngles is enabled', () => {
     const { drawer, point, addWallWithHistory } = createDrawer();
     point.set(0, 0, 0);
     (drawer as any).onDown({ pointerId: 1, button: 0 } as PointerEvent);
-    point.set(0.1, 2, 0);
+    point.set(0.1, 0, 2);
     (drawer as any).onMove({} as PointerEvent);
     const preview = (drawer as any).preview as THREE.Mesh;
     const dist = preview.scale.x;
-    const angle = preview.rotation.z;
+    const angle = preview.rotation.y;
     const endX = preview.position.x + dist * Math.cos(angle);
-    const endY = preview.position.y + dist * Math.sin(angle);
+    const endZ = preview.position.z + dist * Math.sin(angle);
     expect(endX).toBeCloseTo(0);
-    expect(endY).toBeCloseTo(2);
+    expect(endZ).toBeCloseTo(2);
     (drawer as any).onUp({ pointerId: 1, button: 0 } as PointerEvent);
     expect(addWallWithHistory).toHaveBeenCalledWith(
       { x: 0, y: 0 },
@@ -194,7 +194,7 @@ describe('WallDrawer', () => {
     });
     point.set(0, 0, 0);
     (drawer as any).onDown({ pointerId: 1, button: 0 } as PointerEvent);
-    point.set(2, 1, 0);
+    point.set(2, 0, 1);
     (drawer as any).onUp({ pointerId: 1, button: 0 } as PointerEvent);
     expect(addWallWithHistory).toHaveBeenCalledWith(
       { x: 0, y: 0 },
@@ -203,11 +203,11 @@ describe('WallDrawer', () => {
     drawer.disable();
   });
 
-  it('handles negative y coordinates', () => {
+  it('handles negative z coordinates', () => {
     const { drawer, point, addWallWithHistory } = createDrawer();
     point.set(0, 0, 0);
     (drawer as any).onDown({ pointerId: 1, button: 0 } as PointerEvent);
-    point.set(0, -2, 0);
+    point.set(0, 0, -2);
     (drawer as any).onUp({ pointerId: 1, button: 0 } as PointerEvent);
     expect(addWallWithHistory).toHaveBeenCalledWith(
       { x: 0, y: 0 },


### PR DESCRIPTION
## Summary
- Interpret wall drawing on the XZ plane by raycasting against a horizontal plane and mapping intersections to `(x,z)`
- Persist wall points with world `z` as planner `y` and update cursor/preview orientation and math for the new axes
- Expand wall drawer tests to validate XZ axis mapping

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c59b7bd30c8322b272535dc6652978