### PR TITLE
Fix wall drawing axis orientation for correct cursor placement

### DIFF
--- a/src/utils/coordinateSystem.ts
+++ b/src/utils/coordinateSystem.ts
@@ -26,7 +26,7 @@ export const worldAxes: Axes = { x: 1, y: 1, z: 1 };
 export const viewerAxes: Axes = { x: 1, y: 1, z: 1 };
 
 /** Planner axes relative to the world (planner uses the XZ plane). */
-export const plannerAxes: Axes = { x: 1, y: -1, z: 1 };
+export const plannerAxes: Axes = { x: 1, y: 1, z: 1 };
 
 /** Screen (DOM) axes relative to the world. Y grows downward in the DOM. */
 export const screenAxes: Axes = { x: 1, y: -1, z: 1 };

--- a/src/viewer/WallDrawer.ts
+++ b/src/viewer/WallDrawer.ts
@@ -145,7 +145,7 @@ export default class WallDrawer {
     const intersection = this.raycaster.ray.intersectPlane(this.plane, point);
     if (!intersection) return null;
     if (!isFinite(intersection.x) || !isFinite(intersection.z)) return null;
-    point.set(intersection.x, 0, -intersection.z);
+    point.set(intersection.x, 0, intersection.z);
     const { snapToGrid, gridSize } = this.store.getState();
     if (snapToGrid && gridSize > 0) {
       const step = gridSize / 1000;

--- a/tests/coordinateSystem.test.ts
+++ b/tests/coordinateSystem.test.ts
@@ -23,12 +23,12 @@ describe('coordinate system helpers', () => {
   });
 
   it('maps planner Y to world Z', () => {
-    expect(plannerToWorld(1, 'y')).toBe(-1);
-    expect(plannerToWorld(-1, 'y')).toBe(1);
+    expect(plannerToWorld(1, 'y')).toBe(1);
+    expect(plannerToWorld(-1, 'y')).toBe(-1);
   });
 
   it('maps world Z to planner Y', () => {
-    expect(worldToPlanner(1, 'z')).toBe(-1);
-    expect(worldToPlanner(-1, 'z')).toBe(1);
+    expect(worldToPlanner(1, 'z')).toBe(1);
+    expect(worldToPlanner(-1, 'z')).toBe(-1);
   });
 });

--- a/tests/viewer/WallDrawer.test.ts
+++ b/tests/viewer/WallDrawer.test.ts
@@ -118,7 +118,7 @@ describe('WallDrawer', () => {
       clientY: 0,
     } as PointerEvent);
     expect(result?.x).toBe(intersection.x);
-    expect(result?.z).toBe(-intersection.z);
+    expect(result?.z).toBe(intersection.z);
     drawer.disable();
   });
 


### PR DESCRIPTION
## Summary
- remove Z-axis negation when converting pointer coordinates so walls appear where drawn
- update wall drawing tests for new axis mapping

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c5d82860808322b3c674d02ac550a5