### PR TITLE
Add wall dimension menu

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -211,6 +211,7 @@
     "openings": "Openings",
     "height": "Height",
     "width": "Width",
+    "thickness": "Thickness",
     "floorHeight": "Floor height",
     "insert": "Insert",
     "dropCeiling": "Drop ceiling",

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -211,6 +211,7 @@
     "openings": "Otwory",
     "height": "Wysokość",
     "width": "Szerokość",
+    "thickness": "Grubość",
     "floorHeight": "Wysokość od podłogi",
     "insert": "Wstaw",
     "dropCeiling": "Sufit opuszczany",

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -175,6 +175,7 @@ type Store = {
   selectedTool: string | null;
   openingDefaults: { height: number; width: number; floorHeight: number };
   dropCeilingDefaults: { length: number; width: number; height: number };
+  wallDefaults: { height: number; thickness: number; length: number };
   itemsByCabinet: (cabinetId: string) => Item[];
   itemsBySurface: (cabinetId: string, surfaceIndex: number) => Item[];
   setRole: (r: 'stolarz' | 'klient') => void;
@@ -209,6 +210,9 @@ type Store = {
   selectDoor: (type: 'single' | 'double' | 'sliding') => void;
   insertOpening: (height: number, width: number, floorHeight: number) => void;
   placeDropCeiling: (length: number, width: number, height: number) => void;
+  setWallDefaults: (
+    patch: Partial<{ height: number; thickness: number; length: number }>,
+  ) => void;
 };
 
 export const usePlannerStore = create<Store>((set, get) => ({
@@ -243,6 +247,8 @@ export const usePlannerStore = create<Store>((set, get) => ({
   selectedTool: null,
   openingDefaults: { height: 1000, width: 1000, floorHeight: 0 },
   dropCeilingDefaults: { length: 1000, width: 1000, height: 100 },
+  wallDefaults:
+    persisted?.wallDefaults || { height: 2700, thickness: 120, length: 1000 },
   showFronts: true,
   itemsByCabinet: (cabinetId) =>
     get().items.filter((it) => it.cabinetId === cabinetId),
@@ -514,6 +520,8 @@ export const usePlannerStore = create<Store>((set, get) => ({
       selectedTool: 'drop-ceiling',
       dropCeilingDefaults: { length, width, height },
     }),
+  setWallDefaults: (patch) =>
+    set((s) => ({ wallDefaults: { ...s.wallDefaults, ...patch } })),
 }));
 
 const persistSelector = (s: Store) => ({
@@ -533,6 +541,7 @@ const persistSelector = (s: Store) => ({
   measurementUnit: s.measurementUnit,
   playerHeight: s.playerHeight,
   playerSpeed: s.playerSpeed,
+  wallDefaults: s.wallDefaults,
 });
 
 let persistTimeout = 0;

--- a/src/ui/components/RoomToolBar.tsx
+++ b/src/ui/components/RoomToolBar.tsx
@@ -2,12 +2,15 @@ import React from 'react';
 import { Hammer, Users, Pencil } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { usePlannerStore } from '../../state/store';
+import SingleMMInput from './SingleMMInput';
 
 const RoomToolBar: React.FC = () => {
   const { t } = useTranslation();
   const setSelectedTool = usePlannerStore((s) => s.setSelectedTool);
   const startWallPlacement = usePlannerStore((s) => s.startWallPlacement);
   const selectedTool = usePlannerStore((s) => s.selectedTool);
+  const wallDefaults = usePlannerStore((s) => s.wallDefaults);
+  const setWallDefaults = usePlannerStore((s) => s.setWallDefaults);
 
   return (
     <div
@@ -69,6 +72,43 @@ const RoomToolBar: React.FC = () => {
           <Users size={16} />
         </button>
       </div>
+      {selectedTool === 'pencil' && (
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 4,
+            padding: 8,
+            background: 'var(--white)',
+            border: '1px solid var(--border)',
+            borderRadius: 8,
+          }}
+        >
+          <div style={{ display: 'flex', gap: 8 }}>
+            <div>
+              <div className="small">{t('room.height')}</div>
+              <SingleMMInput
+                value={wallDefaults.height}
+                onChange={(v) => setWallDefaults({ height: v })}
+              />
+            </div>
+            <div>
+              <div className="small">{t('room.thickness')}</div>
+              <SingleMMInput
+                value={wallDefaults.thickness}
+                onChange={(v) => setWallDefaults({ thickness: v })}
+              />
+            </div>
+          </div>
+          <div>
+            <div className="small">{t('room.length')}</div>
+            <SingleMMInput
+              value={wallDefaults.length}
+              onChange={(v) => setWallDefaults({ length: v })}
+            />
+          </div>
+        </div>
+      )}
       <div
         style={{
           padding: '4px 8px',


### PR DESCRIPTION
## Summary
- show wall height, thickness, and length inputs when pencil tool is active
- store wall dimension defaults in state and persist them
- add translations for wall thickness

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c6f4ef184c8322a076f78f79a4a4c5