### PR TITLE
Add screen-to-world axis helpers and document orientation

### DIFF
--- a/src/utils/coordinateSystem.ts
+++ b/src/utils/coordinateSystem.ts
@@ -1,6 +1,13 @@
 /**
- * Defines orientation of global coordinate systems and provides helpers
- * to convert values between them.
+ * Defines orientation of global coordinate systems and provides helpers to
+ * convert values between them.
+ *
+ * The application uses a right-handed world space with the **Y axis pointing
+ * upward**. The 3D viewer shares this orientation. The 2D planner operates on
+ * the XZ plane where `Y` is usually `0`.
+ *
+ * Screen (DOM) coordinates follow the typical convention where the Y axis grows
+ * downward.
  */
 export type Axis = 'x' | 'y' | 'z';
 
@@ -10,13 +17,13 @@ export interface Axes {
   z: 1 | -1;
 }
 
-/** Identity world axes (Z up). */
+/** World axes: +Y is up. */
 export const worldAxes: Axes = { x: 1, y: 1, z: 1 };
 
-/** Viewer axes relative to the world. */
+/** Viewer axes relative to the world (matches world orientation). */
 export const viewerAxes: Axes = { x: 1, y: 1, z: 1 };
 
-/** Planner axes relative to the world. */
+/** Planner axes relative to the world (planner uses the XZ plane). */
 export const plannerAxes: Axes = { x: 1, y: 1, z: 1 };
 
 /** Screen (DOM) axes relative to the world. Y grows downward in the DOM. */
@@ -34,4 +41,14 @@ export function convertAxis(
   toAxis: Axis,
 ): number {
   return value * from[fromAxis] * to[toAxis];
+}
+
+/** Convert a screen-space value to world-space along the same axis. */
+export function screenToWorld(value: number, axis: Axis): number {
+  return convertAxis(value, screenAxes, axis, worldAxes, axis);
+}
+
+/** Convert a world-space value to screen-space along the same axis. */
+export function worldToScreen(value: number, axis: Axis): number {
+  return convertAxis(value, worldAxes, axis, screenAxes, axis);
 }

--- a/src/viewer/CabinetDragger.ts
+++ b/src/viewer/CabinetDragger.ts
@@ -3,7 +3,7 @@ import type { WebGLRenderer, Camera } from 'three';
 import type { UseBoundStore, StoreApi } from 'zustand';
 import { usePlannerStore } from '../state/store';
 import type { Module3D } from '../types';
-import { convertAxis, screenAxes, worldAxes } from '../utils/coordinateSystem';
+import { screenToWorld } from '../utils/coordinateSystem';
 
 interface PlannerStore {
   modules: Module3D[];
@@ -51,7 +51,7 @@ export default class CabinetDragger {
     const rect = this.renderer.domElement.getBoundingClientRect();
     const x = ((event.clientX - rect.left) / rect.width) * 2 - 1;
     const yScreen = ((event.clientY - rect.top) / rect.height) * 2 - 1;
-    const y = convertAxis(yScreen, screenAxes, 'y', worldAxes, 'z');
+    const y = screenToWorld(yScreen, 'y');
     const cam = this.getCamera();
     this.raycaster.setFromCamera(new THREE.Vector2(x, y), cam);
     const point = new THREE.Vector3();
@@ -64,7 +64,7 @@ export default class CabinetDragger {
     const rect = this.renderer.domElement.getBoundingClientRect();
     const x = ((e.clientX - rect.left) / rect.width) * 2 - 1;
     const yScreen = ((e.clientY - rect.top) / rect.height) * 2 - 1;
-    const y = convertAxis(yScreen, screenAxes, 'y', worldAxes, 'z');
+    const y = screenToWorld(yScreen, 'y');
     const cam = this.getCamera();
     this.raycaster.setFromCamera(new THREE.Vector2(x, y), cam);
     const intersects = this.raycaster.intersectObjects(this.group.children, true);

--- a/src/viewer/WallDrawer.ts
+++ b/src/viewer/WallDrawer.ts
@@ -3,11 +3,7 @@ import type { WebGLRenderer, Camera } from 'three';
 import type { UseBoundStore, StoreApi } from 'zustand';
 import { usePlannerStore } from '../state/store';
 import type { ShapePoint } from '../types';
-import {
-  convertAxis,
-  screenAxes,
-  worldAxes,
-} from '../utils/coordinateSystem';
+import { screenToWorld } from '../utils/coordinateSystem';
 
 interface PlannerStore {
   snapLength: number;
@@ -138,7 +134,7 @@ export default class WallDrawer {
     const rect = this.renderer.domElement.getBoundingClientRect();
     const x = ((event.clientX - rect.left) / rect.width) * 2 - 1;
     const ny = ((event.clientY - rect.top) / rect.height) * 2 - 1;
-    const y = convertAxis(ny, screenAxes, 'y', worldAxes, 'z');
+    const y = screenToWorld(ny, 'y');
     const cam = this.getCamera();
     this.raycaster.setFromCamera(new THREE.Vector2(x, y), cam);
     const point = new THREE.Vector3();

--- a/tests/coordinateSystem.test.ts
+++ b/tests/coordinateSystem.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { screenToWorld, worldToScreen } from '../src/utils/coordinateSystem';
+
+describe('coordinate system helpers', () => {
+  it('converts screen Y to world Y', () => {
+    expect(screenToWorld(1, 'y')).toBe(-1);
+    expect(screenToWorld(-1, 'y')).toBe(1);
+  });
+
+  it('converts world Y to screen Y', () => {
+    expect(worldToScreen(1, 'y')).toBe(-1);
+    expect(worldToScreen(-1, 'y')).toBe(1);
+  });
+
+  it('leaves X axis unchanged', () => {
+    expect(screenToWorld(1, 'x')).toBe(1);
+    expect(worldToScreen(1, 'x')).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- document global coordinate orientation and planner/DOM axes
- add `screenToWorld`/`worldToScreen` helpers
- refactor viewer modules to use the new helpers
- cover axis helpers with unit tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c5b8c8ff3c8322a8dce31bdadb6130