### PR TITLE
feat: type hardware and legs options

### DIFF
--- a/src/core/builders.ts
+++ b/src/core/builders.ts
@@ -1,12 +1,12 @@
 import * as THREE from 'three'
-import { ModuleAdv } from '../types'
+import { ModuleAdv, HardwareOptions } from '../types'
 
 export interface BuilderOpts {
   width: number // in millimetres
   height: number // in millimetres
   depth: number // in millimetres
   adv?: ModuleAdv
-  hardware?: Record<string, number>
+  hardware?: HardwareOptions
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -59,6 +59,36 @@ export function hasValidSidePanelDimensions(
   );
 }
 
+export interface HardwareOptions {
+  [key: string]: number;
+}
+
+export interface LegsOptions {
+  type: string;
+  height: number;
+  category?: string;
+  legsOffset?: number;
+}
+
+export function isHardwareOptions(obj: unknown): obj is HardwareOptions {
+  return (
+    !!obj &&
+    typeof obj === 'object' &&
+    Object.values(obj as Record<string, unknown>).every(
+      (v) => typeof v === 'number'
+    )
+  );
+}
+
+export function isLegsOptions(obj: unknown): obj is LegsOptions {
+  return (
+    !!obj &&
+    typeof obj === 'object' &&
+    typeof (obj as { type?: unknown }).type === 'string' &&
+    typeof (obj as { height?: unknown }).height === 'number'
+  );
+}
+
 export type TopPanel =
   | { type: 'full' }
   | { type: 'none' }
@@ -165,7 +195,7 @@ export interface ModuleAdv {
   carcassType?: 'type1' | 'type2' | 'type3' | 'type4' | 'type5' | 'type6';
   category?: string;
   legsType?: string;
-  legs?: { type: string; height: number; category?: string; legsOffset?: number };
+  legs?: LegsOptions;
 }
 
 export interface Module3D {

--- a/src/ui/CabinetConfigurator.tsx
+++ b/src/ui/CabinetConfigurator.tsx
@@ -5,7 +5,7 @@ import { usePlannerStore, legCategories } from '../state/store';
 import TechDrawing from './components/TechDrawing';
 import Cabinet3D from './components/Cabinet3D';
 import { CabinetConfig } from './types';
-import { Gaps } from '../types';
+import { Gaps, isHardwareOptions, isLegsOptions } from '../types';
 import {
   CornerCabinetForm,
   SinkCabinetForm,
@@ -111,16 +111,16 @@ const CabinetConfigurator: React.FC<Props> = ({
   const formValues: CabinetFormValues = {
     height: gLocal.height,
     depth: gLocal.depth,
-    hardware: gLocal.hardware,
-    legs: gLocal.legs,
+    hardware: isHardwareOptions(gLocal.hardware) ? gLocal.hardware : undefined,
+    legs: isLegsOptions(gLocal.legs) ? gLocal.legs : undefined,
   };
   const handleFormChange = (vals: CabinetFormValues) => {
     setAdv({
       ...gLocal,
       height: vals.height,
       depth: vals.depth,
-      hardware: vals.hardware,
-      legs: vals.legs,
+      hardware: isHardwareOptions(vals.hardware) ? vals.hardware : undefined,
+      legs: isLegsOptions(vals.legs) ? vals.legs : undefined,
     });
   };
 

--- a/src/ui/forms/CornerCabinetForm.tsx
+++ b/src/ui/forms/CornerCabinetForm.tsx
@@ -1,12 +1,13 @@
 import React, { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import SingleMMInput from '../components/SingleMMInput'
+import { HardwareOptions, LegsOptions } from '../../types'
 
 export interface CabinetFormValues {
   height: number
   depth: number
-  hardware?: any
-  legs?: any
+  hardware?: HardwareOptions
+  legs?: LegsOptions
 }
 
 export interface CabinetFormProps {

--- a/src/ui/types.ts
+++ b/src/ui/types.ts
@@ -4,6 +4,8 @@ import {
   BottomPanel,
   EdgeBanding,
   SidePanelSpec,
+  HardwareOptions,
+  LegsOptions,
 } from '../types';
 
 export interface CabinetConfig {
@@ -31,8 +33,8 @@ export interface CabinetConfig {
     left?: SidePanelSpec & { dropToFloor?: boolean };
     right?: SidePanelSpec & { dropToFloor?: boolean };
   };
-  hardware?: any;
-  legs?: { type: string; height: number; category?: string; legsOffset?: number };
+  hardware?: HardwareOptions;
+  legs?: LegsOptions;
 }
 
 export const PLAYER_MODES = ['furnish', 'decorate'] as const;


### PR DESCRIPTION
## Summary
- add `HardwareOptions` and `LegsOptions` interfaces with validators
- apply typed hardware and legs across forms, config, builders
- validate hardware and leg values before updating cabinet configuration

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c5fd396cb08322951dad1b085392eb