### PR TITLE
chore: remove backup Vite config

### DIFF
--- a/vite.config.ts.backup
+++ b/vite.config.ts.backup
@@ -1,7 +1,0 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
-export default defineConfig({
-  plugins:[react()],
-  server:{ host:true },
-  build:{ outDir:'dist', assetsDir:'assets' }
-})


### PR DESCRIPTION
## Summary
- remove obsolete `vite.config.ts.backup` file
- confirm build scripts rely on standard `vite.config.ts`

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c5f65e29e08322b7ab66fd723950a0