### PR TITLE
Add static axes gizmo to SceneViewer

### DIFF
--- a/tests/sceneViewer.gizmo.test.tsx
+++ b/tests/sceneViewer.gizmo.test.tsx
@@ -1,0 +1,102 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import React from 'react';
+import { act } from 'react';
+import ReactDOM from 'react-dom/client';
+import * as THREE from 'three';
+import SceneViewer from '../src/ui/SceneViewer';
+
+vi.mock('three/examples/jsm/controls/OrbitControls.js', () => ({
+  OrbitControls: vi.fn().mockImplementation(() => ({
+    target: new THREE.Vector3(),
+    enableRotate: true,
+    update: vi.fn(),
+    dispose: vi.fn(),
+    dollyIn: vi.fn(),
+    dollyOut: vi.fn(),
+  })),
+}));
+
+vi.mock('../src/scene/engine', () => {
+  return {
+    setupThree: () => {
+      const dom = document.createElement('canvas');
+      dom.getBoundingClientRect = () => ({
+        left: 0,
+        top: 0,
+        width: 100,
+        height: 100,
+        right: 100,
+        bottom: 100,
+        x: 0,
+        y: 0,
+        toJSON() {},
+      });
+      const perspectiveCamera = new THREE.PerspectiveCamera();
+      const orthographicCamera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0.1, 100);
+      const three: any = {
+        scene: {},
+        camera: perspectiveCamera,
+        renderer: { domElement: dom },
+        controls: {
+          enabled: true,
+          target: new THREE.Vector3(),
+          enableRotate: true,
+          update: () => {},
+          dispose: () => {},
+          dollyIn: () => {},
+          dollyOut: () => {},
+        },
+        playerControls: {
+          lock: vi.fn(),
+          unlock: vi.fn(),
+          addEventListener: vi.fn(),
+          removeEventListener: vi.fn(),
+          isLocked: false,
+        },
+        group: { children: [], add: () => {}, remove: () => {} },
+        cabinetDragger: { enable: vi.fn(), disable: vi.fn() },
+        perspectiveCamera,
+        orthographicCamera,
+      };
+      three.setCamera = (cam: THREE.Camera) => {
+        three.camera = cam;
+      };
+      three.setControls = (c: any) => {
+        three.controls = c;
+      };
+      return three;
+    },
+  };
+});
+
+vi.mock('../src/ui/components/ItemHotbar', () => ({
+  default: () => <div data-testid="item-hotbar"></div>,
+  hotbarItems: [],
+  furnishHotbarItems: [],
+}));
+vi.mock('../src/ui/components/TouchJoystick', () => ({ default: () => null }));
+
+describe('SceneViewer axes gizmo', () => {
+  it('renders axes helper overlay', () => {
+    const threeRef: any = { current: null };
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = ReactDOM.createRoot(container);
+    act(() => {
+      root.render(
+        <SceneViewer
+          threeRef={threeRef}
+          addCountertop={false}
+          mode={null}
+          setMode={vi.fn()}
+          setViewMode={() => {}}
+        />,
+      );
+    });
+    expect(container.querySelector('[data-testid="axes-gizmo"]')).not.toBeNull();
+    root.unmount();
+    container.remove();
+  });
+});
+


### PR DESCRIPTION
## Summary
- render bottom-right axes gizmo in SceneViewer with independent scene
- cover axes gizmo with unit test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c5a9fd0bac8322a99df2cd03d39f11