### PR TITLE
refactor: use plannerToWorld for wall z

### DIFF
--- a/src/ui/SceneViewer.tsx
+++ b/src/ui/SceneViewer.tsx
@@ -16,12 +16,7 @@ import RoomToolBar from './components/RoomToolBar';
 import TouchJoystick from './components/TouchJoystick';
 import { PlayerMode, PlayerSubMode, PLAYER_MODES } from './types';
 import RadialMenu from './components/RadialMenu';
-import {
-  plannerToWorld,
-  convertAxis,
-  plannerAxes,
-  worldAxes,
-} from '../utils/coordinateSystem';
+import { plannerToWorld } from '../utils/coordinateSystem';
 
 type ThreeWithExtras = ThreeEngine & {
   axesHelper?: THREE.AxesHelper;
@@ -496,7 +491,7 @@ const SceneViewer: React.FC<Props> = ({
     const height = wallDefaults.height / 1000;
     segments.forEach(({ start, end }) => {
       const dx = plannerToWorld(end.x - start.x, 'x');
-      const dz = convertAxis(end.y - start.y, plannerAxes, 'y', worldAxes, 'z');
+      const dz = plannerToWorld(end.y - start.y, 'y');
       const length = Math.sqrt(dx * dx + dz * dz);
       const geom = new THREE.BoxGeometry(length, height, width);
       geom.translate(length / 2, 0, 0);
@@ -505,7 +500,7 @@ const SceneViewer: React.FC<Props> = ({
       mesh.position.set(
         plannerToWorld(start.x, 'x'),
         height / 2,
-        convertAxis(start.y, plannerAxes, 'y', worldAxes, 'z'),
+        plannerToWorld(start.y, 'y'),
       );
       mesh.rotation.y = Math.atan2(dz, dx);
       wallGroup.add(mesh);

--- a/tests/scene/wallRendering.test.tsx
+++ b/tests/scene/wallRendering.test.tsx
@@ -7,12 +7,7 @@ import * as THREE from 'three';
 import SceneViewer from '../../src/ui/SceneViewer';
 import { usePlannerStore } from '../../src/state/store';
 import WallDrawer from '../../src/viewer/WallDrawer';
-import {
-  convertAxis,
-  plannerAxes,
-  worldAxes,
-  plannerToWorld,
-} from '../../src/utils/coordinateSystem';
+import { plannerToWorld } from '../../src/utils/coordinateSystem';
 import type { ThreeEngine, PlayerControls } from '../../src/scene/engine';
 
 vi.mock('../../src/ui/components/ItemHotbar', () => ({
@@ -123,62 +118,58 @@ describe('Scene wall rendering', () => {
     });
   });
 
-  it('adds meshes for each roomShape segment and updates on change', () => {
-    const shape1 = {
-      points: [],
-      segments: [
-        { start: { x: 0, y: 0 }, end: { x: 1, y: 0 } },
-        { start: { x: 1, y: 0 }, end: { x: 1, y: 1 } },
-      ],
-    };
+  (['3d', '2d'] as const).forEach((viewMode) => {
+    it(`adds meshes for each roomShape segment and updates on change (${viewMode})`, () => {
+      const shape1 = {
+        points: [],
+        segments: [
+          { start: { x: 0, y: 0 }, end: { x: 1, y: 0 } },
+          { start: { x: 1, y: 0 }, end: { x: 1, y: 1 } },
+        ],
+      };
 
-    act(() => {
-      usePlannerStore.setState({ roomShape: shape1 });
-      root.render(
-        <SceneViewer
-          threeRef={threeRef}
-          addCountertop={false}
-          mode={null}
-          setMode={setMode}
-          viewMode="3d"
-          setViewMode={setViewMode}
-        />,
-      );
+      act(() => {
+        usePlannerStore.setState({ roomShape: shape1 });
+        root.render(
+          <SceneViewer
+            threeRef={threeRef}
+            addCountertop={false}
+            mode={null}
+            setMode={setMode}
+            viewMode={viewMode}
+            setViewMode={setViewMode}
+          />,
+        );
+      });
+
+      const group = threeRef.current.group;
+      expect(group.children).toHaveLength(1);
+      expect(group.children[0].children).toHaveLength(2);
+
+      const [wall1, wall2] = group.children[0].children as THREE.Mesh[];
+      expect(wall1.position.x).toBeCloseTo(plannerToWorld(0, 'x'));
+      expect(wall1.position.z).toBeCloseTo(plannerToWorld(0, 'y'));
+      expect(wall2.position.x).toBeCloseTo(plannerToWorld(1, 'x'));
+      expect(wall2.position.z).toBeCloseTo(plannerToWorld(0, 'y'));
+
+      const shape2 = {
+        points: [],
+        segments: [
+          ...shape1.segments,
+          { start: { x: 1, y: 1 }, end: { x: 0, y: 1 } },
+        ],
+      };
+
+      act(() => {
+        usePlannerStore.setState({ roomShape: shape2 });
+      });
+
+      expect(group.children).toHaveLength(1);
+      expect(group.children[0].children).toHaveLength(3);
+      const wall3 = group.children[0].children[2] as THREE.Mesh;
+      expect(wall3.position.x).toBeCloseTo(plannerToWorld(1, 'x'));
+      expect(wall3.position.z).toBeCloseTo(plannerToWorld(1, 'y'));
     });
-
-    const group = threeRef.current.group;
-    expect(group.children).toHaveLength(1);
-    expect(group.children[0].children).toHaveLength(2);
-
-    const [wall1, wall2] = group.children[0].children as THREE.Mesh[];
-    expect(wall1.position.x).toBeCloseTo(plannerToWorld(0, 'x'));
-    expect(wall1.position.z).toBeCloseTo(
-      convertAxis(0, plannerAxes, 'y', worldAxes, 'z'),
-    );
-    expect(wall2.position.x).toBeCloseTo(plannerToWorld(1, 'x'));
-    expect(wall2.position.z).toBeCloseTo(
-      convertAxis(0, plannerAxes, 'y', worldAxes, 'z'),
-    );
-
-    const shape2 = {
-      points: [],
-      segments: [
-        ...shape1.segments,
-        { start: { x: 1, y: 1 }, end: { x: 0, y: 1 } },
-      ],
-    };
-
-    act(() => {
-      usePlannerStore.setState({ roomShape: shape2 });
-    });
-
-    expect(group.children).toHaveLength(1);
-    expect(group.children[0].children).toHaveLength(3);
-    const wall3 = group.children[0].children[2] as THREE.Mesh;
-    expect(wall3.position.x).toBeCloseTo(plannerToWorld(1, 'x'));
-    expect(wall3.position.z).toBeCloseTo(
-      convertAxis(1, plannerAxes, 'y', worldAxes, 'z'),
-    );
   });
 
   it('orients walls correctly when drawn via WallDrawer', () => {


### PR DESCRIPTION
## Summary
- replace low-level `convertAxis` with `plannerToWorld` when mapping planner Y to world Z in SceneViewer
- adjust wall rendering tests to use `plannerToWorld` and cover both 3D and 2D modes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c602d67db483228c7f575e14a49b21