### PR TITLE
refactor planner coordinate conversions

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,15 @@ Obsługiwane formaty: **glTF** oraz **OBJ**.
 
 Aby rozpocząć rysowanie ścian, naciśnij w widoku sceny klawisz `P` lub wybierz narzędzie ołówka w zakładce **Room**. Na pasku narzędzi pojawią się opcje edycji ścian. Zakończ rysowanie, wciskając `Esc`.
 
+## Układ współrzędnych
+
+Aplikacja korzysta z prawoskrętnego układu współrzędnych, w którym oś **Y** jest skierowana w górę. Widok 2D planera leży na płaszczyźnie **XZ** świata i interpretuje swoje osie następująco:
+
+- planner **X** → świat **X**
+- planner **Y** → świat **Z** (ale rośnie w dół, więc wartości są negowane)
+
+Do konwersji współrzędnych należy używać helperów z `src/utils/coordinateSystem.ts` oraz `src/utils/planner.ts` (`plannerToWorld`, `worldToPlanner`, `plannerPointToWorld`, `worldPointToPlanner`). Ręczne zamiany osi mogą prowadzić do błędów i powinny być zastąpione powyższymi funkcjami.
+
 ## Licencja
 
 Projekt jest udostępniany na licencji **MebloPlan Non-Commercial License 1.0**. Użytkowanie, kopiowanie oraz modyfikacja kodu są dozwolone wyłącznie w celach niekomercyjnych i przy zachowaniu informacji o autorach. Wykorzystanie komercyjne wymaga wcześniejszej zgody wszystkich współautorów.

--- a/src/scene/roomShapeBuilder.ts
+++ b/src/scene/roomShapeBuilder.ts
@@ -1,6 +1,7 @@
 import * as THREE from 'three';
 import { RoomShape } from '../types';
-import { alignToGround, plannerToWorld } from '../utils/coordinateSystem';
+import { alignToGround } from '../utils/coordinateSystem';
+import { plannerPointToWorld } from '../utils/planner';
 
 /**
  * Convert a RoomShape into a Three.js LineSegments mesh.
@@ -11,13 +12,11 @@ export function buildRoomShapeMesh(shape: RoomShape): THREE.LineSegments {
   const verts: number[] = [];
   for (const seg of shape.segments) {
     // Convert planner coordinates to world space to avoid axis inversion
-    const sx = plannerToWorld(seg.start.x, 'x');
-    const sz = plannerToWorld(seg.start.y, 'y');
-    const ex = plannerToWorld(seg.end.x, 'x');
-    const ez = plannerToWorld(seg.end.y, 'y');
+    const s = plannerPointToWorld(seg.start);
+    const e = plannerPointToWorld(seg.end);
 
     // Build geometry in the XY plane; alignToGround will map it onto XZ
-    verts.push(sx, -sz, 0, ex, -ez, 0);
+    verts.push(s.x, -s.z, 0, e.x, -e.z, 0);
   }
   const geometry = new THREE.BufferGeometry();
   geometry.setAttribute('position', new THREE.Float32BufferAttribute(verts, 3));

--- a/src/ui/SceneViewer.tsx
+++ b/src/ui/SceneViewer.tsx
@@ -17,7 +17,7 @@ import { PlayerMode, PlayerSubMode, PLAYER_MODES } from './types';
 import RadialMenu from './components/RadialMenu';
 import { addSegmentToShape } from '../utils/roomShape';
 import { buildRoomShapeMesh } from '../scene/roomShapeBuilder';
-import { plannerToWorld, worldToPlanner } from '../utils/coordinateSystem';
+import { vector3ToPlannerPoint, plannerPointToVector3 } from '../utils/planner';
 
 type ThreeWithExtras = ThreeEngine & {
   axesHelper?: THREE.AxesHelper;
@@ -966,22 +966,17 @@ const SceneViewer: React.FC<Props> = ({
       );
       raycaster.setFromCamera(mouse, three.camera);
       if (!raycaster.ray.intersectPlane(plane, temp)) return null;
-      return {
-        x: worldToPlanner(temp.x, 'x'),
-        y: worldToPlanner(temp.z, 'y'),
-      };
+      return vector3ToPlannerPoint(temp);
     };
 
     const updatePreview = (start: ShapePoint, end: ShapePoint) => {
       let line = wallPreviewRef.current;
-      const sx = plannerToWorld(start.x, 'x');
-      const sz = plannerToWorld(start.y, 'y');
-      const ex = plannerToWorld(end.x, 'x');
-      const ez = plannerToWorld(end.y, 'y');
+      const s = plannerPointToVector3(start);
+      const e = plannerPointToVector3(end);
       if (!line) {
         const geometry = new THREE.BufferGeometry().setFromPoints([
-          new THREE.Vector3(sx, 0, sz),
-          new THREE.Vector3(ex, 0, ez),
+          s,
+          e,
         ]);
         const material = new THREE.LineBasicMaterial({ color: 0x444444 });
         line = new THREE.Line(geometry, material);
@@ -991,12 +986,12 @@ const SceneViewer: React.FC<Props> = ({
         const pos = (
           line.geometry as THREE.BufferGeometry
         ).attributes.position.array as Float32Array;
-        pos[0] = sx;
-        pos[1] = 0;
-        pos[2] = sz;
-        pos[3] = ex;
-        pos[4] = 0;
-        pos[5] = ez;
+        pos[0] = s.x;
+        pos[1] = s.y;
+        pos[2] = s.z;
+        pos[3] = e.x;
+        pos[4] = e.y;
+        pos[5] = e.z;
         (
           line.geometry as THREE.BufferGeometry
         ).attributes.position.needsUpdate = true;

--- a/src/utils/planner.ts
+++ b/src/utils/planner.ts
@@ -1,0 +1,48 @@
+import * as THREE from 'three';
+import type { ShapePoint } from '../types';
+import { plannerToWorld, worldToPlanner } from './coordinateSystem';
+
+/**
+ * Helper utilities for converting between planner 2D coordinates and the 3D
+ * world space used by the viewer.
+ *
+ * Planner axes map to world axes as follows:
+ * - planner **X** → world **X**
+ * - planner **Y** → world **Z** (planner Y grows downward)
+ *
+ * The functions below operate on whole points to avoid repetitive axis swaps
+ * throughout the codebase.
+ */
+
+export interface WorldPoint {
+  x: number;
+  z: number;
+}
+
+/** Convert a planner point (x, y) to world coordinates (x, z). */
+export function plannerPointToWorld(pt: ShapePoint): WorldPoint {
+  return {
+    x: plannerToWorld(pt.x, 'x'),
+    z: plannerToWorld(pt.y, 'y'),
+  };
+}
+
+/** Convert world coordinates (x, z) to a planner point (x, y). */
+export function worldPointToPlanner(pt: WorldPoint): ShapePoint {
+  return {
+    x: worldToPlanner(pt.x, 'x'),
+    y: worldToPlanner(pt.z, 'z'),
+  };
+}
+
+/** Convert a planner point directly to a THREE.Vector3 lying on the ground plane. */
+export function plannerPointToVector3(pt: ShapePoint): THREE.Vector3 {
+  const { x, z } = plannerPointToWorld(pt);
+  return new THREE.Vector3(x, 0, z);
+}
+
+/** Convert a THREE.Vector3 on the ground plane to a planner point. */
+export function vector3ToPlannerPoint(vec: THREE.Vector3): ShapePoint {
+  return worldPointToPlanner({ x: vec.x, z: vec.z });
+}
+

