### PR TITLE
Normalize x and y via screenToWorld in viewer input

### DIFF
--- a/src/viewer/CabinetDragger.ts
+++ b/src/viewer/CabinetDragger.ts
@@ -49,7 +49,8 @@ export default class CabinetDragger {
 
   private getPoint(event: PointerEvent): THREE.Vector3 | null {
     const rect = this.renderer.domElement.getBoundingClientRect();
-    const x = ((event.clientX - rect.left) / rect.width) * 2 - 1;
+    const xScreen = ((event.clientX - rect.left) / rect.width) * 2 - 1;
+    const x = screenToWorld(xScreen, 'x');
     const yScreen = ((event.clientY - rect.top) / rect.height) * 2 - 1;
     const y = screenToWorld(yScreen, 'y');
     const cam = this.getCamera();
@@ -62,7 +63,8 @@ export default class CabinetDragger {
   private onDown = (e: PointerEvent) => {
     this.renderer.domElement.setPointerCapture(e.pointerId);
     const rect = this.renderer.domElement.getBoundingClientRect();
-    const x = ((e.clientX - rect.left) / rect.width) * 2 - 1;
+    const xScreen = ((e.clientX - rect.left) / rect.width) * 2 - 1;
+    const x = screenToWorld(xScreen, 'x');
     const yScreen = ((e.clientY - rect.top) / rect.height) * 2 - 1;
     const y = screenToWorld(yScreen, 'y');
     const cam = this.getCamera();

--- a/src/viewer/WallDrawer.ts
+++ b/src/viewer/WallDrawer.ts
@@ -136,7 +136,8 @@ export default class WallDrawer {
 
   private getPoint(event: PointerEvent): THREE.Vector3 | null {
     const rect = this.renderer.domElement.getBoundingClientRect();
-    const x = ((event.clientX - rect.left) / rect.width) * 2 - 1;
+    const nx = ((event.clientX - rect.left) / rect.width) * 2 - 1;
+    const x = screenToWorld(nx, 'x');
     const ny = ((event.clientY - rect.top) / rect.height) * 2 - 1;
     const y = screenToWorld(ny, 'y');
     const cam = this.getCamera();


### PR DESCRIPTION
## Summary
- convert both X and Y screen coordinates to world space in CabinetDragger and WallDrawer
- verify CabinetDragger and WallDrawer use screenToWorld for both axes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c6056520888322a69ffc740f326b6c