### PR TITLE
Ensure right-angle walls respect grid snapping

### DIFF
--- a/src/viewer/WallDrawer.ts
+++ b/src/viewer/WallDrawer.ts
@@ -165,6 +165,12 @@ export default class WallDrawer {
     const point = this.getPoint(e);
     if (!point) return;
     this.constrainPoint(point);
+    const state = this.store.getState();
+    if (state.snapToGrid && state.gridSize > 0) {
+      const step = state.gridSize / 1000;
+      point.x = Math.round(point.x / step) * step;
+      point.z = Math.round(point.z / step) * step;
+    }
     this.lastPoint = point.clone();
     point.y = 0.001;
     if (this.cursor) {
@@ -232,6 +238,27 @@ export default class WallDrawer {
     }
     this.constrainPoint(point);
     const state = this.store.getState();
+    const stepSize = state.gridSize / 1000;
+    if (state.snapToGrid && state.gridSize > 0) {
+      point.x = Math.round(point.x / stepSize) * stepSize;
+      point.z = Math.round(point.z / stepSize) * stepSize;
+    }
+    this.lastPoint = point.clone();
+    if (this.cursor) {
+      this.cursor.position.set(point.x, 0.001, point.z);
+    }
+    if (this.preview && this.start) {
+      const dx = point.x - this.start.x;
+      const dz = point.z - this.start.z;
+      const dist = Math.sqrt(dx * dx + dz * dz);
+      this.preview.scale.x = dist;
+      this.preview.position.set(
+        this.start.x,
+        this.preview.position.y,
+        this.start.z,
+      );
+      this.preview.rotation.y = Math.atan2(dz, dx);
+    }
     let startX = this.start.x;
     let startZ = this.start.z;
     let endX = point.x;
@@ -239,7 +266,6 @@ export default class WallDrawer {
     let lastX = this.lastPoint?.x;
     let lastZ = this.lastPoint?.z;
     if (state.snapToGrid && state.gridSize > 0) {
-      const stepSize = state.gridSize / 1000;
       startX = Math.round(startX / stepSize) * stepSize;
       startZ = Math.round(startZ / stepSize) * stepSize;
       endX = Math.round(endX / stepSize) * stepSize;

--- a/tests/viewer/WallDrawer.test.ts
+++ b/tests/viewer/WallDrawer.test.ts
@@ -320,6 +320,25 @@ describe('WallDrawer', () => {
     drawer.disable();
   });
 
+  it('snaps right-angled walls to grid nodes', () => {
+    const { drawer, point, addWallWithHistory } = createDrawer({
+      snapToGrid: true,
+      gridSize: 100,
+    });
+    point.set(0.12, 0, 0.18);
+    (drawer as any).onDown({ pointerId: 1, button: 0 } as PointerEvent);
+    point.set(0.27, 0, 0.46);
+    (drawer as any).onMove({} as PointerEvent);
+    (drawer as any).onUp({ pointerId: 1, button: 0 } as PointerEvent);
+    expect(addWallWithHistory).toHaveBeenCalledTimes(1);
+    const [[start, end]] = addWallWithHistory.mock.calls;
+    expect(start.x).toBeCloseTo(worldToPlanner(0.1, 'x'));
+    expect(start.y).toBeCloseTo(worldToPlanner(0.2, 'z'));
+    expect(end.x).toBeCloseTo(worldToPlanner(0.1, 'x'));
+    expect(end.y).toBeCloseTo(worldToPlanner(0.5, 'z'));
+    drawer.disable();
+  });
+
   it('single click with snapping places wall on grid', () => {
     const { drawer, point, addWallWithHistory } = createDrawer({
       snapToGrid: true,


### PR DESCRIPTION
## Summary
- Resnap points to grid after applying right-angle constraint in wall drawing
- Update cursor and preview to reflect resnapped coordinates
- Add test ensuring right-angled walls end on grid nodes when snapping is enabled

## Testing
- `npm test tests/viewer/WallDrawer.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c69cf4a6f88322bc69c04538b0b763