### PR TITLE
Align axes gizmo with 2D view orientation and add test

### DIFF
--- a/tests/sceneViewer.gizmo.test.tsx
+++ b/tests/sceneViewer.gizmo.test.tsx
@@ -14,6 +14,8 @@ vi.mock('three/examples/jsm/controls/OrbitControls.js', () => ({
     dispose: vi.fn(),
     dollyIn: vi.fn(),
     dollyOut: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
   })),
 }));
 
@@ -95,6 +97,30 @@ describe('SceneViewer axes gizmo', () => {
       );
     });
     expect(container.querySelector('[data-testid="axes-gizmo"]')).not.toBeNull();
+    root.unmount();
+    container.remove();
+  });
+
+  it('orients axes with X right and Z up in 2d mode', async () => {
+    const threeRef: any = { current: null };
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = ReactDOM.createRoot(container);
+    act(() => {
+      root.render(
+        <SceneViewer
+          threeRef={threeRef}
+          addCountertop={false}
+          mode={null}
+          setMode={vi.fn()}
+          viewMode="2d"
+          setViewMode={() => {}}
+        />,
+      );
+    });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(threeRef.current.axesHelper).toBeDefined();
+    expect(threeRef.current.axesHelper!.rotation.x).toBeCloseTo(Math.PI / 2);
     root.unmount();
     container.remove();
   });


### PR DESCRIPTION
## Summary
- rotate axes helper when entering 2D mode so the gizmo matches world X/Z orientation
- expose axes helper on three context for testing
- add unit test verifying axes gizmo shows X to the right and Z upward in 2D view

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c5b9f6e27c832290e7fb92b2313ba3