### PR TITLE
Fix planner Y axis orientation for wall drawing

### DIFF
--- a/src/utils/coordinateSystem.ts
+++ b/src/utils/coordinateSystem.ts
@@ -26,7 +26,7 @@ export const worldAxes: Axes = { x: 1, y: 1, z: 1 };
 export const viewerAxes: Axes = { x: 1, y: 1, z: 1 };
 
 /** Planner axes relative to the world (planner uses the XZ plane). */
-export const plannerAxes: Axes = { x: 1, y: -1, z: 1 };
+export const plannerAxes: Axes = { x: 1, y: 1, z: 1 };
 
 /** Screen (DOM) axes relative to the world. Y grows downward in the DOM. */
 export const screenAxes: Axes = { x: 1, y: -1, z: 1 };

--- a/tests/coordinateSystem.test.ts
+++ b/tests/coordinateSystem.test.ts
@@ -23,12 +23,12 @@ describe('coordinate system helpers', () => {
   });
 
   it('maps planner Y to world Z', () => {
-    expect(plannerToWorld(1, 'y')).toBe(-1);
-    expect(plannerToWorld(-1, 'y')).toBe(1);
+    expect(plannerToWorld(1, 'y')).toBe(1);
+    expect(plannerToWorld(-1, 'y')).toBe(-1);
   });
 
   it('maps world Z to planner Y', () => {
-    expect(worldToPlanner(1, 'z')).toBe(-1);
-    expect(worldToPlanner(-1, 'z')).toBe(1);
+    expect(worldToPlanner(1, 'z')).toBe(1);
+    expect(worldToPlanner(-1, 'z')).toBe(-1);
   });
 });


### PR DESCRIPTION
## Summary
- correct planner Y-axis direction to align with world Z
- update coordinate system tests for new axis orientation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c5d82860808322b3c674d02ac550a5