### PR TITLE
chore: remove unused drawWall translations

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -217,7 +217,6 @@
     "length": "Length",
     "place": "Place",
     "pencil": "Pencil",
-    "drawWall": "Draw wall",
     "hammer": "Hammer",
     "group": "Group"
   },

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -217,7 +217,6 @@
     "length": "Długość",
     "place": "Umieść",
     "pencil": "Ołówek",
-    "drawWall": "Rysuj ścianę",
     "hammer": "Młotek",
     "group": "Grupuj"
   },


### PR DESCRIPTION
## Summary
- remove `drawWall` key from room section in English and Polish translations
- verify no components reference `t('room.drawWall')`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c6dc6e02a483229921eef369c4bacb