### PR TITLE
feat: add ThreeEngine interface and render controls

### DIFF
--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -8,7 +8,7 @@ import { createTranslator } from './i18n';
 import MainTabs from './MainTabs';
 import { safeSetItem } from '../utils/storage';
 import { PlayerMode } from './types';
-import type { ThreeContext } from '../scene/engine';
+import type { ThreeEngine } from '../scene/engine';
 
 type PlayerSubMode = Exclude<PlayerMode, null>;
 
@@ -18,7 +18,7 @@ export default function App() {
   const [kind, setKind] = useState<Kind | null>(null);
   const [variant, setVariant] = useState<Variant | null>(null);
   const [addCountertop, setAddCountertop] = useState(true);
-  const threeRef = useRef<ThreeContext | null>(null);
+  const threeRef = useRef<ThreeEngine | null>(null);
 
   const { t, i18n } = createTranslator();
   const [lang, setLang] = useState(

--- a/src/ui/MainTabs.tsx
+++ b/src/ui/MainTabs.tsx
@@ -10,7 +10,7 @@ import { CabinetConfig, PlayerMode } from './types';
 import SlidingPanel from './components/SlidingPanel';
 import GlobalSettings from './panels/GlobalSettings';
 import PlayPanel from './panels/PlayPanel';
-import type { ThreeContext } from '../scene/engine';
+import type { ThreeEngine } from '../scene/engine';
 
 interface MainTabsProps {
   t: (key: string, opts?: any) => string;
@@ -45,7 +45,7 @@ interface MainTabsProps {
   setBoardHasGrain: (v: boolean) => void;
   addCountertop: boolean;
   setAddCountertop: (v: boolean) => void;
-  threeRef: React.MutableRefObject<ThreeContext | null>;
+  threeRef: React.MutableRefObject<ThreeEngine | null>;
   setMode: (v: PlayerMode) => void;
   startMode: Exclude<PlayerMode, null>;
   setStartMode: (v: Exclude<PlayerMode, null>) => void;

--- a/src/ui/RoomUploader.tsx
+++ b/src/ui/RoomUploader.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import type { MutableRefObject } from 'react';
 import { loadRoomFile } from '../import/roomImport';
-import type { ThreeContext } from '../scene/engine';
+import type { ThreeEngine } from '../scene/engine';
 
 interface Props {
-  three: MutableRefObject<ThreeContext | null>;
+  three: MutableRefObject<ThreeEngine | null>;
 }
 
 /**

--- a/src/ui/SceneViewer.tsx
+++ b/src/ui/SceneViewer.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import * as THREE from 'three';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 import WallDrawer from '../viewer/WallDrawer';
-import { setupThree, ThreeContext } from '../scene/engine';
+import { setupThree, ThreeEngine } from '../scene/engine';
 import { buildCabinetMesh } from '../scene/cabinetBuilder';
 import { FAMILY } from '../core/catalog';
 import { usePlannerStore, legCategories } from '../state/store';
@@ -23,7 +23,7 @@ import {
   worldAxes,
 } from '../utils/coordinateSystem';
 
-type ThreeWithExtras = ThreeContext & {
+type ThreeWithExtras = ThreeEngine & {
   axesHelper?: THREE.AxesHelper;
   showPointerLockError?: (msg: string) => void;
 };

--- a/src/ui/panels/PlayPanel.tsx
+++ b/src/ui/panels/PlayPanel.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import { usePlannerStore } from '../../state/store';
 import { PlayerMode, PlayerSubMode, PLAYER_MODES } from '../types';
-import type { ThreeContext } from '../../scene/engine';
+import type { ThreeEngine } from '../../scene/engine';
 
 interface Props {
-  threeRef: React.MutableRefObject<ThreeContext | null>;
+  threeRef: React.MutableRefObject<ThreeEngine | null>;
   t: (key: string, opts?: any) => string;
   setMode: (v: PlayerMode) => void;
   startMode: PlayerSubMode;

--- a/tests/scene/wallRendering.test.tsx
+++ b/tests/scene/wallRendering.test.tsx
@@ -13,7 +13,7 @@ import {
   worldAxes,
   plannerToWorld,
 } from '../../src/utils/coordinateSystem';
-import type { ThreeContext } from '../../src/scene/engine';
+import type { ThreeEngine, PlayerControls } from '../../src/scene/engine';
 
 vi.mock('../../src/ui/components/ItemHotbar', () => ({
   default: () => null,
@@ -48,7 +48,7 @@ vi.mock('../../src/scene/engine', () => {
           this.children = this.children.filter((c) => c !== obj);
         },
       };
-      const three: any = {
+      const three: ThreeEngine = {
         scene: {},
         camera: perspectiveCamera,
         renderer: { domElement: dom },
@@ -66,18 +66,30 @@ vi.mock('../../src/scene/engine', () => {
           unlock: vi.fn(),
           addEventListener: vi.fn(),
           removeEventListener: vi.fn(),
+          dispatchEvent: vi.fn(),
           isLocked: false,
-        },
+        } as PlayerControls,
         group,
         cabinetDragger: { enable: vi.fn(), disable: vi.fn() },
         perspectiveCamera,
         orthographicCamera,
-      };
-      three.setCamera = (cam: THREE.Camera) => {
-        three.camera = cam;
-      };
-      three.setControls = (c: any) => {
-        three.controls = c;
+        setPlayerParams: vi.fn(),
+        setMove: vi.fn(),
+        setMoveFromJoystick: vi.fn(),
+        updateCameraRotation: vi.fn(),
+        resetCameraRotation: vi.fn(),
+        onJump: vi.fn(),
+        onCrouch: vi.fn(),
+        updateGrid: vi.fn(),
+        dispose: vi.fn(),
+        setCamera: (cam: THREE.Camera) => {
+          three.camera = cam;
+        },
+        setControls: (c: any) => {
+          three.controls = c;
+        },
+        start: vi.fn(),
+        stop: vi.fn(),
       };
       return three;
     },
@@ -87,7 +99,7 @@ vi.mock('../../src/scene/engine', () => {
 describe('Scene wall rendering', () => {
   let container: HTMLDivElement;
   let root: ReactDOM.Root;
-  const threeRef: React.MutableRefObject<ThreeContext | null> = { current: null };
+  const threeRef: React.MutableRefObject<ThreeEngine | null> = { current: null };
   const setMode = vi.fn();
   const setViewMode = vi.fn();
 

--- a/tests/sceneViewer.gizmo.test.tsx
+++ b/tests/sceneViewer.gizmo.test.tsx
@@ -5,7 +5,7 @@ import { act } from 'react';
 import ReactDOM from 'react-dom/client';
 import * as THREE from 'three';
 import SceneViewer from '../src/ui/SceneViewer';
-import type { ThreeContext } from '../src/scene/engine';
+import type { ThreeEngine, PlayerControls } from '../src/scene/engine';
 
 vi.mock('three/examples/jsm/controls/OrbitControls.js', () => ({
   OrbitControls: vi.fn().mockImplementation(() => ({
@@ -37,7 +37,7 @@ vi.mock('../src/scene/engine', () => {
       });
       const perspectiveCamera = new THREE.PerspectiveCamera();
       const orthographicCamera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0.1, 100);
-      const three: any = {
+      const three: ThreeEngine = {
         scene: {},
         camera: perspectiveCamera,
         renderer: { domElement: dom },
@@ -55,18 +55,30 @@ vi.mock('../src/scene/engine', () => {
           unlock: vi.fn(),
           addEventListener: vi.fn(),
           removeEventListener: vi.fn(),
+          dispatchEvent: vi.fn(),
           isLocked: false,
-        },
+        } as PlayerControls,
         group: { children: [], add: () => {}, remove: () => {} },
         cabinetDragger: { enable: vi.fn(), disable: vi.fn() },
         perspectiveCamera,
         orthographicCamera,
-      };
-      three.setCamera = (cam: THREE.Camera) => {
-        three.camera = cam;
-      };
-      three.setControls = (c: any) => {
-        three.controls = c;
+        setPlayerParams: vi.fn(),
+        setMove: vi.fn(),
+        setMoveFromJoystick: vi.fn(),
+        updateCameraRotation: vi.fn(),
+        resetCameraRotation: vi.fn(),
+        onJump: vi.fn(),
+        onCrouch: vi.fn(),
+        updateGrid: vi.fn(),
+        dispose: vi.fn(),
+        setCamera: (cam: THREE.Camera) => {
+          three.camera = cam;
+        },
+        setControls: (c: any) => {
+          three.controls = c;
+        },
+        start: vi.fn(),
+        stop: vi.fn(),
       };
       return three;
     },
@@ -82,7 +94,7 @@ vi.mock('../src/ui/components/TouchJoystick', () => ({ default: () => null }));
 
 describe('SceneViewer axes gizmo', () => {
   it('renders axes helper overlay', () => {
-    const threeRef: React.MutableRefObject<ThreeContext | null> = { current: null };
+    const threeRef: React.MutableRefObject<ThreeEngine | null> = { current: null };
     const container = document.createElement('div');
     document.body.appendChild(container);
     const root = ReactDOM.createRoot(container);
@@ -105,7 +117,7 @@ describe('SceneViewer axes gizmo', () => {
   it.each(["3d", "2d"] as const)(
     "matches world axes in %s view",
     async (viewMode) => {
-      const threeRef: React.MutableRefObject<ThreeContext | null> = { current: null };
+      const threeRef: React.MutableRefObject<ThreeEngine | null> = { current: null };
       const container = document.createElement("div");
       document.body.appendChild(container);
       const root = ReactDOM.createRoot(container);
@@ -132,7 +144,7 @@ describe('SceneViewer axes gizmo', () => {
   );
 
   it('matches world axes after switching view modes', async () => {
-    const threeRef: React.MutableRefObject<ThreeContext | null> = { current: null };
+    const threeRef: React.MutableRefObject<ThreeEngine | null> = { current: null };
     const container = document.createElement('div');
     document.body.appendChild(container);
     const root = ReactDOM.createRoot(container);

--- a/tests/sceneViewer.radialMenu.test.tsx
+++ b/tests/sceneViewer.radialMenu.test.tsx
@@ -5,7 +5,7 @@ import { act } from 'react';
 import ReactDOM from 'react-dom/client';
 import * as THREE from 'three';
 import SceneViewer from '../src/ui/SceneViewer';
-import type { ThreeContext } from '../src/scene/engine';
+import type { ThreeEngine, PlayerControls } from '../src/scene/engine';
 
 const visibleStates: boolean[] = [];
 
@@ -35,7 +35,7 @@ vi.mock('../src/scene/engine', () => {
       });
       const perspectiveCamera = new THREE.PerspectiveCamera();
       const orthographicCamera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0.1, 100);
-      const three: any = {
+      const three: ThreeEngine = {
         scene: {},
         camera: perspectiveCamera,
         renderer: { domElement: dom },
@@ -53,18 +53,30 @@ vi.mock('../src/scene/engine', () => {
           unlock: vi.fn(),
           addEventListener: vi.fn(),
           removeEventListener: vi.fn(),
+          dispatchEvent: vi.fn(),
           isLocked: false,
-        },
+        } as PlayerControls,
         group: { children: [], add: () => {}, remove: () => {} },
         cabinetDragger: { enable: vi.fn(), disable: vi.fn() },
         perspectiveCamera,
         orthographicCamera,
-      };
-      three.setCamera = (cam: THREE.Camera) => {
-        three.camera = cam;
-      };
-      three.setControls = (c: any) => {
-        three.controls = c;
+        setPlayerParams: vi.fn(),
+        setMove: vi.fn(),
+        setMoveFromJoystick: vi.fn(),
+        updateCameraRotation: vi.fn(),
+        resetCameraRotation: vi.fn(),
+        onJump: vi.fn(),
+        onCrouch: vi.fn(),
+        updateGrid: vi.fn(),
+        dispose: vi.fn(),
+        setCamera: (cam: THREE.Camera) => {
+          three.camera = cam;
+        },
+        setControls: (c: any) => {
+          three.controls = c;
+        },
+        start: vi.fn(),
+        stop: vi.fn(),
       };
       return three;
     },
@@ -87,7 +99,7 @@ vi.mock('../src/ui/components/RadialMenu', () => ({
 describe('SceneViewer RadialMenu visibility', () => {
   it('shows on Q down and hides on Q up', () => {
     visibleStates.length = 0;
-    const threeRef: React.MutableRefObject<ThreeContext | null> = { current: null };
+    const threeRef: React.MutableRefObject<ThreeEngine | null> = { current: null };
     const setMode = vi.fn();
     const container = document.createElement('div');
     document.body.appendChild(container);
@@ -122,7 +134,7 @@ describe('SceneViewer RadialMenu visibility', () => {
     const modes = ['furnish', 'decorate'] as const;
     for (const m of modes) {
       visibleStates.length = 0;
-      const threeRef: React.MutableRefObject<ThreeContext | null> = { current: null };
+      const threeRef: React.MutableRefObject<ThreeEngine | null> = { current: null };
       const setMode = vi.fn();
       const container = document.createElement('div');
       document.body.appendChild(container);

--- a/tests/sceneViewer.viewMode.test.tsx
+++ b/tests/sceneViewer.viewMode.test.tsx
@@ -5,7 +5,7 @@ import { act } from 'react';
 import ReactDOM from 'react-dom/client';
 import * as THREE from 'three';
 import SceneViewer from '../src/ui/SceneViewer';
-import type { ThreeContext } from '../src/scene/engine';
+import type { ThreeEngine, PlayerControls } from '../src/scene/engine';
 
 vi.mock('../src/ui/components/ItemHotbar', () => ({
   default: () => null,
@@ -44,7 +44,7 @@ vi.mock('../src/scene/engine', () => {
       });
       const perspectiveCamera = new THREE.PerspectiveCamera();
       const orthographicCamera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0.1, 100);
-      const three: any = {
+      const three: ThreeEngine = {
         scene: {},
         camera: perspectiveCamera,
         renderer: { domElement: dom },
@@ -62,18 +62,30 @@ vi.mock('../src/scene/engine', () => {
           unlock: vi.fn(),
           addEventListener: vi.fn(),
           removeEventListener: vi.fn(),
+          dispatchEvent: vi.fn(),
           isLocked: false,
-        },
+        } as PlayerControls,
         group: { children: [], add: () => {}, remove: () => {} },
         cabinetDragger: { enable: vi.fn(), disable: vi.fn() },
         perspectiveCamera,
         orthographicCamera,
-      };
-      three.setCamera = (cam: THREE.Camera) => {
-        three.camera = cam;
-      };
-      three.setControls = (c: any) => {
-        three.controls = c;
+        setPlayerParams: vi.fn(),
+        setMove: vi.fn(),
+        setMoveFromJoystick: vi.fn(),
+        updateCameraRotation: vi.fn(),
+        resetCameraRotation: vi.fn(),
+        onJump: vi.fn(),
+        onCrouch: vi.fn(),
+        updateGrid: vi.fn(),
+        dispose: vi.fn(),
+        setCamera: (cam: THREE.Camera) => {
+          three.camera = cam;
+        },
+        setControls: (c: any) => {
+          three.controls = c;
+        },
+        start: vi.fn(),
+        stop: vi.fn(),
       };
       return three;
     },
@@ -82,7 +94,7 @@ vi.mock('../src/scene/engine', () => {
 
 describe('SceneViewer view mode', () => {
   it('uses orthographic camera in 2d mode', () => {
-    const threeRef: React.MutableRefObject<ThreeContext | null> = { current: null };
+    const threeRef: React.MutableRefObject<ThreeEngine | null> = { current: null };
     const setMode = vi.fn();
     const setViewMode = vi.fn();
     const container = document.createElement('div');


### PR DESCRIPTION
## Summary
- define new `ThreeEngine` and `PlayerControls` interfaces for typing core three.js engine
- expose `start` and `stop` methods and replace `run` flag in render loop
- update tests and components to use typed engine instead of `any`

## Testing
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68c5f89a06388322a392254dd325707f