### PR TITLE
feat: add wall mode shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ W aplikacji webowej przejdź do zakładki **Room** i w sekcji "Import room scan"
 
 Obsługiwane formaty: **glTF** oraz **OBJ**.
 
+## Rysowanie ścian
+
+Aby rozpocząć rysowanie ścian, naciśnij w widoku sceny klawisz `P` lub wybierz narzędzie ołówka w zakładce **Room**. Na pasku narzędzi pojawią się opcje edycji ścian. Zakończ rysowanie, wciskając `Esc`.
+
 ## Licencja
 
 Projekt jest udostępniany na licencji **MebloPlan Non-Commercial License 1.0**. Użytkowanie, kopiowanie oraz modyfikacja kodu są dozwolone wyłącznie w celach niekomercyjnych i przy zachowaniu informacji o autorach. Wykorzystanie komercyjne wymaga wcześniejszej zgody wszystkich współautorów.

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -219,7 +219,8 @@
     "pencil": "Pencil",
     "hammer": "Hammer",
     "group": "Group",
-    "pressEscToFinish": "Press Esc to finish"
+    "pressEscToFinish": "Press Esc to finish",
+    "pressPToStart": "Press P to start drawing walls"
   },
   "items": {
     "cup": "Cup",

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -219,7 +219,8 @@
     "pencil": "Ołówek",
     "hammer": "Młotek",
     "group": "Grupuj",
-    "pressEscToFinish": "Naciśnij Esc, aby zakończyć"
+    "pressEscToFinish": "Naciśnij Esc, aby zakończyć",
+    "pressPToStart": "Naciśnij P, aby rozpocząć rysowanie ścian"
   },
   "items": {
     "cup": "Kubek",

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -158,7 +158,7 @@ export default function App() {
           setMode={handleSetMode}
           viewMode={viewMode}
           setViewMode={handleSetViewMode}
-          showRoomTools={activeTab === 'room'}
+          showRoomTools={activeTab === 'room' || store.selectedTool !== null}
         />
       </div>
     </div>

--- a/src/ui/SceneViewer.tsx
+++ b/src/ui/SceneViewer.tsx
@@ -60,6 +60,7 @@ const SceneViewer: React.FC<Props> = ({
   const containerRef = useRef<HTMLDivElement>(null);
   const axesRef = useRef<HTMLDivElement>(null);
   const store = usePlannerStore();
+  const startWallPlacement = usePlannerStore((s) => s.startWallPlacement);
   const showEdges = store.role === 'stolarz';
   const showFronts = store.showFronts;
   const threeInitialized = useRef(false);
@@ -536,6 +537,19 @@ const SceneViewer: React.FC<Props> = ({
     window.addEventListener('keydown', handleTab);
     return () => window.removeEventListener('keydown', handleTab);
   }, [mode, setMode]);
+
+  useEffect(() => {
+    if (mode !== null) return;
+    const handleStartWall = (e: KeyboardEvent) => {
+      if (e.key.toLowerCase() === 'p') {
+        e.preventDefault();
+        startWallPlacement();
+        setViewMode('2d');
+      }
+    };
+    window.addEventListener('keydown', handleStartWall);
+    return () => window.removeEventListener('keydown', handleStartWall);
+  }, [mode, startWallPlacement, setViewMode]);
 
   useEffect(() => {
     updateGhost();

--- a/src/ui/components/RoomToolBar.tsx
+++ b/src/ui/components/RoomToolBar.tsx
@@ -69,19 +69,19 @@ const RoomToolBar: React.FC = () => {
           <Users size={16} />
         </button>
       </div>
-      {selectedTool === 'pencil' && (
-        <div
-          style={{
-            padding: '4px 8px',
-            background: 'var(--white)',
-            border: '1px solid var(--border)',
-            borderRadius: 8,
-            fontSize: 12,
-          }}
-        >
-          {t('room.pressEscToFinish')}
-        </div>
-      )}
+      <div
+        style={{
+          padding: '4px 8px',
+          background: 'var(--white)',
+          border: '1px solid var(--border)',
+          borderRadius: 8,
+          fontSize: 12,
+        }}
+      >
+        {selectedTool === 'pencil'
+          ? t('room.pressEscToFinish')
+          : t('room.pressPToStart')}
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- show room tools while a room editing tool is active
- add "P" keyboard shortcut to start wall placement and switch to 2D view
- document wall-drawing shortcut and add UI hints

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c6f1014868832286392120d9ccdada