### PR TITLE
refactor: centralize ground plane orientation

### DIFF
--- a/src/scene/engine.ts
+++ b/src/scene/engine.ts
@@ -3,6 +3,7 @@ import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 import { PointerLockControls } from 'three/examples/jsm/controls/PointerLockControls.js';
 import { usePlannerStore } from '../state/store';
 import CabinetDragger from '../viewer/CabinetDragger';
+import { alignToGround } from '../utils/coordinateSystem';
 
 export function setupThree(container: HTMLElement) {
   const scene = new THREE.Scene();
@@ -80,7 +81,7 @@ export function setupThree(container: HTMLElement) {
     );
     const material = new THREE.LineBasicMaterial({ color: 0x515152 });
     grid = new THREE.LineSegments(geometry, material);
-    grid.rotateX(-Math.PI / 2);
+    alignToGround(grid);
     scene.add(grid);
     currentDivX = divX;
     currentDivY = divY;
@@ -94,7 +95,7 @@ export function setupThree(container: HTMLElement) {
     new THREE.PlaneGeometry(boardWidth, boardHeight),
     new THREE.MeshStandardMaterial({ color: 0xf9fafc, side: THREE.DoubleSide }),
   );
-  floor.rotateX(-Math.PI / 2);
+  alignToGround(floor);
   scene.add(floor);
 
   const group = new THREE.Group();

--- a/src/utils/coordinateSystem.ts
+++ b/src/utils/coordinateSystem.ts
@@ -1,3 +1,5 @@
+import * as THREE from 'three';
+
 /**
  * Defines orientation of global coordinate systems and provides helpers to
  * convert values between them.
@@ -28,6 +30,28 @@ export const plannerAxes: Axes = { x: 1, y: 1, z: 1 };
 
 /** Screen (DOM) axes relative to the world. Y grows downward in the DOM. */
 export const screenAxes: Axes = { x: 1, y: -1, z: 1 };
+
+/** Shared normal for the ground plane (XZ plane, Y up). */
+export const GROUND_NORMAL = new THREE.Vector3(0, 1, 0);
+
+/**
+ * Create a plane representing the ground (XZ plane).
+ */
+export function groundPlane(): THREE.Plane {
+  return new THREE.Plane(GROUND_NORMAL.clone(), 0);
+}
+
+/**
+ * Orient an object so that its surface lies on the ground plane.
+ * Useful for aligning geometries created in the XY plane to the XZ plane.
+ */
+export function alignToGround(obj: THREE.Object3D) {
+  const quat = new THREE.Quaternion().setFromUnitVectors(
+    new THREE.Vector3(0, 0, 1),
+    GROUND_NORMAL,
+  );
+  obj.applyQuaternion(quat);
+}
 
 /**
  * Converts a coordinate value from one axis in the source system to an axis in

--- a/src/viewer/CabinetDragger.ts
+++ b/src/viewer/CabinetDragger.ts
@@ -3,7 +3,7 @@ import type { WebGLRenderer, Camera } from 'three';
 import type { UseBoundStore, StoreApi } from 'zustand';
 import { usePlannerStore } from '../state/store';
 import type { Module3D } from '../types';
-import { screenToWorld } from '../utils/coordinateSystem';
+import { screenToWorld, groundPlane } from '../utils/coordinateSystem';
 
 interface PlannerStore {
   modules: Module3D[];
@@ -16,7 +16,7 @@ export default class CabinetDragger {
   private group: THREE.Group;
   private store: UseBoundStore<StoreApi<PlannerStore>>;
   private raycaster = new THREE.Raycaster();
-  private plane = new THREE.Plane(new THREE.Vector3(0, 1, 0), 0);
+  private plane = groundPlane();
   private draggingId: string | null = null;
   private offset = new THREE.Vector3();
 

--- a/src/viewer/WallDrawer.ts
+++ b/src/viewer/WallDrawer.ts
@@ -3,7 +3,7 @@ import type { WebGLRenderer, Camera } from 'three';
 import type { UseBoundStore, StoreApi } from 'zustand';
 import { usePlannerStore } from '../state/store';
 import type { ShapePoint } from '../types';
-import { screenToWorld } from '../utils/coordinateSystem';
+import { screenToWorld, groundPlane } from '../utils/coordinateSystem';
 
 interface PlannerStore {
   snapLength: number;
@@ -20,7 +20,7 @@ export default class WallDrawer {
   private group: THREE.Group;
   private store: UseBoundStore<StoreApi<PlannerStore>>;
   private raycaster = new THREE.Raycaster();
-  private plane = new THREE.Plane(new THREE.Vector3(0, 1, 0), 0);
+  private plane = groundPlane();
   private cursor: THREE.Mesh | null = null;
   private cursorTarget: THREE.Vector3 | null = null;
   private animationId: number | null = null;

--- a/tests/cabinetDragger.pointerCapture.test.ts
+++ b/tests/cabinetDragger.pointerCapture.test.ts
@@ -2,6 +2,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import * as THREE from 'three';
 import CabinetDragger from '../src/viewer/CabinetDragger';
+import { GROUND_NORMAL } from '../src/utils/coordinateSystem';
 import type { Module3D } from '../src/types';
 
 describe('CabinetDragger pointer capture', () => {
@@ -63,6 +64,31 @@ describe('CabinetDragger pointer capture', () => {
     (dragger as any).onUp(up);
     expect(canvas.releasePointerCapture).toHaveBeenCalledWith(1);
     expect((dragger as any).draggingId).toBeNull();
+  });
+
+  it('uses shared ground plane normal', () => {
+    const canvas = document.createElement('canvas');
+    canvas.getBoundingClientRect = () => ({
+      left: 0,
+      top: 0,
+      width: 100,
+      height: 100,
+      right: 100,
+      bottom: 100,
+      x: 0,
+      y: 0,
+      toJSON() {},
+    });
+    const renderer = { domElement: canvas } as unknown as THREE.WebGLRenderer;
+    const camera = new THREE.PerspectiveCamera();
+    const getCamera = () => camera;
+    const group = new THREE.Group();
+    const store = {
+      getState: () => ({ modules: [], updateModule: vi.fn() }),
+    } as any;
+    const dragger = new CabinetDragger(renderer, getCamera, group, store);
+    const plane = (dragger as any).plane as THREE.Plane;
+    expect(plane.normal.equals(GROUND_NORMAL)).toBe(true);
   });
 
   it('updates module position along XZ plane when dragging', () => {

--- a/tests/viewer/WallDrawer.test.ts
+++ b/tests/viewer/WallDrawer.test.ts
@@ -2,6 +2,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import * as THREE from 'three';
 import WallDrawer from '../../src/viewer/WallDrawer';
+import { GROUND_NORMAL } from '../../src/utils/coordinateSystem';
 
 const THICKNESS = 100; // mm
 const HEIGHT = 2500; // mm
@@ -65,6 +66,13 @@ describe('WallDrawer', () => {
     const geom = cursor.geometry as THREE.PlaneGeometry;
     expect((geom.parameters as any).width).toBeCloseTo(THICKNESS / 1000);
     expect((geom.parameters as any).height).toBeCloseTo(THICKNESS / 1000);
+    drawer.disable();
+  });
+
+  it('uses shared ground plane normal', () => {
+    const { drawer } = createDrawer();
+    const plane = (drawer as any).plane as THREE.Plane;
+    expect(plane.normal.equals(GROUND_NORMAL)).toBe(true);
     drawer.disable();
   });
 


### PR DESCRIPTION
## Summary
- export reusable ground plane normal and helpers
- use shared ground plane for dragging and wall drawing
- align grid and floor using centralized orientation constants
- add tests for ground plane normal

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c5beac1bf88322aa490a62a8450e83