### PR TITLE
Use Y-up orientation consistently for scene viewer

### DIFF
--- a/src/scene/engine.ts
+++ b/src/scene/engine.ts
@@ -15,7 +15,7 @@ export function setupThree(container: HTMLElement) {
     100,
   );
   perspectiveCamera.position.set(4, 6, 3);
-  perspectiveCamera.up.set(0, 0, 1);
+  perspectiveCamera.up.set(0, 1, 0);
 
   const aspect = container.clientWidth / container.clientHeight;
   const size = 5;
@@ -27,7 +27,7 @@ export function setupThree(container: HTMLElement) {
     0.1,
     100,
   );
-  orthographicCamera.position.set(0, 0, 10);
+  orthographicCamera.position.set(0, 10, 0);
   orthographicCamera.up.set(0, 1, 0);
   orthographicCamera.lookAt(0, 0, 0);
 
@@ -80,6 +80,7 @@ export function setupThree(container: HTMLElement) {
     );
     const material = new THREE.LineBasicMaterial({ color: 0x515152 });
     grid = new THREE.LineSegments(geometry, material);
+    grid.rotateX(-Math.PI / 2);
     scene.add(grid);
     currentDivX = divX;
     currentDivY = divY;
@@ -93,6 +94,7 @@ export function setupThree(container: HTMLElement) {
     new THREE.PlaneGeometry(boardWidth, boardHeight),
     new THREE.MeshStandardMaterial({ color: 0xf9fafc, side: THREE.DoubleSide }),
   );
+  floor.rotateX(-Math.PI / 2);
   scene.add(floor);
 
   const group = new THREE.Group();

--- a/src/ui/SceneViewer.tsx
+++ b/src/ui/SceneViewer.tsx
@@ -131,10 +131,11 @@ const SceneViewer: React.FC<Props> = ({
         c.enableDamping = true;
         c.enableRotate = false;
         three.setControls(c);
-        three.camera.position.set(0, 0, 10);
+        const pos = savedView.current.pos;
+        three.camera.position.set(pos.x, 10, pos.z);
         three.camera.up.set(0, 1, 0);
-        c.target.set(0, 0, 0);
-        three.camera.lookAt(0, 0, 0);
+        c.target.copy(savedView.current.target);
+        three.camera.lookAt(c.target);
         c.update();
         const updateGrid = () => {
           const base = Math.max(
@@ -161,7 +162,7 @@ const SceneViewer: React.FC<Props> = ({
           three.camera.position.copy(savedView.current.pos);
           c.target.copy(savedView.current.target);
         }
-        three.camera.up.set(0, 0, 1);
+        three.camera.up.set(0, 1, 0);
         c.update();
         const base = Math.max(
           1,

--- a/tests/scene/wallRendering.test.tsx
+++ b/tests/scene/wallRendering.test.tsx
@@ -214,7 +214,9 @@ describe('Scene wall rendering', () => {
 
     const wallGroup = threeRef.current.group.children[0];
     const [mesh1, mesh2] = wallGroup.children as THREE.Mesh[];
+    expect(mesh1.rotation.x).toBeCloseTo(0);
     expect(mesh1.rotation.z).toBeCloseTo(0);
+    expect(mesh2.rotation.x).toBeCloseTo(0);
     expect(mesh2.rotation.z).toBeCloseTo(0);
   });
 

--- a/tests/sceneViewer.viewMode.test.tsx
+++ b/tests/sceneViewer.viewMode.test.tsx
@@ -101,6 +101,7 @@ describe('SceneViewer view mode', () => {
 
     expect(threeRef.current.camera).toBe(threeRef.current.orthographicCamera);
     expect(threeRef.current.controls.enableRotate).toBe(false);
+    expect(threeRef.current.camera.up).toEqual(new THREE.Vector3(0, 1, 0));
 
     act(() => {
       root.render(
@@ -117,6 +118,7 @@ describe('SceneViewer view mode', () => {
 
     expect(threeRef.current.camera).toBe(threeRef.current.perspectiveCamera);
     expect(threeRef.current.controls.enableRotate).toBe(true);
+    expect(threeRef.current.camera.up).toEqual(new THREE.Vector3(0, 1, 0));
 
     root.unmount();
   });


### PR DESCRIPTION
## Summary
- Set all cameras to Y-up and remove mode-based differences
- Rotate floor and grid so XZ is ground plane
- Adjust view mode handling and wall orientation tests

## Testing
- `npm test tests/sceneViewer.viewMode.test.tsx tests/scene/wallRendering.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c59e7f9a78832299325c0ad91e82cc