### PR TITLE
Refactor wall drawer to use XY mapping

### DIFF
--- a/src/viewer/WallDrawer.ts
+++ b/src/viewer/WallDrawer.ts
@@ -24,7 +24,7 @@ export default class WallDrawer {
   private group: THREE.Group;
   private store: UseBoundStore<StoreApi<PlannerStore>>;
   private raycaster = new THREE.Raycaster();
-  private plane = new THREE.Plane(new THREE.Vector3(0, 1, 0), 0);
+  private plane = new THREE.Plane(new THREE.Vector3(0, 0, 1), 0);
   private cursor: THREE.Mesh | null = null;
   private cursorTarget: THREE.Vector3 | null = null;
   private animationId: number | null = null;
@@ -91,7 +91,6 @@ export default class WallDrawer {
   private addCursor() {
     this.removeCursor();
     const geom = new THREE.PlaneGeometry(this.thickness, this.thickness);
-    geom.rotateX(-Math.PI / 2);
     const mat = new THREE.MeshBasicMaterial({
       color: 0x00ffff,
       transparent: true,
@@ -99,7 +98,7 @@ export default class WallDrawer {
       side: THREE.DoubleSide,
     });
     this.cursor = new THREE.Mesh(geom, mat);
-    this.cursor.position.set(0, 0.001, 0);
+    this.cursor.position.set(0, 0, 0.001);
     this.cursorTarget = this.cursor.position.clone();
     this.group.add(this.cursor);
   }
@@ -139,19 +138,19 @@ export default class WallDrawer {
     const rect = this.renderer.domElement.getBoundingClientRect();
     const x = ((event.clientX - rect.left) / rect.width) * 2 - 1;
     const ny = ((event.clientY - rect.top) / rect.height) * 2 - 1;
-    const y = convertAxis(ny, screenAxes, 'y', worldAxes, 'z');
+    const y = convertAxis(ny, screenAxes, 'y', worldAxes, 'y');
     const cam = this.getCamera();
     this.raycaster.setFromCamera(new THREE.Vector2(x, y), cam);
     const point = new THREE.Vector3();
     const intersection = this.raycaster.ray.intersectPlane(this.plane, point);
     if (!intersection) return null;
-    if (!isFinite(intersection.x) || !isFinite(intersection.z)) return null;
-    point.set(intersection.x, 0, intersection.z);
+    if (!isFinite(intersection.x) || !isFinite(intersection.y)) return null;
+    point.set(intersection.x, intersection.y, 0);
     const { snapToGrid, gridSize } = this.store.getState();
     if (snapToGrid && gridSize > 0) {
       const step = gridSize / 1000;
       point.x = Math.round(point.x / step) * step;
-      point.z = Math.round(point.z / step) * step;
+      point.y = Math.round(point.y / step) * step;
     }
     return point;
   }
@@ -160,9 +159,9 @@ export default class WallDrawer {
     const { snapRightAngles } = this.store.getState();
     if (!this.start || !snapRightAngles) return point;
     const dx = Math.abs(point.x - this.start.x);
-    const dz = Math.abs(point.z - this.start.z);
-    if (dx > dz) {
-      point.z = this.start.z;
+    const dy = Math.abs(point.y - this.start.y);
+    if (dx > dy) {
+      point.y = this.start.y;
     } else {
       point.x = this.start.x;
     }
@@ -173,25 +172,25 @@ export default class WallDrawer {
     const point = this.getPoint(e);
     if (!point) return;
     this.constrainPoint(point);
-    point.y = 0.001;
-    this.lastPoint = point;
+    point.z = 0.001;
+    this.lastPoint = point.clone();
     this.cursorTarget = point.clone();
     if (this.dragging && this.start && this.preview) {
       if (this.cursor) {
-        this.cursor.position.copy(point).setY(0.001);
+        this.cursor.position.copy(point).setZ(0.001);
       }
       const dx = point.x - this.start.x;
-      const dz = point.z - this.start.z;
+      const dy = point.y - this.start.y;
       const distX = Math.abs(dx);
-      const distZ = Math.abs(dz);
-      const dist = Math.sqrt(distX * distX + distZ * distZ);
+      const distY = Math.abs(dy);
+      const dist = Math.sqrt(distX * distX + distY * distY);
       this.preview.scale.x = dist;
       this.preview.position.set(
         this.start.x,
         this.preview.position.y,
-        this.start.z,
+        this.start.y,
       );
-      this.preview.rotation.y = Math.atan2(dz, dx);
+      this.preview.rotation.y = Math.atan2(dy, dx);
     }
   };
 
@@ -205,7 +204,7 @@ export default class WallDrawer {
     this.start = point.clone();
     this.lastPoint = this.start.clone();
     if (this.cursor) {
-      this.cursor.position.copy(point).setY(0.001);
+      this.cursor.position.copy(point).setZ(0.001);
       this.cursorTarget = this.cursor.position.clone();
     }
     const state = this.store.getState();
@@ -220,7 +219,7 @@ export default class WallDrawer {
       opacity: 0.5,
     });
     this.preview = new THREE.Mesh(geom, mat);
-    this.preview.position.set(point.x, height / 2, point.z);
+    this.preview.position.set(point.x, height / 2, point.y);
     this.preview.scale.set(0.0001, 1, 1);
     this.group.add(this.preview);
   };
@@ -243,47 +242,47 @@ export default class WallDrawer {
     this.constrainPoint(point);
     const state = this.store.getState();
     let endX = point.x;
-    let endZ = point.z;
+    let endY = point.y;
     const dx = endX - this.start.x;
-    const dz = endZ - this.start.z;
-    const dist = Math.sqrt(dx * dx + dz * dz);
+    const dy = endY - this.start.y;
+    const dist = Math.sqrt(dx * dx + dy * dy);
     if (dist < 0.001) {
       const snapLength = state.snapLength > 0 ? state.snapLength : 10;
       const step = snapLength / 1000;
       let dirX = dx;
-      let dirZ = dz;
-      if (dirX === 0 && dirZ === 0 && this.lastPoint) {
+      let dirY = dy;
+      if (dirX === 0 && dirY === 0 && this.lastPoint) {
         dirX = this.lastPoint.x - this.start.x;
-        dirZ = this.lastPoint.z - this.start.z;
+        dirY = this.lastPoint.y - this.start.y;
       }
-      if (dirX === 0 && dirZ === 0) {
+      if (dirX === 0 && dirY === 0) {
         dirX = 1;
-        dirZ = 0;
+        dirY = 0;
       }
-      const len = Math.sqrt(dirX * dirX + dirZ * dirZ);
+      const len = Math.sqrt(dirX * dirX + dirY * dirY);
       dirX /= len;
-      dirZ /= len;
+      dirY /= len;
       endX = this.start.x + dirX * step;
-      endZ = this.start.z + dirZ * step;
-      point.set(endX, 0, endZ);
+      endY = this.start.y + dirY * step;
+      point.set(endX, endY, 0);
     }
     let startX = this.start.x;
-    let startZ = this.start.z;
+    let startY = this.start.y;
     if (state.snapToGrid && state.gridSize > 0) {
       const stepSize = state.gridSize / 1000;
       startX = Math.round(startX / stepSize) * stepSize;
-      startZ = Math.round(startZ / stepSize) * stepSize;
+      startY = Math.round(startY / stepSize) * stepSize;
       endX = Math.round(endX / stepSize) * stepSize;
-      endZ = Math.round(endZ / stepSize) * stepSize;
-      point.set(endX, 0, endZ);
+      endY = Math.round(endY / stepSize) * stepSize;
+      point.set(endX, endY, 0);
     }
-    const start = { x: startX, y: startZ };
-    const end = { x: endX, y: endZ };
+    const start = { x: startX, y: startY };
+    const end = { x: endX, y: endY };
     state.addWallWithHistory(start, end);
     this.start = null;
     this.disposePreview();
     if (this.cursor) {
-      this.cursor.position.set(point.x, 0.001, point.z);
+      this.cursor.position.set(point.x, point.y, 0.001);
       this.cursorTarget = this.cursor.position.clone();
     }
   };
@@ -302,7 +301,11 @@ export default class WallDrawer {
     this.start = null;
     this.disposePreview();
     if (this.cursor && this.lastPoint) {
-      this.cursor.position.set(this.lastPoint.x, 0.001, this.lastPoint.z);
+      this.cursor.position.set(
+        this.lastPoint.x,
+        this.lastPoint.y,
+        0.001,
+      );
       this.cursorTarget = this.cursor.position.clone();
     }
   };

--- a/tests/viewer/WallDrawer.test.ts
+++ b/tests/viewer/WallDrawer.test.ts
@@ -97,7 +97,7 @@ describe('WallDrawer', () => {
     const drawer = new WallDrawer(renderer, () => camera, group, store);
     drawer.enable(state.wallDefaults.thickness);
 
-    const intersection = new THREE.Vector3(1.2345, 0, 2.3456);
+    const intersection = new THREE.Vector3(1.2345, 2.3456, 0);
     (drawer as any).raycaster.ray.intersectPlane = vi.fn(
       (_plane: THREE.Plane, point: THREE.Vector3) => {
         point.copy(intersection);
@@ -110,7 +110,7 @@ describe('WallDrawer', () => {
       clientY: 0,
     } as PointerEvent);
     expect(result?.x).toBe(intersection.x);
-    expect(result?.z).toBe(intersection.z);
+    expect(result?.y).toBe(intersection.y);
     drawer.disable();
   });
 
@@ -129,7 +129,7 @@ describe('WallDrawer', () => {
 
   it('single click after moving cursor starts in default direction', () => {
     const { drawer, point, addWallWithHistory } = createDrawer();
-    point.set(0, 0, 1);
+    point.set(0, 1, 0);
     (drawer as any).onMove({} as PointerEvent);
     point.set(0, 0, 0);
     (drawer as any).onDown({ pointerId: 1, button: 0 } as PointerEvent);
@@ -152,11 +152,21 @@ describe('WallDrawer', () => {
     expect(preview.position.x).toBeCloseTo(0);
     drawer.disable();
   });
+
+  it('maps XY input to XZ preview position', () => {
+    const { drawer, point } = createDrawer();
+    point.set(1, 2, 0);
+    (drawer as any).onDown({ pointerId: 1, button: 0 } as PointerEvent);
+    const preview = (drawer as any).preview as THREE.Mesh;
+    expect(preview.position.x).toBeCloseTo(1);
+    expect(preview.position.z).toBeCloseTo(2);
+    drawer.disable();
+  });
   it('preview end matches constrained cursor position', () => {
     const { drawer, point } = createDrawer();
     point.set(0, 0, 0);
     (drawer as any).onDown({ pointerId: 1, button: 0 } as PointerEvent);
-    point.set(2, 0, 1);
+    point.set(2, 1, 0);
     (drawer as any).onMove({} as PointerEvent);
     const preview = (drawer as any).preview as THREE.Mesh;
     const dist = preview.scale.x;
@@ -171,7 +181,7 @@ describe('WallDrawer', () => {
     const { drawer, point, addWallWithHistory } = createDrawer();
     point.set(0, 0, 0);
     (drawer as any).onDown({ pointerId: 1, button: 0 } as PointerEvent);
-    point.set(0.1, 0, 2);
+    point.set(0.1, 2, 0);
     (drawer as any).onMove({} as PointerEvent);
     const preview = (drawer as any).preview as THREE.Mesh;
     const dist = preview.scale.x;
@@ -194,7 +204,7 @@ describe('WallDrawer', () => {
     });
     point.set(0, 0, 0);
     (drawer as any).onDown({ pointerId: 1, button: 0 } as PointerEvent);
-    point.set(2, 0, 1);
+    point.set(2, 1, 0);
     (drawer as any).onUp({ pointerId: 1, button: 0 } as PointerEvent);
     expect(addWallWithHistory).toHaveBeenCalledWith(
       { x: 0, y: 0 },
@@ -203,11 +213,11 @@ describe('WallDrawer', () => {
     drawer.disable();
   });
 
-  it('handles negative z coordinates', () => {
+  it('handles negative y coordinates', () => {
     const { drawer, point, addWallWithHistory } = createDrawer();
     point.set(0, 0, 0);
     (drawer as any).onDown({ pointerId: 1, button: 0 } as PointerEvent);
-    point.set(0, 0, -2);
+    point.set(0, -2, 0);
     (drawer as any).onUp({ pointerId: 1, button: 0 } as PointerEvent);
     expect(addWallWithHistory).toHaveBeenCalledWith(
       { x: 0, y: 0 },


### PR DESCRIPTION
## Summary
- handle drawing on XY plane with plane normal (0,0,1)
- replace z-based logic with y-based coordinates and map to XZ for 3D
- update wall drawer tests for new axis mapping and add XY→XZ preview check

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c5a4e8afa8832298661b6fd0d4990f