### PR TITLE
Keep SceneViewer Y-up orientation across view modes

### DIFF
--- a/src/ui/SceneViewer.tsx
+++ b/src/ui/SceneViewer.tsx
@@ -152,6 +152,7 @@ const SceneViewer: React.FC<Props> = ({
     (mode: '3d' | '2d') => {
       const three = threeRef.current;
       if (!three?.renderer || !three.setCamera || !three.setControls) return;
+      three.camera.up.set(0, 1, 0);
       if ((three as any).gridChangeHandler) {
         three.controls.removeEventListener('change', (three as any).gridChangeHandler);
         (three as any).gridChangeHandler = null;
@@ -171,7 +172,6 @@ const SceneViewer: React.FC<Props> = ({
         const pos = savedView.current.pos;
         const height = 10;
         three.camera.position.set(pos.x, height, pos.z);
-        three.camera.up.set(0, 0, -1);
         c.target.set(pos.x, 0, pos.z);
         three.camera.lookAt(c.target);
         c.update();
@@ -202,7 +202,6 @@ const SceneViewer: React.FC<Props> = ({
           three.camera.position.copy(savedView.current.pos);
           c.target.copy(savedView.current.target);
         }
-        three.camera.up.set(0, 1, 0);
         c.update();
         const base = Math.max(
           1,

--- a/tests/sceneViewer.viewMode.test.tsx
+++ b/tests/sceneViewer.viewMode.test.tsx
@@ -104,13 +104,13 @@ describe('SceneViewer view mode', () => {
     expect(threeRef.current.camera).toBe(threeRef.current.orthographicCamera);
     expect(threeRef.current.controls.enableRotate).toBe(false);
     expect(threeRef.current.controls.screenSpacePanning).toBe(true);
-    expect(threeRef.current.camera.up).toEqual(new THREE.Vector3(0, 0, -1));
+    expect(threeRef.current.camera.up).toEqual(new THREE.Vector3(0, 1, 0));
     expect(threeRef.current.camera.position).toEqual(new THREE.Vector3(0, 10, 0));
     expect(threeRef.current.controls.target).toEqual(new THREE.Vector3(0, 0, 0));
     const dir = new THREE.Vector3();
     threeRef.current.camera.getWorldDirection(dir);
     expect(dir.x).toBeCloseTo(0);
-    expect(dir.y).toBe(-1);
+    expect(dir.y).toBeCloseTo(-1);
     expect(dir.z).toBeCloseTo(0);
 
     act(() => {


### PR DESCRIPTION
## Summary
- Always set camera up vector to Y-up in SceneViewer and remove mode-specific flips
- Orient 2D view using camera position and controls instead of changing up-vector
- Update view mode test to assert Y-up orientation in both 2D and 3D

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c5bd5108ec8322805c149cb110c77f