### PR TITLE
Prefer pointerup coordinates when drawing walls

### DIFF
--- a/src/viewer/WallDrawer.ts
+++ b/src/viewer/WallDrawer.ts
@@ -233,7 +233,7 @@ export default class WallDrawer {
     if (!this.dragging) return;
     this.dragging = false;
     if (!this.start) return;
-    const point = this.lastPoint?.clone() ?? this.getPoint(e);
+    const point = this.getPoint(e) ?? this.lastPoint?.clone();
     if (!point) {
       this.start = null;
       this.disposePreview();

--- a/tests/viewer/WallDrawer.test.ts
+++ b/tests/viewer/WallDrawer.test.ts
@@ -161,6 +161,21 @@ describe('WallDrawer', () => {
     drawer.disable();
   });
 
+  it('uses pointerup coordinates when lastPoint is stale', () => {
+    const { drawer, point, addWallWithHistory } = createDrawer();
+    point.set(0, 0, 0);
+    (drawer as any).onDown({ pointerId: 1, button: 0 } as PointerEvent);
+    point.set(1, 0, 0);
+    (drawer as any).onMove({} as PointerEvent);
+    point.set(2, 0, 0);
+    (drawer as any).onUp({ pointerId: 1, button: 0 } as PointerEvent);
+    expect(addWallWithHistory).toHaveBeenCalledWith(
+      { x: worldToPlanner(0, 'x'), y: worldToPlanner(0, 'z') },
+      { x: worldToPlanner(2, 'x'), y: worldToPlanner(0, 'z') },
+    );
+    drawer.disable();
+  });
+
   it('places preview using XZ coordinates', () => {
     const { drawer, point } = createDrawer();
     point.set(1, 0, 2);


### PR DESCRIPTION
## Summary
- use pointerup event's location for wall end point before falling back to lastPoint
- add regression test ensuring stale lastPoint doesn't override pointerup coordinates

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c5edad7d7c8322861fde6af26bf7a9