### PR TITLE
Add pencil tool to room toolbar

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -216,6 +216,7 @@
     "dropCeiling": "Drop ceiling",
     "length": "Length",
     "place": "Place",
+    "pencil": "Pencil",
     "hammer": "Hammer",
     "group": "Group"
   },

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -216,6 +216,7 @@
     "dropCeiling": "Sufit opuszczany",
     "length": "Długość",
     "place": "Umieść",
+    "pencil": "Ołówek",
     "hammer": "Młotek",
     "group": "Grupuj"
   },

--- a/src/ui/components/RoomToolBar.tsx
+++ b/src/ui/components/RoomToolBar.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Hammer, Users } from 'lucide-react';
+import { Hammer, Users, Pencil } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { usePlannerStore } from '../../state/store';
 
@@ -31,6 +31,18 @@ const RoomToolBar: React.FC = () => {
           borderRadius: 8,
         }}
       >
+        <button
+          className="btnGhost"
+          title={t('room.pencil')}
+          onClick={() => setSelectedTool('pencil')}
+          style={
+            selectedTool === 'pencil'
+              ? { background: 'var(--accent)', color: 'var(--white)' }
+              : undefined
+          }
+        >
+          <Pencil size={16} />
+        </button>
         <button
           className="btnGhost"
           title={t('room.hammer')}


### PR DESCRIPTION
## Summary
- add pencil tool button to the room toolbar
- add English and Polish translations for pencil tool

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c6a497e96883228fd1bcac0d0aaac8