### PR TITLE
Add Escape key hint for pencil tool

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -218,7 +218,8 @@
     "place": "Place",
     "pencil": "Pencil",
     "hammer": "Hammer",
-    "group": "Group"
+    "group": "Group",
+    "pressEscToFinish": "Press Esc to finish"
   },
   "items": {
     "cup": "Cup",

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -218,7 +218,8 @@
     "place": "Umieść",
     "pencil": "Ołówek",
     "hammer": "Młotek",
-    "group": "Grupuj"
+    "group": "Grupuj",
+    "pressEscToFinish": "Naciśnij Esc, aby zakończyć"
   },
   "items": {
     "cup": "Kubek",

--- a/src/ui/SceneViewer.tsx
+++ b/src/ui/SceneViewer.tsx
@@ -941,11 +941,16 @@ const SceneViewer: React.FC<Props> = ({
       wallStartRef.current = null;
       usePlannerStore.getState().setSelectedTool(null);
     };
+    const handleKeyDown = (ev: KeyboardEvent) => {
+      if (ev.key === 'Escape') finish();
+    };
     canvas.addEventListener('pointerdown', handleClick);
     canvas.addEventListener('dblclick', finish);
+    window.addEventListener('keydown', handleKeyDown);
     return () => {
       canvas.removeEventListener('pointerdown', handleClick);
       canvas.removeEventListener('dblclick', finish);
+      window.removeEventListener('keydown', handleKeyDown);
     };
   }, [store.selectedTool, threeRef]);
 

--- a/src/ui/components/RoomToolBar.tsx
+++ b/src/ui/components/RoomToolBar.tsx
@@ -69,6 +69,19 @@ const RoomToolBar: React.FC = () => {
           <Users size={16} />
         </button>
       </div>
+      {selectedTool === 'pencil' && (
+        <div
+          style={{
+            padding: '4px 8px',
+            background: 'var(--white)',
+            border: '1px solid var(--border)',
+            borderRadius: 8,
+            fontSize: 12,
+          }}
+        >
+          {t('room.pressEscToFinish')}
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- allow finishing pencil tool using the Escape key in SceneViewer
- add English and Polish translations for the Escape shortcut
- display Esc shortcut hint in the room toolbar when pencil tool is active

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c6de8720c88322bf6a0e79ba91c408