### PR TITLE
Drag cabinets on XY plane

### DIFF
--- a/src/viewer/CabinetDragger.ts
+++ b/src/viewer/CabinetDragger.ts
@@ -16,7 +16,7 @@ export default class CabinetDragger {
   private group: THREE.Group;
   private store: UseBoundStore<StoreApi<PlannerStore>>;
   private raycaster = new THREE.Raycaster();
-  private plane = new THREE.Plane(new THREE.Vector3(0, 1, 0), 0);
+  private plane = new THREE.Plane(new THREE.Vector3(0, 0, 1), 0);
   private draggingId: string | null = null;
   private offset = new THREE.Vector3();
 
@@ -51,7 +51,7 @@ export default class CabinetDragger {
     const rect = this.renderer.domElement.getBoundingClientRect();
     const x = ((event.clientX - rect.left) / rect.width) * 2 - 1;
     const yScreen = ((event.clientY - rect.top) / rect.height) * 2 - 1;
-    const y = convertAxis(yScreen, screenAxes, 'y', worldAxes, 'z');
+    const y = convertAxis(yScreen, screenAxes, 'y', worldAxes, 'y');
     const cam = this.getCamera();
     this.raycaster.setFromCamera(new THREE.Vector2(x, y), cam);
     const point = new THREE.Vector3();
@@ -64,7 +64,7 @@ export default class CabinetDragger {
     const rect = this.renderer.domElement.getBoundingClientRect();
     const x = ((e.clientX - rect.left) / rect.width) * 2 - 1;
     const yScreen = ((e.clientY - rect.top) / rect.height) * 2 - 1;
-    const y = convertAxis(yScreen, screenAxes, 'y', worldAxes, 'z');
+    const y = convertAxis(yScreen, screenAxes, 'y', worldAxes, 'y');
     const cam = this.getCamera();
     this.raycaster.setFromCamera(new THREE.Vector2(x, y), cam);
     const intersects = this.raycaster.intersectObjects(this.group.children, true);
@@ -83,8 +83,8 @@ export default class CabinetDragger {
     const point = this.getPoint(e);
     if (!point) return;
     this.draggingId = mod.id;
-    const pointXZ = new THREE.Vector3(point.x, point.z, 0);
-    this.offset.set(mod.position[0], mod.position[2], 0).sub(pointXZ);
+    const pointXY = new THREE.Vector3(point.x, point.y, 0);
+    this.offset.set(mod.position[0], mod.position[1], 0).sub(pointXY);
   };
 
   private onMove = (e: PointerEvent) => {
@@ -95,9 +95,9 @@ export default class CabinetDragger {
     const current = mods.find((m) => m.id === this.draggingId);
     if (!current) return;
     const newX = point.x + this.offset.x;
-    const newZ = point.z + this.offset.y;
+    const newY = point.y + this.offset.y;
     this.store.getState().updateModule(this.draggingId, {
-      position: [newX, current.position[1], newZ],
+      position: [newX, newY, current.position[2]],
     });
   };
 

--- a/tests/cabinetDragger.pointerCapture.test.ts
+++ b/tests/cabinetDragger.pointerCapture.test.ts
@@ -65,7 +65,7 @@ describe('CabinetDragger pointer capture', () => {
     expect((dragger as any).draggingId).toBeNull();
   });
 
-  it('updates module position along XZ plane when dragging', () => {
+  it('updates module position along XY plane when dragging', () => {
     const canvas = document.createElement('canvas');
     canvas.getBoundingClientRect = () => ({
       left: 0,
@@ -89,7 +89,7 @@ describe('CabinetDragger pointer capture', () => {
     obj.userData.kind = 'cab';
     group.add(obj);
 
-    const module = { id: '1', position: [0, 5, 0] } as Module3D;
+    const module = { id: '1', position: [0, 0, 5] } as Module3D;
     const updateModule = vi.fn();
     const store = {
       getState: () => ({
@@ -111,7 +111,7 @@ describe('CabinetDragger pointer capture', () => {
     } as PointerEvent;
     (dragger as any).onDown(down);
 
-    (dragger as any).getPoint = () => new THREE.Vector3(10, 0, 20);
+    (dragger as any).getPoint = () => new THREE.Vector3(10, 20, 0);
     const move = {
       clientX: 10,
       clientY: 10,
@@ -121,7 +121,7 @@ describe('CabinetDragger pointer capture', () => {
     (dragger as any).onMove(move);
 
     expect(updateModule).toHaveBeenCalledWith('1', {
-      position: [10, 5, 20],
+      position: [10, 20, 5],
     });
   });
 });


### PR DESCRIPTION
## Summary
- Switch dragging plane to XY and map pointer y to world Y with `convertAxis`
- Update cabinet offset and position calculations to track X/Y movement while keeping depth
- Adjust cabinet drag unit test for XY-plane behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c5a6582a788322bd9f8f8e54bb937f