### PR TITLE
refactor: type three context

### DIFF
--- a/src/scene/engine.ts
+++ b/src/scene/engine.ts
@@ -5,7 +5,35 @@ import { usePlannerStore } from '../state/store';
 import CabinetDragger from '../viewer/CabinetDragger';
 import { alignToGround } from '../utils/coordinateSystem';
 
-export function setupThree(container: HTMLElement) {
+export interface ThreeContext {
+  scene: THREE.Scene;
+  camera: THREE.Camera;
+  renderer: THREE.WebGLRenderer;
+  controls: OrbitControls;
+  playerControls: PointerLockControls;
+  group: THREE.Group;
+  cabinetDragger: CabinetDragger;
+  perspectiveCamera: THREE.PerspectiveCamera;
+  orthographicCamera: THREE.OrthographicCamera;
+  setPlayerParams: (p: { height?: number; speed?: number }) => void;
+  setMove: (m: {
+    forward?: boolean;
+    backward?: boolean;
+    left?: boolean;
+    right?: boolean;
+  }) => void;
+  setMoveFromJoystick: (v: { x?: number; y?: number }) => void;
+  updateCameraRotation: (dx: number, dy: number) => void;
+  resetCameraRotation: () => void;
+  onJump: () => void;
+  onCrouch: (active: boolean) => void;
+  updateGrid: (divisions: number) => void;
+  dispose: () => void;
+  setCamera: (cam: THREE.Camera) => void;
+  setControls: (c: OrbitControls) => void;
+}
+
+export function setupThree(container: HTMLElement): ThreeContext {
   const scene = new THREE.Scene();
   scene.background = new THREE.Color(0xf9fafc);
 
@@ -394,7 +422,7 @@ export function setupThree(container: HTMLElement) {
     window.removeEventListener('resize', onResize);
   };
 
-  const three: any = {
+  const three: ThreeContext = {
     scene,
     camera,
     renderer,
@@ -413,19 +441,15 @@ export function setupThree(container: HTMLElement) {
     onCrouch,
     updateGrid,
     dispose,
+    setCamera: (cam: THREE.Camera) => {
+      camera = cam;
+      three.camera = cam;
+    },
+    setControls: (c: OrbitControls) => {
+      controls = c;
+      three.controls = c;
+    },
   };
-
-  const setCamera = (cam: THREE.Camera) => {
-    camera = cam;
-    three.camera = cam;
-  };
-  const setControls = (c: OrbitControls) => {
-    controls = c;
-    three.controls = c;
-  };
-
-  three.setCamera = setCamera;
-  three.setControls = setControls;
 
   return three;
 }

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -8,6 +8,7 @@ import { createTranslator } from './i18n';
 import MainTabs from './MainTabs';
 import { safeSetItem } from '../utils/storage';
 import { PlayerMode } from './types';
+import type { ThreeContext } from '../scene/engine';
 
 type PlayerSubMode = Exclude<PlayerMode, null>;
 
@@ -17,7 +18,7 @@ export default function App() {
   const [kind, setKind] = useState<Kind | null>(null);
   const [variant, setVariant] = useState<Variant | null>(null);
   const [addCountertop, setAddCountertop] = useState(true);
-  const threeRef = useRef<any>(null);
+  const threeRef = useRef<ThreeContext | null>(null);
 
   const { t, i18n } = createTranslator();
   const [lang, setLang] = useState(

--- a/src/ui/MainTabs.tsx
+++ b/src/ui/MainTabs.tsx
@@ -10,6 +10,7 @@ import { CabinetConfig, PlayerMode } from './types';
 import SlidingPanel from './components/SlidingPanel';
 import GlobalSettings from './panels/GlobalSettings';
 import PlayPanel from './panels/PlayPanel';
+import type { ThreeContext } from '../scene/engine';
 
 interface MainTabsProps {
   t: (key: string, opts?: any) => string;
@@ -44,7 +45,7 @@ interface MainTabsProps {
   setBoardHasGrain: (v: boolean) => void;
   addCountertop: boolean;
   setAddCountertop: (v: boolean) => void;
-  threeRef: React.MutableRefObject<any>;
+  threeRef: React.MutableRefObject<ThreeContext | null>;
   setMode: (v: PlayerMode) => void;
   startMode: Exclude<PlayerMode, null>;
   setStartMode: (v: Exclude<PlayerMode, null>) => void;

--- a/src/ui/RoomUploader.tsx
+++ b/src/ui/RoomUploader.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import type { MutableRefObject } from 'react';
 import { loadRoomFile } from '../import/roomImport';
+import type { ThreeContext } from '../scene/engine';
 
 interface Props {
-  three: MutableRefObject<any>;
+  three: MutableRefObject<ThreeContext | null>;
 }
 
 /**

--- a/src/ui/SceneViewer.tsx
+++ b/src/ui/SceneViewer.tsx
@@ -1,10 +1,8 @@
 import React, { useEffect, useRef, useState } from 'react';
 import * as THREE from 'three';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
-import type { PointerLockControls } from 'three/examples/jsm/controls/PointerLockControls.js';
-import type CabinetDragger from '../viewer/CabinetDragger';
 import WallDrawer from '../viewer/WallDrawer';
-import { setupThree } from '../scene/engine';
+import { setupThree, ThreeContext } from '../scene/engine';
 import { buildCabinetMesh } from '../scene/cabinetBuilder';
 import { FAMILY } from '../core/catalog';
 import { usePlannerStore, legCategories } from '../state/store';
@@ -25,38 +23,13 @@ import {
   worldAxes,
 } from '../utils/coordinateSystem';
 
-interface ThreeContext {
-  scene: THREE.Scene;
-  camera: THREE.Camera;
-  renderer: THREE.WebGLRenderer;
-  controls: OrbitControls;
-  playerControls: PointerLockControls;
-  group: THREE.Group;
-  cabinetDragger: CabinetDragger;
-  perspectiveCamera: THREE.PerspectiveCamera;
-  orthographicCamera: THREE.OrthographicCamera;
+type ThreeWithExtras = ThreeContext & {
   axesHelper?: THREE.AxesHelper;
-  setCamera?: (cam: THREE.Camera) => void;
-  setControls?: (c: OrbitControls) => void;
-  updateGrid?: (divisions: number) => void;
-  setPlayerParams?: (p: { height?: number; speed?: number }) => void;
-  setMove?: (m: {
-    forward: boolean;
-    backward: boolean;
-    left: boolean;
-    right: boolean;
-  }) => void;
-  setMoveFromJoystick?: (v: { x: number; y: number }) => void;
-  updateCameraRotation?: (dx: number, dy: number) => void;
-  resetCameraRotation?: () => void;
-  onJump?: () => void;
-  onCrouch?: (active: boolean) => void;
-  dispose?: () => void;
   showPointerLockError?: (msg: string) => void;
-}
+};
 
 interface Props {
-  threeRef: React.MutableRefObject<ThreeContext | null>;
+  threeRef: React.MutableRefObject<ThreeWithExtras | null>;
   addCountertop: boolean;
   mode: PlayerMode;
   setMode: React.Dispatch<React.SetStateAction<PlayerMode>>;
@@ -275,7 +248,7 @@ const SceneViewer: React.FC<Props> = ({
 
   useEffect(() => {
     if (!containerRef.current) return;
-    threeRef.current = setupThree(containerRef.current) as ThreeContext;
+    threeRef.current = setupThree(containerRef.current);
     wallDrawerRef.current = new WallDrawer(
       threeRef.current.renderer,
       () => threeRef.current!.camera,

--- a/src/ui/panels/PlayPanel.tsx
+++ b/src/ui/panels/PlayPanel.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import { usePlannerStore } from '../../state/store';
 import { PlayerMode, PlayerSubMode, PLAYER_MODES } from '../types';
+import type { ThreeContext } from '../../scene/engine';
 
 interface Props {
-  threeRef: React.MutableRefObject<any>;
+  threeRef: React.MutableRefObject<ThreeContext | null>;
   t: (key: string, opts?: any) => string;
   setMode: (v: PlayerMode) => void;
   startMode: PlayerSubMode;

--- a/tests/scene/wallRendering.test.tsx
+++ b/tests/scene/wallRendering.test.tsx
@@ -13,6 +13,7 @@ import {
   worldAxes,
   plannerToWorld,
 } from '../../src/utils/coordinateSystem';
+import type { ThreeContext } from '../../src/scene/engine';
 
 vi.mock('../../src/ui/components/ItemHotbar', () => ({
   default: () => null,
@@ -86,7 +87,7 @@ vi.mock('../../src/scene/engine', () => {
 describe('Scene wall rendering', () => {
   let container: HTMLDivElement;
   let root: ReactDOM.Root;
-  const threeRef: any = { current: null };
+  const threeRef: React.MutableRefObject<ThreeContext | null> = { current: null };
   const setMode = vi.fn();
   const setViewMode = vi.fn();
 

--- a/tests/sceneViewer.gizmo.test.tsx
+++ b/tests/sceneViewer.gizmo.test.tsx
@@ -5,6 +5,7 @@ import { act } from 'react';
 import ReactDOM from 'react-dom/client';
 import * as THREE from 'three';
 import SceneViewer from '../src/ui/SceneViewer';
+import type { ThreeContext } from '../src/scene/engine';
 
 vi.mock('three/examples/jsm/controls/OrbitControls.js', () => ({
   OrbitControls: vi.fn().mockImplementation(() => ({
@@ -81,7 +82,7 @@ vi.mock('../src/ui/components/TouchJoystick', () => ({ default: () => null }));
 
 describe('SceneViewer axes gizmo', () => {
   it('renders axes helper overlay', () => {
-    const threeRef: any = { current: null };
+    const threeRef: React.MutableRefObject<ThreeContext | null> = { current: null };
     const container = document.createElement('div');
     document.body.appendChild(container);
     const root = ReactDOM.createRoot(container);
@@ -104,7 +105,7 @@ describe('SceneViewer axes gizmo', () => {
   it.each(["3d", "2d"] as const)(
     "matches world axes in %s view",
     async (viewMode) => {
-      const threeRef: any = { current: null };
+      const threeRef: React.MutableRefObject<ThreeContext | null> = { current: null };
       const container = document.createElement("div");
       document.body.appendChild(container);
       const root = ReactDOM.createRoot(container);
@@ -131,7 +132,7 @@ describe('SceneViewer axes gizmo', () => {
   );
 
   it('matches world axes after switching view modes', async () => {
-    const threeRef: any = { current: null };
+    const threeRef: React.MutableRefObject<ThreeContext | null> = { current: null };
     const container = document.createElement('div');
     document.body.appendChild(container);
     const root = ReactDOM.createRoot(container);

--- a/tests/sceneViewer.mode.test.tsx
+++ b/tests/sceneViewer.mode.test.tsx
@@ -7,6 +7,7 @@ import * as THREE from 'three';
 import SceneViewer from '../src/ui/SceneViewer';
 import { usePlannerStore } from '../src/state/store';
 import { PlayerMode, PLAYER_MODES } from '../src/ui/types';
+import type { ThreeContext } from '../src/scene/engine';
 
 vi.mock('three/examples/jsm/controls/OrbitControls.js', () => ({
   OrbitControls: vi.fn().mockImplementation(() => ({
@@ -79,7 +80,7 @@ vi.mock('../src/ui/components/TouchJoystick', () => ({ default: () => null }));
 
 describe('SceneViewer hotbar visibility', () => {
   it('renders hotbar only when mode is not null', () => {
-    const threeRef: any = { current: null };
+    const threeRef: React.MutableRefObject<ThreeContext | null> = { current: null };
     const setMode = vi.fn();
     const container = document.createElement('div');
     document.body.appendChild(container);
@@ -120,7 +121,7 @@ describe('SceneViewer mode bar visibility', () => {
       configurable: true,
       value: 1,
     });
-    const threeRef: any = { current: null };
+    const threeRef: React.MutableRefObject<ThreeContext | null> = { current: null };
     const setMode = vi.fn();
     const container = document.createElement('div');
     document.body.appendChild(container);
@@ -163,7 +164,7 @@ describe('SceneViewer mode bar visibility', () => {
 
 describe('SceneViewer cabinetDragger mode control', () => {
   it('enables cabinetDragger only in furnish mode', () => {
-    const threeRef: any = { current: null };
+    const threeRef: React.MutableRefObject<ThreeContext | null> = { current: null };
     const setMode = vi.fn();
     const container = document.createElement('div');
     document.body.appendChild(container);
@@ -193,7 +194,7 @@ describe('SceneViewer cabinetDragger mode control', () => {
 
 describe('SceneViewer Tab key', () => {
   it('does nothing when mode is null', () => {
-    const threeRef: any = { current: null };
+    const threeRef: React.MutableRefObject<ThreeContext | null> = { current: null };
     const setMode = vi.fn();
     const container = document.createElement('div');
     document.body.appendChild(container);
@@ -214,7 +215,7 @@ describe('SceneViewer Tab key', () => {
   });
 
   it('cycles through modes when active', () => {
-    const threeRef: any = { current: null };
+    const threeRef: React.MutableRefObject<ThreeContext | null> = { current: null };
     let mode: PlayerMode = PLAYER_MODES[0];
     const setMode = vi.fn((updater: any) => {
       mode = typeof updater === 'function' ? updater(mode) : updater;
@@ -243,7 +244,7 @@ describe('SceneViewer Tab key', () => {
 
 describe('SceneViewer hotbar keys', () => {
   it('does not change selectedItemSlot when mode is null', () => {
-    const threeRef: any = { current: null };
+    const threeRef: React.MutableRefObject<ThreeContext | null> = { current: null };
     const setMode = vi.fn();
     const container = document.createElement('div');
     document.body.appendChild(container);
@@ -273,7 +274,7 @@ describe('SceneViewer hotbar keys', () => {
   });
 
   it('changes selectedItemSlot when mode is active', () => {
-    const threeRef: any = { current: null };
+    const threeRef: React.MutableRefObject<ThreeContext | null> = { current: null };
     const setMode = vi.fn();
     const container = document.createElement('div');
     document.body.appendChild(container);

--- a/tests/sceneViewer.pointerLock.test.tsx
+++ b/tests/sceneViewer.pointerLock.test.tsx
@@ -7,6 +7,7 @@ import * as THREE from 'three';
 import SceneViewer from '../src/ui/SceneViewer';
 import PlayPanel from '../src/ui/panels/PlayPanel';
 import { PlayerMode, PlayerSubMode } from '../src/ui/types';
+import type { ThreeContext } from '../src/scene/engine';
 
 vi.mock('three/examples/jsm/controls/OrbitControls.js', () => ({
   OrbitControls: vi.fn().mockImplementation(() => ({
@@ -90,7 +91,7 @@ vi.mock('../src/ui/components/TouchJoystick', () => ({ default: () => null }));
 const t = (s: string) => s;
 
 describe('pointer lock handling', () => {
-  const threeRef: any = { current: null };
+  const threeRef: React.MutableRefObject<ThreeContext | null> = { current: null };
   let mode: PlayerMode = null;
   const setMode = vi.fn((v: any) => {
     mode = typeof v === 'function' ? v(mode) : v;

--- a/tests/sceneViewer.radialMenu.test.tsx
+++ b/tests/sceneViewer.radialMenu.test.tsx
@@ -5,6 +5,7 @@ import { act } from 'react';
 import ReactDOM from 'react-dom/client';
 import * as THREE from 'three';
 import SceneViewer from '../src/ui/SceneViewer';
+import type { ThreeContext } from '../src/scene/engine';
 
 const visibleStates: boolean[] = [];
 
@@ -86,7 +87,7 @@ vi.mock('../src/ui/components/RadialMenu', () => ({
 describe('SceneViewer RadialMenu visibility', () => {
   it('shows on Q down and hides on Q up', () => {
     visibleStates.length = 0;
-    const threeRef: any = { current: null };
+    const threeRef: React.MutableRefObject<ThreeContext | null> = { current: null };
     const setMode = vi.fn();
     const container = document.createElement('div');
     document.body.appendChild(container);
@@ -121,7 +122,7 @@ describe('SceneViewer RadialMenu visibility', () => {
     const modes = ['furnish', 'decorate'] as const;
     for (const m of modes) {
       visibleStates.length = 0;
-      const threeRef: any = { current: null };
+      const threeRef: React.MutableRefObject<ThreeContext | null> = { current: null };
       const setMode = vi.fn();
       const container = document.createElement('div');
       document.body.appendChild(container);

--- a/tests/sceneViewer.viewMode.test.tsx
+++ b/tests/sceneViewer.viewMode.test.tsx
@@ -5,6 +5,7 @@ import { act } from 'react';
 import ReactDOM from 'react-dom/client';
 import * as THREE from 'three';
 import SceneViewer from '../src/ui/SceneViewer';
+import type { ThreeContext } from '../src/scene/engine';
 
 vi.mock('../src/ui/components/ItemHotbar', () => ({
   default: () => null,
@@ -81,7 +82,7 @@ vi.mock('../src/scene/engine', () => {
 
 describe('SceneViewer view mode', () => {
   it('uses orthographic camera in 2d mode', () => {
-    const threeRef: any = { current: null };
+    const threeRef: React.MutableRefObject<ThreeContext | null> = { current: null };
     const setMode = vi.fn();
     const setViewMode = vi.fn();
     const container = document.createElement('div');


### PR DESCRIPTION
## Summary
- define and export `ThreeContext` for `setupThree`
- use `ThreeContext` for `threeRef` across app and tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c5f73854b88322bf772fdb1d827724