### PR TITLE
feat: add draw wall translation

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -217,6 +217,7 @@
     "length": "Length",
     "place": "Place",
     "pencil": "Pencil",
+    "drawWall": "Draw wall",
     "hammer": "Hammer",
     "group": "Group"
   },

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -217,6 +217,7 @@
     "length": "Długość",
     "place": "Umieść",
     "pencil": "Ołówek",
+    "drawWall": "Rysuj ścianę",
     "hammer": "Młotek",
     "group": "Grupuj"
   },


### PR DESCRIPTION
## Summary
- add missing `drawWall` translation for English and Polish room sections

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c6a5696360832291c053444508d2b3