### PR TITLE
Align 2D view on XZ plane

### DIFF
--- a/src/ui/SceneViewer.tsx
+++ b/src/ui/SceneViewer.tsx
@@ -155,12 +155,15 @@ const SceneViewer: React.FC<Props> = ({
         c.screenSpacePanning = true;
         three.setControls(c);
         const pos = savedView.current.pos;
-        three.camera.position.set(pos.x, pos.y, 10);
-        three.camera.up.set(0, 1, 0);
-        c.target.set(pos.x, pos.y, 0);
+        const height = 10;
+        three.camera.position.set(pos.x, height, pos.z);
+        three.camera.up.set(0, 0, -1);
+        c.target.set(pos.x, 0, pos.z);
         three.camera.lookAt(c.target);
         c.update();
         const updateGrid = () => {
+          three.camera.position.y = height;
+          c.target.y = 0;
           const base = Math.max(
             1,
             Math.round(16 / (usePlannerStore.getState().gridSize / 100)),

--- a/tests/sceneViewer.viewMode.test.tsx
+++ b/tests/sceneViewer.viewMode.test.tsx
@@ -104,14 +104,14 @@ describe('SceneViewer view mode', () => {
     expect(threeRef.current.camera).toBe(threeRef.current.orthographicCamera);
     expect(threeRef.current.controls.enableRotate).toBe(false);
     expect(threeRef.current.controls.screenSpacePanning).toBe(true);
-    expect(threeRef.current.camera.up).toEqual(new THREE.Vector3(0, 1, 0));
-    expect(threeRef.current.camera.position).toEqual(new THREE.Vector3(0, 0, 10));
+    expect(threeRef.current.camera.up).toEqual(new THREE.Vector3(0, 0, -1));
+    expect(threeRef.current.camera.position).toEqual(new THREE.Vector3(0, 10, 0));
     expect(threeRef.current.controls.target).toEqual(new THREE.Vector3(0, 0, 0));
     const dir = new THREE.Vector3();
     threeRef.current.camera.getWorldDirection(dir);
     expect(dir.x).toBeCloseTo(0);
-    expect(dir.y).toBeCloseTo(0);
-    expect(dir.z).toBe(-1);
+    expect(dir.y).toBe(-1);
+    expect(dir.z).toBeCloseTo(0);
 
     act(() => {
       root.render(


### PR DESCRIPTION
## Summary
- Orient orthographic camera above XZ floor plane for 2D view
- Restrict OrbitControls to panning in XZ and disable rotation
- Update view-mode test expectations for new camera orientation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c5b514c79c8322b3b23f70378a8a14