### PR TITLE
Fix wall drawing coordinate conversions

### DIFF
--- a/src/ui/SceneViewer.tsx
+++ b/src/ui/SceneViewer.tsx
@@ -17,6 +17,7 @@ import { PlayerMode, PlayerSubMode, PLAYER_MODES } from './types';
 import RadialMenu from './components/RadialMenu';
 import { addSegmentToShape } from '../utils/roomShape';
 import { buildRoomShapeMesh } from '../scene/roomShapeBuilder';
+import { plannerToWorld, worldToPlanner } from '../utils/coordinateSystem';
 
 type ThreeWithExtras = ThreeEngine & {
   axesHelper?: THREE.AxesHelper;
@@ -965,15 +966,22 @@ const SceneViewer: React.FC<Props> = ({
       );
       raycaster.setFromCamera(mouse, three.camera);
       if (!raycaster.ray.intersectPlane(plane, temp)) return null;
-      return { x: temp.x, y: temp.z };
+      return {
+        x: worldToPlanner(temp.x, 'x'),
+        y: worldToPlanner(temp.z, 'y'),
+      };
     };
 
     const updatePreview = (start: ShapePoint, end: ShapePoint) => {
       let line = wallPreviewRef.current;
+      const sx = plannerToWorld(start.x, 'x');
+      const sz = plannerToWorld(start.y, 'y');
+      const ex = plannerToWorld(end.x, 'x');
+      const ez = plannerToWorld(end.y, 'y');
       if (!line) {
         const geometry = new THREE.BufferGeometry().setFromPoints([
-          new THREE.Vector3(start.x, 0, start.y),
-          new THREE.Vector3(end.x, 0, end.y),
+          new THREE.Vector3(sx, 0, sz),
+          new THREE.Vector3(ex, 0, ez),
         ]);
         const material = new THREE.LineBasicMaterial({ color: 0x444444 });
         line = new THREE.Line(geometry, material);
@@ -983,12 +991,12 @@ const SceneViewer: React.FC<Props> = ({
         const pos = (
           line.geometry as THREE.BufferGeometry
         ).attributes.position.array as Float32Array;
-        pos[0] = start.x;
+        pos[0] = sx;
         pos[1] = 0;
-        pos[2] = start.y;
-        pos[3] = end.x;
+        pos[2] = sz;
+        pos[3] = ex;
         pos[4] = 0;
-        pos[5] = end.y;
+        pos[5] = ez;
         (
           line.geometry as THREE.BufferGeometry
         ).attributes.position.needsUpdate = true;
@@ -1027,6 +1035,8 @@ const SceneViewer: React.FC<Props> = ({
       if (!start) return;
       const end = getPoint(ev);
       if (end) {
+        // Ensure preview reflects final cursor position using world coords
+        updatePreview(start, end);
         const shape = usePlannerStore.getState().roomShape;
         const newShape = addSegmentToShape(shape, { start, end });
         if (newShape) {


### PR DESCRIPTION
## Summary
- convert world coords to planner space when picking points
- convert planner points back to world space for wall preview and finalize

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c6fc6d67bc8322a25e032ba669bb37