### PR TITLE
Render room shape walls in SceneViewer

### DIFF
--- a/src/scene/roomShapeBuilder.ts
+++ b/src/scene/roomShapeBuilder.ts
@@ -1,0 +1,21 @@
+import * as THREE from 'three';
+import { RoomShape } from '../types';
+import { alignToGround } from '../utils/coordinateSystem';
+
+/**
+ * Convert a RoomShape into a Three.js LineSegments mesh.
+ * Each segment is represented by a line on the XZ plane
+ * (planner X/Y mapped to world X/Z).
+ */
+export function buildRoomShapeMesh(shape: RoomShape): THREE.LineSegments {
+  const verts: number[] = [];
+  for (const seg of shape.segments) {
+    verts.push(seg.start.x, seg.start.y, 0, seg.end.x, seg.end.y, 0);
+  }
+  const geometry = new THREE.BufferGeometry();
+  geometry.setAttribute('position', new THREE.Float32BufferAttribute(verts, 3));
+  const material = new THREE.LineBasicMaterial({ color: 0x333333 });
+  const lines = new THREE.LineSegments(geometry, material);
+  alignToGround(lines);
+  return lines;
+}


### PR DESCRIPTION
## Summary
- add helper to convert RoomShape segments into line segments
- render and cleanup room shape mesh in SceneViewer on roomShape changes

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c6ef7967a08322a2af505d364f4d31