### PR TITLE
refactor: simplify base variant rules

### DIFF
--- a/src/core/variantRules.ts
+++ b/src/core/variantRules.ts
@@ -13,18 +13,15 @@ export interface VariantRule {
 
 // Configuration describing behaviour of module variants
 export const variantRules: Record<FAMILY, Record<string, VariantRule>> = {
-  [FAMILY.BASE]: (() => {
-    const rules: Record<string, VariantRule> = {
-      doors: {},
-      drawers: {},
-      sink: { doors: 2, kits: ['sinkKit'] },
-      hob: { doors: 2 },
-      cargo150: { cargo: '150' },
-      cargo200: { cargo: '200' },
-      cargo300: { cargo: '300' },
-    }
-    return rules
-  })(),
+  [FAMILY.BASE]: {
+    doors: {},
+    drawers: {},
+    sink: { doors: 2, kits: ['sinkKit'] },
+    hob: { doors: 2 },
+    cargo150: { cargo: '150' },
+    cargo200: { cargo: '200' },
+    cargo300: { cargo: '300' },
+  },
   [FAMILY.TALL]: {
     t1: { doors: 1 },
     t2: { doors: 2 },


### PR DESCRIPTION
## Summary
- replace IIFE for FAMILY.BASE with an object literal

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c5fa14e20c8322af2745463e278fc5