--- a/tests/coordinateSystem.test.ts
+++ b/tests/coordinateSystem.test.ts
@@ -5,6 +5,7 @@ import {
   plannerToWorld,
   worldToPlanner,
 } from '../src/utils/coordinateSystem';
+import { plannerPointToWorld, worldPointToPlanner } from '../src/utils/planner';
 
 describe('coordinate system helpers', () => {
   it('converts screen Y to world Y', () => {
@@ -42,5 +43,12 @@ describe('coordinate system helpers', () => {
   it('maps world Y to planner Z', () => {
     expect(worldToPlanner(1, 'y')).toBe(1);
     expect(worldToPlanner(-1, 'y')).toBe(-1);
+  });
+
+  it('converts planner points to world points and back', () => {
+    const p = { x: 2, y: -3 };
+    const w = plannerPointToWorld(p);
+    expect(w).toEqual({ x: 2, z: 3 });
+    expect(worldPointToPlanner(w)).toEqual(p);
   });
 });

--- a/tests/wallPlacement2d.test.ts
+++ b/tests/wallPlacement2d.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { addSegmentToShape } from '../src/utils/roomShape';
-import { worldToPlanner } from '../src/utils/coordinateSystem';
+import { worldPointToPlanner } from '../src/utils/planner';
 import { usePlannerStore } from '../src/state/store';
 import type { ShapePoint } from '../src/types';
 
@@ -14,10 +14,7 @@ vi.mock('../src/utils/uuid', () => ({
 const createWorldClickSimulator = () => {
   let start: ShapePoint | null = null;
   return (x: number, z: number) => {
-    const point: ShapePoint = {
-      x: worldToPlanner(x, 'x'),
-      y: worldToPlanner(z, 'z'),
-    };
+    const point: ShapePoint = worldPointToPlanner({ x, z });
     if (!start) {
       start = point;
       return;


### PR DESCRIPTION
## Summary
- add helper utilities for planner↔world point conversion
- refactor SceneViewer and roomShapeBuilder to use new helpers
- document coordinate system and add conversion tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6ffce71e48322bf763aea57a1053e