### PR TITLE
Use global axes for viewer gizmo

### DIFF
--- a/src/ui/SceneViewer.tsx
+++ b/src/ui/SceneViewer.tsx
@@ -120,9 +120,6 @@ const SceneViewer: React.FC<Props> = ({
     const camera = new THREE.PerspectiveCamera(50, 1, 0.1, 10);
     camera.position.set(0, 0, 2);
     const axes = new THREE.AxesHelper(0.5);
-    if (viewMode === '2d') {
-      axes.rotation.set(Math.PI / 2, 0, 0);
-    }
     scene.add(axes);
     renderer?.render(scene, camera);
     if (threeRef.current) {
@@ -367,9 +364,6 @@ const SceneViewer: React.FC<Props> = ({
     axesCamera.position.set(2, 2, 2);
     axesCamera.lookAt(0, 0, 0);
     const axes = new THREE.AxesHelper(1);
-    if (viewMode === '2d') {
-      axes.rotation.set(Math.PI / 2, 0, 0);
-    }
     axesScene.add(axes);
     if (threeRef.current) {
       threeRef.current.axesHelper = axes;

--- a/tests/sceneViewer.gizmo.test.tsx
+++ b/tests/sceneViewer.gizmo.test.tsx
@@ -101,28 +101,33 @@ describe('SceneViewer axes gizmo', () => {
     container.remove();
   });
 
-  it('orients axes with X right and Z up in 2d mode', async () => {
-    const threeRef: any = { current: null };
-    const container = document.createElement('div');
-    document.body.appendChild(container);
-    const root = ReactDOM.createRoot(container);
-    act(() => {
-      root.render(
-        <SceneViewer
-          threeRef={threeRef}
-          addCountertop={false}
-          mode={null}
-          setMode={vi.fn()}
-          viewMode="2d"
-          setViewMode={() => {}}
-        />,
-      );
-    });
-    await new Promise((r) => setTimeout(r, 0));
-    expect(threeRef.current.axesHelper).toBeDefined();
-    expect(threeRef.current.axesHelper!.rotation.x).toBeCloseTo(Math.PI / 2);
-    root.unmount();
-    container.remove();
-  });
+  it.each(["3d", "2d"] as const)(
+    "matches world axes in %s view",
+    async (viewMode) => {
+      const threeRef: any = { current: null };
+      const container = document.createElement("div");
+      document.body.appendChild(container);
+      const root = ReactDOM.createRoot(container);
+      act(() => {
+        root.render(
+          <SceneViewer
+            threeRef={threeRef}
+            addCountertop={false}
+            mode={null}
+            setMode={vi.fn()}
+            viewMode={viewMode}
+            setViewMode={() => {}}
+          />,
+        );
+      });
+      await new Promise((r) => setTimeout(r, 0));
+      expect(threeRef.current.axesHelper).toBeDefined();
+      expect(threeRef.current.axesHelper!.rotation.x).toBeCloseTo(0);
+      expect(threeRef.current.axesHelper!.rotation.y).toBeCloseTo(0);
+      expect(threeRef.current.axesHelper!.rotation.z).toBeCloseTo(0);
+      root.unmount();
+      container.remove();
+    },
+  );
 });
 


### PR DESCRIPTION
## Summary
- Remove view-mode-specific rotations and use world axes for the SceneViewer gizmo
- Re-render gizmo overlay on view mode changes using shared orientation
- Test that gizmo aligns with world axes in both 2D and 3D views

## Testing
- `npm test tests/sceneViewer.gizmo.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c5c0a73e1083228b0b70f6cad73c24