### PR TITLE
Use last pointer position for wall end

### DIFF
--- a/src/viewer/WallDrawer.ts
+++ b/src/viewer/WallDrawer.ts
@@ -233,7 +233,7 @@ export default class WallDrawer {
     if (!this.dragging) return;
     this.dragging = false;
     if (!this.start) return;
-    const point = this.getPoint(e);
+    const point = this.lastPoint?.clone() ?? this.getPoint(e);
     if (!point) {
       this.start = null;
       this.disposePreview();

--- a/tests/viewer/WallDrawer.test.ts
+++ b/tests/viewer/WallDrawer.test.ts
@@ -213,6 +213,7 @@ describe('WallDrawer', () => {
     point.set(0, 0, 0);
     (drawer as any).onDown({ pointerId: 1, button: 0 } as PointerEvent);
     point.set(2, 0, 1);
+    (drawer as any).onMove({} as PointerEvent);
     (drawer as any).onUp({ pointerId: 1, button: 0 } as PointerEvent);
     expect(addWallWithHistory).toHaveBeenCalledWith(
       { x: worldToPlanner(0, 'x'), y: worldToPlanner(0, 'z') },
@@ -226,6 +227,7 @@ describe('WallDrawer', () => {
     point.set(0, 0, 0);
     (drawer as any).onDown({ pointerId: 1, button: 0 } as PointerEvent);
     point.set(0, 0, -2);
+    (drawer as any).onMove({} as PointerEvent);
     (drawer as any).onUp({ pointerId: 1, button: 0 } as PointerEvent);
     expect(addWallWithHistory).toHaveBeenCalledWith(
       { x: worldToPlanner(0, 'x'), y: worldToPlanner(0, 'z') },
@@ -241,6 +243,7 @@ describe('WallDrawer', () => {
     point.set(0.12, 0, 0);
     (drawer as any).onDown({ pointerId: 1, button: 0 } as PointerEvent);
     point.set(0.26, 0, 0);
+    (drawer as any).onMove({} as PointerEvent);
     (drawer as any).onUp({ pointerId: 1, button: 0 } as PointerEvent);
     expect(addWallWithHistory).toHaveBeenCalledTimes(1);
     const [[start, end]] = addWallWithHistory.mock.calls;


### PR DESCRIPTION
## Summary
- ensure wall end uses last pointer if available before falling back to current event
- update WallDrawer tests to simulate pointer movement before release

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c5e5671d4483228adf4a3c09cee0fe