### PR TITLE
Align wall and cabinet interactions to XZ ground plane

### DIFF
--- a/src/viewer/CabinetDragger.ts
+++ b/src/viewer/CabinetDragger.ts
@@ -16,7 +16,7 @@ export default class CabinetDragger {
   private group: THREE.Group;
   private store: UseBoundStore<StoreApi<PlannerStore>>;
   private raycaster = new THREE.Raycaster();
-  private plane = new THREE.Plane(new THREE.Vector3(0, 0, 1), 0);
+  private plane = new THREE.Plane(new THREE.Vector3(0, 1, 0), 0);
   private draggingId: string | null = null;
   private offset = new THREE.Vector3();
 
@@ -51,7 +51,7 @@ export default class CabinetDragger {
     const rect = this.renderer.domElement.getBoundingClientRect();
     const x = ((event.clientX - rect.left) / rect.width) * 2 - 1;
     const yScreen = ((event.clientY - rect.top) / rect.height) * 2 - 1;
-    const y = convertAxis(yScreen, screenAxes, 'y', worldAxes, 'y');
+    const y = convertAxis(yScreen, screenAxes, 'y', worldAxes, 'z');
     const cam = this.getCamera();
     this.raycaster.setFromCamera(new THREE.Vector2(x, y), cam);
     const point = new THREE.Vector3();
@@ -64,7 +64,7 @@ export default class CabinetDragger {
     const rect = this.renderer.domElement.getBoundingClientRect();
     const x = ((e.clientX - rect.left) / rect.width) * 2 - 1;
     const yScreen = ((e.clientY - rect.top) / rect.height) * 2 - 1;
-    const y = convertAxis(yScreen, screenAxes, 'y', worldAxes, 'y');
+    const y = convertAxis(yScreen, screenAxes, 'y', worldAxes, 'z');
     const cam = this.getCamera();
     this.raycaster.setFromCamera(new THREE.Vector2(x, y), cam);
     const intersects = this.raycaster.intersectObjects(this.group.children, true);
@@ -83,8 +83,8 @@ export default class CabinetDragger {
     const point = this.getPoint(e);
     if (!point) return;
     this.draggingId = mod.id;
-    const pointXY = new THREE.Vector3(point.x, point.y, 0);
-    this.offset.set(mod.position[0], mod.position[1], 0).sub(pointXY);
+    const pointXZ = new THREE.Vector3(point.x, point.z, 0);
+    this.offset.set(mod.position[0], mod.position[2], 0).sub(pointXZ);
   };
 
   private onMove = (e: PointerEvent) => {
@@ -95,9 +95,9 @@ export default class CabinetDragger {
     const current = mods.find((m) => m.id === this.draggingId);
     if (!current) return;
     const newX = point.x + this.offset.x;
-    const newY = point.y + this.offset.y;
+    const newZ = point.z + this.offset.y;
     this.store.getState().updateModule(this.draggingId, {
-      position: [newX, newY, current.position[2]],
+      position: [newX, current.position[1], newZ],
     });
   };
 

--- a/src/viewer/WallDrawer.ts
+++ b/src/viewer/WallDrawer.ts
@@ -24,7 +24,7 @@ export default class WallDrawer {
   private group: THREE.Group;
   private store: UseBoundStore<StoreApi<PlannerStore>>;
   private raycaster = new THREE.Raycaster();
-  private plane = new THREE.Plane(new THREE.Vector3(0, 0, 1), 0);
+  private plane = new THREE.Plane(new THREE.Vector3(0, 1, 0), 0);
   private cursor: THREE.Mesh | null = null;
   private cursorTarget: THREE.Vector3 | null = null;
   private animationId: number | null = null;
@@ -98,7 +98,7 @@ export default class WallDrawer {
       side: THREE.DoubleSide,
     });
     this.cursor = new THREE.Mesh(geom, mat);
-    this.cursor.position.set(0, 0, 0.001);
+    this.cursor.position.set(0, 0.001, 0);
     this.cursorTarget = this.cursor.position.clone();
     this.group.add(this.cursor);
   }
@@ -138,19 +138,19 @@ export default class WallDrawer {
     const rect = this.renderer.domElement.getBoundingClientRect();
     const x = ((event.clientX - rect.left) / rect.width) * 2 - 1;
     const ny = ((event.clientY - rect.top) / rect.height) * 2 - 1;
-    const y = convertAxis(ny, screenAxes, 'y', worldAxes, 'y');
+    const y = convertAxis(ny, screenAxes, 'y', worldAxes, 'z');
     const cam = this.getCamera();
     this.raycaster.setFromCamera(new THREE.Vector2(x, y), cam);
     const point = new THREE.Vector3();
     const intersection = this.raycaster.ray.intersectPlane(this.plane, point);
     if (!intersection) return null;
-    if (!isFinite(intersection.x) || !isFinite(intersection.y)) return null;
-    point.set(intersection.x, intersection.y, 0);
+    if (!isFinite(intersection.x) || !isFinite(intersection.z)) return null;
+    point.set(intersection.x, 0, intersection.z);
     const { snapToGrid, gridSize } = this.store.getState();
     if (snapToGrid && gridSize > 0) {
       const step = gridSize / 1000;
       point.x = Math.round(point.x / step) * step;
-      point.y = Math.round(point.y / step) * step;
+      point.z = Math.round(point.z / step) * step;
     }
     return point;
   }
@@ -159,9 +159,9 @@ export default class WallDrawer {
     const { snapRightAngles } = this.store.getState();
     if (!this.start || !snapRightAngles) return point;
     const dx = Math.abs(point.x - this.start.x);
-    const dy = Math.abs(point.y - this.start.y);
-    if (dx > dy) {
-      point.y = this.start.y;
+    const dz = Math.abs(point.z - this.start.z);
+    if (dx > dz) {
+      point.z = this.start.z;
     } else {
       point.x = this.start.x;
     }
@@ -172,25 +172,25 @@ export default class WallDrawer {
     const point = this.getPoint(e);
     if (!point) return;
     this.constrainPoint(point);
-    point.z = 0.001;
+    point.y = 0.001;
     this.lastPoint = point.clone();
     this.cursorTarget = point.clone();
     if (this.dragging && this.start && this.preview) {
       if (this.cursor) {
-        this.cursor.position.copy(point).setZ(0.001);
+        this.cursor.position.copy(point).setY(0.001);
       }
       const dx = point.x - this.start.x;
-      const dy = point.y - this.start.y;
+      const dz = point.z - this.start.z;
       const distX = Math.abs(dx);
-      const distY = Math.abs(dy);
-      const dist = Math.sqrt(distX * distX + distY * distY);
+      const distZ = Math.abs(dz);
+      const dist = Math.sqrt(distX * distX + distZ * distZ);
       this.preview.scale.x = dist;
       this.preview.position.set(
         this.start.x,
         this.preview.position.y,
-        this.start.y,
+        this.start.z,
       );
-      this.preview.rotation.y = Math.atan2(dy, dx);
+      this.preview.rotation.y = Math.atan2(dz, dx);
     }
   };
 
@@ -204,7 +204,7 @@ export default class WallDrawer {
     this.start = point.clone();
     this.lastPoint = this.start.clone();
     if (this.cursor) {
-      this.cursor.position.copy(point).setZ(0.001);
+      this.cursor.position.copy(point).setY(0.001);
       this.cursorTarget = this.cursor.position.clone();
     }
     const state = this.store.getState();
@@ -219,7 +219,7 @@ export default class WallDrawer {
       opacity: 0.5,
     });
     this.preview = new THREE.Mesh(geom, mat);
-    this.preview.position.set(point.x, height / 2, point.y);
+    this.preview.position.set(point.x, height / 2, point.z);
     this.preview.scale.set(0.0001, 1, 1);
     this.group.add(this.preview);
   };
@@ -242,47 +242,47 @@ export default class WallDrawer {
     this.constrainPoint(point);
     const state = this.store.getState();
     let endX = point.x;
-    let endY = point.y;
+    let endZ = point.z;
     const dx = endX - this.start.x;
-    const dy = endY - this.start.y;
-    const dist = Math.sqrt(dx * dx + dy * dy);
+    const dz = endZ - this.start.z;
+    const dist = Math.sqrt(dx * dx + dz * dz);
     if (dist < 0.001) {
       const snapLength = state.snapLength > 0 ? state.snapLength : 10;
       const step = snapLength / 1000;
       let dirX = dx;
-      let dirY = dy;
-      if (dirX === 0 && dirY === 0 && this.lastPoint) {
+      let dirZ = dz;
+      if (dirX === 0 && dirZ === 0 && this.lastPoint) {
         dirX = this.lastPoint.x - this.start.x;
-        dirY = this.lastPoint.y - this.start.y;
+        dirZ = this.lastPoint.z - this.start.z;
       }
-      if (dirX === 0 && dirY === 0) {
+      if (dirX === 0 && dirZ === 0) {
         dirX = 1;
-        dirY = 0;
+        dirZ = 0;
       }
-      const len = Math.sqrt(dirX * dirX + dirY * dirY);
+      const len = Math.sqrt(dirX * dirX + dirZ * dirZ);
       dirX /= len;
-      dirY /= len;
+      dirZ /= len;
       endX = this.start.x + dirX * step;
-      endY = this.start.y + dirY * step;
-      point.set(endX, endY, 0);
+      endZ = this.start.z + dirZ * step;
+      point.set(endX, 0, endZ);
     }
     let startX = this.start.x;
-    let startY = this.start.y;
+    let startZ = this.start.z;
     if (state.snapToGrid && state.gridSize > 0) {
       const stepSize = state.gridSize / 1000;
       startX = Math.round(startX / stepSize) * stepSize;
-      startY = Math.round(startY / stepSize) * stepSize;
+      startZ = Math.round(startZ / stepSize) * stepSize;
       endX = Math.round(endX / stepSize) * stepSize;
-      endY = Math.round(endY / stepSize) * stepSize;
-      point.set(endX, endY, 0);
+      endZ = Math.round(endZ / stepSize) * stepSize;
+      point.set(endX, 0, endZ);
     }
-    const start = { x: startX, y: startY };
-    const end = { x: endX, y: endY };
+    const start = { x: startX, y: startZ };
+    const end = { x: endX, y: endZ };
     state.addWallWithHistory(start, end);
     this.start = null;
     this.disposePreview();
     if (this.cursor) {
-      this.cursor.position.set(point.x, point.y, 0.001);
+      this.cursor.position.set(point.x, 0.001, point.z);
       this.cursorTarget = this.cursor.position.clone();
     }
   };
@@ -303,8 +303,8 @@ export default class WallDrawer {
     if (this.cursor && this.lastPoint) {
       this.cursor.position.set(
         this.lastPoint.x,
-        this.lastPoint.y,
         0.001,
+        this.lastPoint.z,
       );
       this.cursorTarget = this.cursor.position.clone();
     }

--- a/tests/cabinetDragger.pointerCapture.test.ts
+++ b/tests/cabinetDragger.pointerCapture.test.ts
@@ -65,7 +65,7 @@ describe('CabinetDragger pointer capture', () => {
     expect((dragger as any).draggingId).toBeNull();
   });
 
-  it('updates module position along XY plane when dragging', () => {
+  it('updates module position along XZ plane when dragging', () => {
     const canvas = document.createElement('canvas');
     canvas.getBoundingClientRect = () => ({
       left: 0,
@@ -102,7 +102,7 @@ describe('CabinetDragger pointer capture', () => {
 
     (dragger as any).raycaster.intersectObjects = () => [{ object: obj }];
 
-    (dragger as any).getPoint = () => new THREE.Vector3(0, 0, 0);
+    (dragger as any).getPoint = () => new THREE.Vector3(0, 0, 5);
     const down = {
       clientX: 0,
       clientY: 0,
@@ -111,7 +111,7 @@ describe('CabinetDragger pointer capture', () => {
     } as PointerEvent;
     (dragger as any).onDown(down);
 
-    (dragger as any).getPoint = () => new THREE.Vector3(10, 20, 0);
+    (dragger as any).getPoint = () => new THREE.Vector3(10, 0, 20);
     const move = {
       clientX: 10,
       clientY: 10,
@@ -121,7 +121,7 @@ describe('CabinetDragger pointer capture', () => {
     (dragger as any).onMove(move);
 
     expect(updateModule).toHaveBeenCalledWith('1', {
-      position: [10, 20, 5],
+      position: [10, 0, 20],
     });
   });
 });

--- a/tests/viewer/WallDrawer.test.ts
+++ b/tests/viewer/WallDrawer.test.ts
@@ -97,7 +97,7 @@ describe('WallDrawer', () => {
     const drawer = new WallDrawer(renderer, () => camera, group, store);
     drawer.enable(state.wallDefaults.thickness);
 
-    const intersection = new THREE.Vector3(1.2345, 2.3456, 0);
+    const intersection = new THREE.Vector3(1.2345, 0, 2.3456);
     (drawer as any).raycaster.ray.intersectPlane = vi.fn(
       (_plane: THREE.Plane, point: THREE.Vector3) => {
         point.copy(intersection);
@@ -110,7 +110,7 @@ describe('WallDrawer', () => {
       clientY: 0,
     } as PointerEvent);
     expect(result?.x).toBe(intersection.x);
-    expect(result?.y).toBe(intersection.y);
+    expect(result?.z).toBe(intersection.z);
     drawer.disable();
   });
 
@@ -129,7 +129,7 @@ describe('WallDrawer', () => {
 
   it('single click after moving cursor starts in default direction', () => {
     const { drawer, point, addWallWithHistory } = createDrawer();
-    point.set(0, 1, 0);
+    point.set(0, 0, 1);
     (drawer as any).onMove({} as PointerEvent);
     point.set(0, 0, 0);
     (drawer as any).onDown({ pointerId: 1, button: 0 } as PointerEvent);
@@ -153,9 +153,9 @@ describe('WallDrawer', () => {
     drawer.disable();
   });
 
-  it('maps XY input to XZ preview position', () => {
+  it('places preview using XZ coordinates', () => {
     const { drawer, point } = createDrawer();
-    point.set(1, 2, 0);
+    point.set(1, 0, 2);
     (drawer as any).onDown({ pointerId: 1, button: 0 } as PointerEvent);
     const preview = (drawer as any).preview as THREE.Mesh;
     expect(preview.position.x).toBeCloseTo(1);
@@ -166,7 +166,7 @@ describe('WallDrawer', () => {
     const { drawer, point } = createDrawer();
     point.set(0, 0, 0);
     (drawer as any).onDown({ pointerId: 1, button: 0 } as PointerEvent);
-    point.set(2, 1, 0);
+    point.set(2, 0, 1);
     (drawer as any).onMove({} as PointerEvent);
     const preview = (drawer as any).preview as THREE.Mesh;
     const dist = preview.scale.x;
@@ -181,7 +181,7 @@ describe('WallDrawer', () => {
     const { drawer, point, addWallWithHistory } = createDrawer();
     point.set(0, 0, 0);
     (drawer as any).onDown({ pointerId: 1, button: 0 } as PointerEvent);
-    point.set(0.1, 2, 0);
+    point.set(0.1, 0, 2);
     (drawer as any).onMove({} as PointerEvent);
     const preview = (drawer as any).preview as THREE.Mesh;
     const dist = preview.scale.x;
@@ -204,7 +204,7 @@ describe('WallDrawer', () => {
     });
     point.set(0, 0, 0);
     (drawer as any).onDown({ pointerId: 1, button: 0 } as PointerEvent);
-    point.set(2, 1, 0);
+    point.set(2, 0, 1);
     (drawer as any).onUp({ pointerId: 1, button: 0 } as PointerEvent);
     expect(addWallWithHistory).toHaveBeenCalledWith(
       { x: 0, y: 0 },
@@ -213,11 +213,11 @@ describe('WallDrawer', () => {
     drawer.disable();
   });
 
-  it('handles negative y coordinates', () => {
+  it('handles negative z coordinates', () => {
     const { drawer, point, addWallWithHistory } = createDrawer();
     point.set(0, 0, 0);
     (drawer as any).onDown({ pointerId: 1, button: 0 } as PointerEvent);
-    point.set(0, -2, 0);
+    point.set(0, 0, -2);
     (drawer as any).onUp({ pointerId: 1, button: 0 } as PointerEvent);
     expect(addWallWithHistory).toHaveBeenCalledWith(
       { x: 0, y: 0 },


### PR DESCRIPTION
## Summary
- Move wall and cabinet dragging to intersect the XZ ground plane using a Y-up normal.
- Store and constrain positions using point.z and convert screen Y to world Z.
- Update viewer tests to verify new XZ behaviour.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c5b62c52e48322a1d953470615b0ed