### PR TITLE
Use convertAxis for planner Y to world Z in SceneViewer

### DIFF
--- a/src/ui/SceneViewer.tsx
+++ b/src/ui/SceneViewer.tsx
@@ -18,7 +18,12 @@ import RoomToolBar from './components/RoomToolBar';
 import TouchJoystick from './components/TouchJoystick';
 import { PlayerMode, PlayerSubMode, PLAYER_MODES } from './types';
 import RadialMenu from './components/RadialMenu';
-import { plannerToWorld } from '../utils/coordinateSystem';
+import {
+  plannerToWorld,
+  convertAxis,
+  plannerAxes,
+  worldAxes,
+} from '../utils/coordinateSystem';
 
 interface ThreeContext {
   scene: THREE.Scene;
@@ -458,7 +463,7 @@ const SceneViewer: React.FC<Props> = ({
     const height = wallDefaults.height / 1000;
     segments.forEach(({ start, end }) => {
       const dx = plannerToWorld(end.x - start.x, 'x');
-      const dz = plannerToWorld(end.y - start.y, 'y');
+      const dz = convertAxis(end.y - start.y, plannerAxes, 'y', worldAxes, 'z');
       const length = Math.sqrt(dx * dx + dz * dz);
       const geom = new THREE.BoxGeometry(length, height, width);
       geom.translate(length / 2, 0, 0);
@@ -467,7 +472,7 @@ const SceneViewer: React.FC<Props> = ({
       mesh.position.set(
         plannerToWorld(start.x, 'x'),
         height / 2,
-        plannerToWorld(start.y, 'y'),
+        convertAxis(start.y, plannerAxes, 'y', worldAxes, 'z'),
       );
       mesh.rotation.y = Math.atan2(dz, dx);
       wallGroup.add(mesh);

--- a/tests/scene/wallRendering.test.tsx
+++ b/tests/scene/wallRendering.test.tsx
@@ -7,6 +7,12 @@ import * as THREE from 'three';
 import SceneViewer from '../../src/ui/SceneViewer';
 import { usePlannerStore } from '../../src/state/store';
 import WallDrawer from '../../src/viewer/WallDrawer';
+import {
+  convertAxis,
+  plannerAxes,
+  worldAxes,
+  plannerToWorld,
+} from '../../src/utils/coordinateSystem';
 
 vi.mock('../../src/ui/components/ItemHotbar', () => ({
   default: () => null,
@@ -131,6 +137,16 @@ describe('Scene wall rendering', () => {
     expect(group.children).toHaveLength(1);
     expect(group.children[0].children).toHaveLength(2);
 
+    const [wall1, wall2] = group.children[0].children as THREE.Mesh[];
+    expect(wall1.position.x).toBeCloseTo(plannerToWorld(0, 'x'));
+    expect(wall1.position.z).toBeCloseTo(
+      convertAxis(0, plannerAxes, 'y', worldAxes, 'z'),
+    );
+    expect(wall2.position.x).toBeCloseTo(plannerToWorld(1, 'x'));
+    expect(wall2.position.z).toBeCloseTo(
+      convertAxis(0, plannerAxes, 'y', worldAxes, 'z'),
+    );
+
     const shape2 = {
       points: [],
       segments: [
@@ -145,6 +161,11 @@ describe('Scene wall rendering', () => {
 
     expect(group.children).toHaveLength(1);
     expect(group.children[0].children).toHaveLength(3);
+    const wall3 = group.children[0].children[2] as THREE.Mesh;
+    expect(wall3.position.x).toBeCloseTo(plannerToWorld(1, 'x'));
+    expect(wall3.position.z).toBeCloseTo(
+      convertAxis(1, plannerAxes, 'y', worldAxes, 'z'),
+    );
   });
 
   it('orients walls correctly when drawn via WallDrawer', () => {


### PR DESCRIPTION
## Summary
- derive wall depth and placement via convertAxis to honor planner vs world axes
- remove manual sign inversions for wall Z positioning
- add assertions for wall world coordinates in wall rendering tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c5c723d9a083228482378403f9dca7