### PR TITLE
Convert room shape segments to world coordinates

### DIFF
--- a/src/scene/roomShapeBuilder.ts
+++ b/src/scene/roomShapeBuilder.ts
@@ -1,6 +1,6 @@
 import * as THREE from 'three';
 import { RoomShape } from '../types';
-import { alignToGround } from '../utils/coordinateSystem';
+import { alignToGround, plannerToWorld } from '../utils/coordinateSystem';
 
 /**
  * Convert a RoomShape into a Three.js LineSegments mesh.
@@ -10,7 +10,14 @@ import { alignToGround } from '../utils/coordinateSystem';
 export function buildRoomShapeMesh(shape: RoomShape): THREE.LineSegments {
   const verts: number[] = [];
   for (const seg of shape.segments) {
-    verts.push(seg.start.x, seg.start.y, 0, seg.end.x, seg.end.y, 0);
+    // Convert planner coordinates to world space to avoid axis inversion
+    const sx = plannerToWorld(seg.start.x, 'x');
+    const sz = plannerToWorld(seg.start.y, 'y');
+    const ex = plannerToWorld(seg.end.x, 'x');
+    const ez = plannerToWorld(seg.end.y, 'y');
+
+    // Build geometry in the XY plane; alignToGround will map it onto XZ
+    verts.push(sx, -sz, 0, ex, -ez, 0);
   }
   const geometry = new THREE.BufferGeometry();
   geometry.setAttribute('position', new THREE.Float32BufferAttribute(verts, 3));


### PR DESCRIPTION
## Summary
- Convert planner room shape coordinates to world space using `plannerToWorld`
- Populate geometry array with world-space values before aligning to ground

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c6fb60381083228d2bba2ddedccc1c