### PR TITLE
Parameterize minimal module width and add edge-case tests

### DIFF
--- a/src/utils/auto.ts
+++ b/src/utils/auto.ts
@@ -1,12 +1,29 @@
-export function autoWidthsForRun(lengthMM:number, prefs:number[] = [600,800,400,500,300]){
-  const result:number[] = []
-  let remaining = Math.max(0, Math.floor(lengthMM))
-  while (remaining >= 260){
-    const pick = prefs.find(p=>p<=remaining) || remaining
-    const width = (remaining - pick < 260 && remaining > 260) ? remaining : pick
+export const DEFAULT_MIN_WIDTH_MM = 260
+
+/**
+ * Generate automatically sized module widths for a run.
+ * @param lengthMM total run length in millimeters
+ * @param prefs preferred module widths (largest to smallest)
+ * @param minWidthMM minimal allowed module width in millimeters
+ * @returns array of module widths or an empty array when length is below the minimum
+ */
+export function autoWidthsForRun(
+  lengthMM: number,
+  prefs: number[] = [600, 800, 400, 500, 300],
+  minWidthMM: number = DEFAULT_MIN_WIDTH_MM
+): number[] {
+  const result: number[] = []
+  let remaining = Math.floor(lengthMM)
+
+  if (remaining < minWidthMM) return result
+
+  while (remaining >= minWidthMM) {
+    const pick = prefs.find(p => p <= remaining) ?? remaining
+    const width =
+      remaining - pick < minWidthMM && remaining > minWidthMM ? remaining : pick
     result.push(width)
     remaining -= width
-    if (remaining < 260 && remaining>0){
+    if (remaining < minWidthMM && remaining > 0) {
       result.push(remaining)
       remaining = 0
     }

--- a/tests/autoWidthsForRun.test.ts
+++ b/tests/autoWidthsForRun.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest'
+import { autoWidthsForRun, DEFAULT_MIN_WIDTH_MM } from '../src/utils/auto'
+
+describe('autoWidthsForRun', () => {
+  it('returns empty array for length below minimum or negative', () => {
+    expect(autoWidthsForRun(DEFAULT_MIN_WIDTH_MM - 1)).toEqual([])
+    expect(autoWidthsForRun(-100)).toEqual([])
+  })
+
+  it('handles exact multiples of the minimum width', () => {
+    expect(autoWidthsForRun(DEFAULT_MIN_WIDTH_MM)).toEqual([DEFAULT_MIN_WIDTH_MM])
+    expect(autoWidthsForRun(DEFAULT_MIN_WIDTH_MM * 2)).toEqual([
+      DEFAULT_MIN_WIDTH_MM * 2,
+    ])
+  })
+
+  it('respects custom minimum width', () => {
+    expect(autoWidthsForRun(149, [600, 800, 400, 500, 300], 150)).toEqual([])
+    expect(autoWidthsForRun(300, [600, 800, 400, 500, 300], 150)).toEqual([300])
+  })
+})


### PR DESCRIPTION
## Summary
- make minimum module width configurable and document usage
- validate run length before generating widths
- add unit tests for negative lengths, lengths below minimum, and exact multiples

## Testing
- `npm test tests/autoWidthsForRun.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c5fba8673c83229ebfea8205a262be