### PR TITLE
test: ensure gizmo orientation survives view switch

### DIFF
--- a/tests/sceneViewer.gizmo.test.tsx
+++ b/tests/sceneViewer.gizmo.test.tsx
@@ -129,5 +129,68 @@ describe('SceneViewer axes gizmo', () => {
       container.remove();
     },
   );
+
+  it('matches world axes after switching view modes', async () => {
+    const threeRef: any = { current: null };
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = ReactDOM.createRoot(container);
+    act(() => {
+      root.render(
+        <SceneViewer
+          threeRef={threeRef}
+          addCountertop={false}
+          mode={null}
+          setMode={vi.fn()}
+          viewMode="3d"
+          setViewMode={() => {}}
+        />,
+      );
+    });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(threeRef.current.axesHelper).toBeDefined();
+    expect(threeRef.current.axesHelper!.rotation.x).toBeCloseTo(0);
+    expect(threeRef.current.axesHelper!.rotation.y).toBeCloseTo(0);
+    expect(threeRef.current.axesHelper!.rotation.z).toBeCloseTo(0);
+
+    act(() => {
+      root.render(
+        <SceneViewer
+          threeRef={threeRef}
+          addCountertop={false}
+          mode={null}
+          setMode={vi.fn()}
+          viewMode="2d"
+          setViewMode={() => {}}
+        />,
+      );
+    });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(threeRef.current.axesHelper).toBeDefined();
+    expect(threeRef.current.axesHelper!.rotation.x).toBeCloseTo(0);
+    expect(threeRef.current.axesHelper!.rotation.y).toBeCloseTo(0);
+    expect(threeRef.current.axesHelper!.rotation.z).toBeCloseTo(0);
+
+    act(() => {
+      root.render(
+        <SceneViewer
+          threeRef={threeRef}
+          addCountertop={false}
+          mode={null}
+          setMode={vi.fn()}
+          viewMode="3d"
+          setViewMode={() => {}}
+        />,
+      );
+    });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(threeRef.current.axesHelper).toBeDefined();
+    expect(threeRef.current.axesHelper!.rotation.x).toBeCloseTo(0);
+    expect(threeRef.current.axesHelper!.rotation.y).toBeCloseTo(0);
+    expect(threeRef.current.axesHelper!.rotation.z).toBeCloseTo(0);
+
+    root.unmount();
+    container.remove();
+  });
 });
 


### PR DESCRIPTION
## Summary
- add regression test to verify axes gizmo stays aligned when toggling between 3D and 2D views

## Testing
- `npm test tests/sceneViewer.gizmo.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c5c9fc042883228843289315743de9