### PR TITLE
Add planner/world coordinate helpers

### DIFF
--- a/src/ui/SceneViewer.tsx
+++ b/src/ui/SceneViewer.tsx
@@ -18,6 +18,7 @@ import RoomToolBar from './components/RoomToolBar';
 import TouchJoystick from './components/TouchJoystick';
 import { PlayerMode, PlayerSubMode, PLAYER_MODES } from './types';
 import RadialMenu from './components/RadialMenu';
+import { plannerToWorld } from '../utils/coordinateSystem';
 
 interface ThreeContext {
   scene: THREE.Scene;
@@ -456,14 +457,18 @@ const SceneViewer: React.FC<Props> = ({
     const width = wallDefaults.thickness / 1000;
     const height = wallDefaults.height / 1000;
     segments.forEach(({ start, end }) => {
-      const dx = end.x - start.x;
-      const dz = -(end.y - start.y);
+      const dx = plannerToWorld(end.x - start.x, 'x');
+      const dz = plannerToWorld(end.y - start.y, 'y');
       const length = Math.sqrt(dx * dx + dz * dz);
       const geom = new THREE.BoxGeometry(length, height, width);
       geom.translate(length / 2, 0, 0);
       const mat = new THREE.MeshStandardMaterial({ color: 0x888888 });
       const mesh = new THREE.Mesh(geom, mat);
-      mesh.position.set(start.x, height / 2, -start.y);
+      mesh.position.set(
+        plannerToWorld(start.x, 'x'),
+        height / 2,
+        plannerToWorld(start.y, 'y'),
+      );
       mesh.rotation.y = Math.atan2(dz, dx);
       wallGroup.add(mesh);
     });

--- a/src/utils/coordinateSystem.ts
+++ b/src/utils/coordinateSystem.ts
@@ -26,7 +26,7 @@ export const worldAxes: Axes = { x: 1, y: 1, z: 1 };
 export const viewerAxes: Axes = { x: 1, y: 1, z: 1 };
 
 /** Planner axes relative to the world (planner uses the XZ plane). */
-export const plannerAxes: Axes = { x: 1, y: 1, z: 1 };
+export const plannerAxes: Axes = { x: 1, y: -1, z: 1 };
 
 /** Screen (DOM) axes relative to the world. Y grows downward in the DOM. */
 export const screenAxes: Axes = { x: 1, y: -1, z: 1 };
@@ -64,7 +64,8 @@ export function convertAxis(
   to: Axes,
   toAxis: Axis,
 ): number {
-  return value * from[fromAxis] * to[toAxis];
+  const result = value * from[fromAxis] * to[toAxis];
+  return Object.is(result, -0) ? 0 : result;
 }
 
 /** Convert a screen-space value to world-space along the same axis. */
@@ -75,4 +76,16 @@ export function screenToWorld(value: number, axis: Axis): number {
 /** Convert a world-space value to screen-space along the same axis. */
 export function worldToScreen(value: number, axis: Axis): number {
   return convertAxis(value, worldAxes, axis, screenAxes, axis);
+}
+
+const plannerAxisMap: Record<Axis, Axis> = { x: 'x', y: 'z', z: 'y' };
+
+/** Convert a planner-space value to world-space. */
+export function plannerToWorld(value: number, axis: Axis): number {
+  return convertAxis(value, plannerAxes, axis, worldAxes, plannerAxisMap[axis]);
+}
+
+/** Convert a world-space value to planner-space. */
+export function worldToPlanner(value: number, axis: Axis): number {
+  return convertAxis(value, worldAxes, axis, plannerAxes, plannerAxisMap[axis]);
 }

--- a/src/viewer/WallDrawer.ts
+++ b/src/viewer/WallDrawer.ts
@@ -3,7 +3,11 @@ import type { WebGLRenderer, Camera } from 'three';
 import type { UseBoundStore, StoreApi } from 'zustand';
 import { usePlannerStore } from '../state/store';
 import type { ShapePoint } from '../types';
-import { screenToWorld, groundPlane } from '../utils/coordinateSystem';
+import {
+  screenToWorld,
+  groundPlane,
+  worldToPlanner,
+} from '../utils/coordinateSystem';
 
 interface PlannerStore {
   snapLength: number;
@@ -272,8 +276,8 @@ export default class WallDrawer {
       endZ = Math.round(endZ / stepSize) * stepSize;
       point.set(endX, 0, endZ);
     }
-    const start = { x: startX, y: startZ };
-    const end = { x: endX, y: endZ };
+    const start = { x: startX, y: worldToPlanner(startZ, 'z') };
+    const end = { x: endX, y: worldToPlanner(endZ, 'z') };
     state.addWallWithHistory(start, end);
     this.start = null;
     this.disposePreview();

--- a/tests/coordinateSystem.test.ts
+++ b/tests/coordinateSystem.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { screenToWorld, worldToScreen } from '../src/utils/coordinateSystem';
+import {
+  screenToWorld,
+  worldToScreen,
+  plannerToWorld,
+  worldToPlanner,
+} from '../src/utils/coordinateSystem';
 
 describe('coordinate system helpers', () => {
   it('converts screen Y to world Y', () => {
@@ -15,5 +20,15 @@ describe('coordinate system helpers', () => {
   it('leaves X axis unchanged', () => {
     expect(screenToWorld(1, 'x')).toBe(1);
     expect(worldToScreen(1, 'x')).toBe(1);
+  });
+
+  it('maps planner Y to world Z', () => {
+    expect(plannerToWorld(1, 'y')).toBe(-1);
+    expect(plannerToWorld(-1, 'y')).toBe(1);
+  });
+
+  it('maps world Z to planner Y', () => {
+    expect(worldToPlanner(1, 'z')).toBe(-1);
+    expect(worldToPlanner(-1, 'z')).toBe(1);
   });
 });

--- a/tests/viewer/WallDrawer.test.ts
+++ b/tests/viewer/WallDrawer.test.ts
@@ -201,7 +201,7 @@ describe('WallDrawer', () => {
     (drawer as any).onUp({ pointerId: 1, button: 0 } as PointerEvent);
     expect(addWallWithHistory).toHaveBeenCalledWith(
       { x: 0, y: 0 },
-      { x: 0, y: 2 },
+      { x: 0, y: -2 },
     );
     drawer.disable();
   });
@@ -216,7 +216,7 @@ describe('WallDrawer', () => {
     (drawer as any).onUp({ pointerId: 1, button: 0 } as PointerEvent);
     expect(addWallWithHistory).toHaveBeenCalledWith(
       { x: 0, y: 0 },
-      { x: 2, y: 1 },
+      { x: 2, y: -1 },
     );
     drawer.disable();
   });
@@ -229,7 +229,7 @@ describe('WallDrawer', () => {
     (drawer as any).onUp({ pointerId: 1, button: 0 } as PointerEvent);
     expect(addWallWithHistory).toHaveBeenCalledWith(
       { x: 0, y: 0 },
-      { x: 0, y: -2 },
+      { x: 0, y: 2 },
     );
     drawer.disable();
   });


### PR DESCRIPTION
## Summary
- define plannerAxes to use XZ ground plane and expose planner↔world conversion helpers
- use new helpers in WallDrawer and SceneViewer to remove manual axis negations
- test planner/world conversions for walls and coordinate utilities

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c5c4ac0cd48322867fe4b23a34874c