### PR TITLE
Invert planner Z axis

### DIFF
--- a/src/utils/coordinateSystem.ts
+++ b/src/utils/coordinateSystem.ts
@@ -25,8 +25,8 @@ export const worldAxes: Axes = { x: 1, y: 1, z: 1 };
 /** Viewer axes relative to the world (matches world orientation). */
 export const viewerAxes: Axes = { x: 1, y: 1, z: 1 };
 
-/** Planner axes relative to the world (planner uses the XZ plane). */
-export const plannerAxes: Axes = { x: 1, y: 1, z: 1 };
+/** Planner axes relative to the world (planner uses the XZ plane). Z grows downward. */
+export const plannerAxes: Axes = { x: 1, y: -1, z: 1 };
 
 /** Screen (DOM) axes relative to the world. Y grows downward in the DOM. */
 export const screenAxes: Axes = { x: 1, y: -1, z: 1 };

--- a/tests/coordinateSystem.test.ts
+++ b/tests/coordinateSystem.test.ts
@@ -22,13 +22,13 @@ describe('coordinate system helpers', () => {
     expect(worldToScreen(1, 'x')).toBe(1);
   });
 
-  it('maps planner Y to world Z', () => {
-    expect(plannerToWorld(1, 'y')).toBe(1);
-    expect(plannerToWorld(-1, 'y')).toBe(-1);
+  it('maps planner Y to world Z with inverted sign', () => {
+    expect(plannerToWorld(1, 'y')).toBe(-1);
+    expect(plannerToWorld(-1, 'y')).toBe(1);
   });
 
-  it('maps world Z to planner Y', () => {
-    expect(worldToPlanner(1, 'z')).toBe(1);
-    expect(worldToPlanner(-1, 'z')).toBe(-1);
+  it('maps world Z to planner Y with inverted sign', () => {
+    expect(worldToPlanner(1, 'z')).toBe(-1);
+    expect(worldToPlanner(-1, 'z')).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary
- invert planner Z axis to grow downward in 2D
- adjust coordinate system tests for flipped planner Z

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c5e75a02d48322917d63290ba561c9