### PR TITLE
Remove nonfunctional zoom controls

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -4,7 +4,6 @@
 .topbar{z-index:10;display:flex;gap:8px;background:rgba(255,255,255,.85);border:1px solid var(--border);border-radius:10px;padding:8px;backdrop-filter:blur(6px);margin:12px}
 .topBarWrap{border-top:1px solid var(--border)}
 .bottombar{position:absolute;bottom:12px;left:12px;z-index:10;display:flex;gap:8px;background:rgba(255,255,255,.85);border:1px solid var(--border);border-radius:10px;padding:8px;backdrop-filter:blur(6px)}
-.zoomControls{position:absolute;bottom:12px;right:12px;z-index:10;display:flex;flex-direction:column;gap:8px;background:rgba(255,255,255,.85);border:1px solid var(--border);border-radius:10px;padding:8px;backdrop-filter:blur(6px)}
 .h1{font-size:18px;font-weight:700}
 .small{font-size:12px;color:var(--muted)}
 .btn{padding:8px 10px;background:var(--accent);color:var(--white);border-radius:8px;border:none;cursor:pointer;font-weight:600}

--- a/src/ui/SceneViewer.tsx
+++ b/src/ui/SceneViewer.tsx
@@ -941,22 +941,6 @@ const SceneViewer: React.FC<Props> = ({
       };
     }, [mode, threeRef]);
 
-  const handleZoomIn = () => {
-    const controls = threeRef.current?.controls;
-    if (controls) {
-      controls.dollyIn(0.95);
-      controls.update();
-    }
-  };
-
-  const handleZoomOut = () => {
-    const controls = threeRef.current?.controls;
-    if (controls) {
-      controls.dollyOut(0.95);
-      controls.update();
-    }
-  };
-
   return (
     <div style={{ position: 'absolute', inset: 0 }}>
       <div ref={containerRef} style={{ position: 'absolute', inset: 0 }} />
@@ -988,16 +972,6 @@ const SceneViewer: React.FC<Props> = ({
         }}
         visible={showRadial}
       />
-      {mode === null && (
-        <div className="zoomControls">
-          <button className="btnGhost" onClick={handleZoomIn}>
-            +
-          </button>
-          <button className="btnGhost" onClick={handleZoomOut}>
-            −
-          </button>
-        </div>
-      )}
       {mode && showHint && (
         <div
           style={{


### PR DESCRIPTION
## Summary
- remove unused zoom control buttons from SceneViewer
- clean up related CSS rule

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c5cb8b515c8322b430f280bad7b77d