### PR TITLE
Orient 2D view along Z axis

### DIFF
--- a/src/ui/SceneViewer.tsx
+++ b/src/ui/SceneViewer.tsx
@@ -130,11 +130,12 @@ const SceneViewer: React.FC<Props> = ({
         const c = new OrbitControls(three.camera, three.renderer.domElement);
         c.enableDamping = true;
         c.enableRotate = false;
+        c.screenSpacePanning = true;
         three.setControls(c);
         const pos = savedView.current.pos;
-        three.camera.position.set(pos.x, 10, pos.z);
+        three.camera.position.set(pos.x, pos.y, 10);
         three.camera.up.set(0, 1, 0);
-        c.target.copy(savedView.current.target);
+        c.target.set(pos.x, pos.y, 0);
         three.camera.lookAt(c.target);
         c.update();
         const updateGrid = () => {

--- a/tests/sceneViewer.viewMode.test.tsx
+++ b/tests/sceneViewer.viewMode.test.tsx
@@ -17,6 +17,8 @@ vi.mock('three/examples/jsm/controls/OrbitControls.js', () => ({
   OrbitControls: vi.fn().mockImplementation(() => ({
     target: new THREE.Vector3(),
     enableRotate: true,
+    enablePan: true,
+    screenSpacePanning: false,
     update: vi.fn(),
     dispose: vi.fn(),
     addEventListener: vi.fn(),
@@ -101,7 +103,15 @@ describe('SceneViewer view mode', () => {
 
     expect(threeRef.current.camera).toBe(threeRef.current.orthographicCamera);
     expect(threeRef.current.controls.enableRotate).toBe(false);
+    expect(threeRef.current.controls.screenSpacePanning).toBe(true);
     expect(threeRef.current.camera.up).toEqual(new THREE.Vector3(0, 1, 0));
+    expect(threeRef.current.camera.position).toEqual(new THREE.Vector3(0, 0, 10));
+    expect(threeRef.current.controls.target).toEqual(new THREE.Vector3(0, 0, 0));
+    const dir = new THREE.Vector3();
+    threeRef.current.camera.getWorldDirection(dir);
+    expect(dir.x).toBeCloseTo(0);
+    expect(dir.y).toBeCloseTo(0);
+    expect(dir.z).toBe(-1);
 
     act(() => {
       root.render(
@@ -118,6 +128,7 @@ describe('SceneViewer view mode', () => {
 
     expect(threeRef.current.camera).toBe(threeRef.current.perspectiveCamera);
     expect(threeRef.current.controls.enableRotate).toBe(true);
+    expect(threeRef.current.controls.screenSpacePanning).toBe(false);
     expect(threeRef.current.camera.up).toEqual(new THREE.Vector3(0, 1, 0));
 
     root.unmount();


### PR DESCRIPTION
## Summary
- align orthographic camera to look along +Z and support X/Y panning only
- test camera orientation and control flags in 2D mode

## Testing
- `npm test tests/sceneViewer.viewMode.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c5a3b616ec8322802f43a0de44ed21