### PR TITLE
Clarify planner axis mapping

### DIFF
--- a/src/utils/coordinateSystem.ts
+++ b/src/utils/coordinateSystem.ts
@@ -5,8 +5,13 @@ import * as THREE from 'three';
  * convert values between them.
  *
  * The application uses a right-handed world space with the **Y axis pointing
- * upward**. The 3D viewer shares this orientation. The 2D planner operates on
- * the XZ plane where `Y` is usually `0`.
+ * upward**. The 3D viewer shares this orientation. The 2D planner lays on the
+ * world's XZ plane and interprets its local axes as:
+ *
+ * - planner **X** → world **X**
+ * - planner **Y** → world **Z** (but planner Y grows downward, so values are
+ *   negated)
+ * - planner **Z** → world **Y**
  *
  * Screen (DOM) coordinates follow the typical convention where the Y axis grows
  * downward.
@@ -25,7 +30,11 @@ export const worldAxes: Axes = { x: 1, y: 1, z: 1 };
 /** Viewer axes relative to the world (matches world orientation). */
 export const viewerAxes: Axes = { x: 1, y: 1, z: 1 };
 
-/** Planner axes relative to the world (planner uses the XZ plane). Z grows downward. */
+/**
+ * Planner axes relative to the world. Planner X matches world X. Planner Y
+ * corresponds to world Z but grows in the opposite direction (negative values
+ * are up). Planner Z corresponds directly to world Y.
+ */
 export const plannerAxes: Axes = { x: 1, y: -1, z: 1 };
 
 /** Screen (DOM) axes relative to the world. Y grows downward in the DOM. */
@@ -78,6 +87,10 @@ export function worldToScreen(value: number, axis: Axis): number {
   return convertAxis(value, worldAxes, axis, screenAxes, axis);
 }
 
+/**
+ * Maps planner axis names to the world axis names used for conversion.
+ * `x → x`, `y → z`, `z → y`.
+ */
 const plannerAxisMap: Record<Axis, Axis> = { x: 'x', y: 'z', z: 'y' };
 
 /** Convert a planner-space value to world-space. */

--- a/tests/coordinateSystem.test.ts
+++ b/tests/coordinateSystem.test.ts
@@ -20,6 +20,8 @@ describe('coordinate system helpers', () => {
   it('leaves X axis unchanged', () => {
     expect(screenToWorld(1, 'x')).toBe(1);
     expect(worldToScreen(1, 'x')).toBe(1);
+    expect(plannerToWorld(1, 'x')).toBe(1);
+    expect(worldToPlanner(1, 'x')).toBe(1);
   });
 
   it('maps planner Y to world Z with inverted sign', () => {
@@ -30,5 +32,15 @@ describe('coordinate system helpers', () => {
   it('maps world Z to planner Y with inverted sign', () => {
     expect(worldToPlanner(1, 'z')).toBe(-1);
     expect(worldToPlanner(-1, 'z')).toBe(1);
+  });
+
+  it('maps planner Z to world Y', () => {
+    expect(plannerToWorld(1, 'z')).toBe(1);
+    expect(plannerToWorld(-1, 'z')).toBe(-1);
+  });
+
+  it('maps world Y to planner Z', () => {
+    expect(worldToPlanner(1, 'y')).toBe(1);
+    expect(worldToPlanner(-1, 'y')).toBe(-1);
   });
 });


### PR DESCRIPTION
## Summary
- document how planner axes map to world axes, including Y ↔ Z inversion
- add comprehensive coordinate system tests verifying axis mapping

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c6045e9630832281b388840e4fee03