### PR TITLE
feat: scaffold new 2d planner

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,13 @@ Aplikacja korzysta z prawoskrętnego układu współrzędnych, w którym oś **Y
 
 Do konwersji współrzędnych należy używać helperów z `src/utils/coordinateSystem.ts` oraz `src/utils/planner.ts` (`plannerToWorld`, `worldToPlanner`, `plannerPointToWorld`, `worldPointToPlanner`). Ręczne zamiany osi mogą prowadzić do błędów i powinny być zastąpione powyższymi funkcjami.
 
+## Eksperymentalny tryb 2D
+
+Istniejący moduł 2D jest traktowany jako "legacy" i może zostać wyłączony
+przez ustawienie zmiennej środowiskowej `VITE_ENABLE_LEGACY_2D=false`. Dzięki
+temu nowy system 2D może być rozwijany równolegle. Wstępny dokument projektowy
+znajduje się w [`docs/new-2d-system.md`](docs/new-2d-system.md).
+
 ## Licencja
 
 Projekt jest udostępniany na licencji **MebloPlan Non-Commercial License 1.0**. Użytkowanie, kopiowanie oraz modyfikacja kodu są dozwolone wyłącznie w celach niekomercyjnych i przy zachowaniu informacji o autorach. Wykorzystanie komercyjne wymaga wcześniejszej zgody wszystkich współautorów.

--- a/docs/new-2d-system.md
+++ b/docs/new-2d-system.md
@@ -1,0 +1,33 @@
+# New 2D System Design
+
+## Goals
+- Build a new 2D planner that can evolve independently from the existing viewer.
+- Keep the 2D layer in sync with the 3D world while allowing lighter interactions.
+- Reuse proven utilities and state management to reduce duplication.
+
+## Coordinate System
+- Application uses a right‑handed world with **Y up**.
+- The planner lies on the **XZ** plane:
+  - planner **X** → world **X**
+  - planner **Y** → world **Z** (grows downward)
+- Conversion helpers from `src/utils/coordinateSystem.ts` and `src/utils/planner.ts` must be used.
+
+## Architecture
+- New code lives under `src/new2d/`.
+- A small adapter translates planner points to world coordinates (`projectPlannerPoint`).
+- A feature flag decides whether the legacy 2D mode is available so both systems can coexist.
+
+## Integration Points
+- `SceneViewer` will instantiate either the legacy or the new 2D layer based on flags.
+- Shared state (store, undo/redo) remains unchanged.
+- Rendering and input handling are isolated to simplify replacement.
+
+## Iterative Plan
+1. Establish feature flag and scaffolding (this commit).
+2. Implement rendering primitives and hit testing.
+3. Port existing editing tools using the new abstractions.
+4. Remove legacy mode after tests and documentation are complete.
+
+## Open Questions
+- Should measurements switch to millimetres or remain unitless?
+- How will mobile room‑scan imports map into the new planner?

--- a/src/new2d/index.ts
+++ b/src/new2d/index.ts
@@ -1,0 +1,10 @@
+import type { ShapePoint } from '../types';
+import { plannerPointToWorld, type WorldPoint } from '../utils/planner';
+
+/**
+ * Prototype helpers for the upcoming 2D planner rewrite.
+ * For now it only exposes point projection using existing utilities.
+ */
+export function projectPlannerPoint(pt: ShapePoint): WorldPoint {
+  return plannerPointToWorld(pt);
+}

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -9,6 +9,7 @@ import MainTabs from './MainTabs';
 import { safeSetItem } from '../utils/storage';
 import { PlayerMode } from './types';
 import type { ThreeEngine } from '../scene/engine';
+import { legacy2dEnabled } from '../utils/featureFlags';
 
 type PlayerSubMode = Exclude<PlayerMode, null>;
 
@@ -85,14 +86,16 @@ export default function App() {
   }, [mode]);
 
   useEffect(() => {
-    if (tab === 'room') handleSetViewMode('2d');
+    if (tab === 'room' && legacy2dEnabled) handleSetViewMode('2d');
   }, [tab]);
 
   const handleSetViewMode = (v: '3d' | '2d') => {
+    if (!legacy2dEnabled && v === '2d') return;
     setViewMode(v);
   };
 
   const toggleViewMode = () => {
+    if (!legacy2dEnabled) return;
     const next = viewMode === '3d' ? '2d' : '3d';
     handleSetViewMode(next);
   };

--- a/src/ui/TopBar.tsx
+++ b/src/ui/TopBar.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import type { Kind, Variant } from '../core/catalog';
+import { legacy2dEnabled } from '../utils/featureFlags';
 
 interface TopBarProps {
   t: (key: string, opts?: any) => string;
@@ -30,9 +31,11 @@ export default function TopBar({ t, store, setVariant, setKind, lang, setLang, v
       <button className="btnGhost" onClick={() => store.clear()}>
         {t('app.clear')}
       </button>
-      <button className="btnGhost" onClick={toggleViewMode}>
-        {viewMode === '3d' ? '2D' : '3D'}
-      </button>
+      {legacy2dEnabled && (
+        <button className="btnGhost" onClick={toggleViewMode}>
+          {viewMode === '3d' ? '2D' : '3D'}
+        </button>
+      )}
       <select className="btnGhost" value={lang} onChange={e => setLang((e.target as HTMLSelectElement).value)}>
         <option value="pl">PL</option>
         <option value="en">EN</option>

--- a/src/utils/featureFlags.ts
+++ b/src/utils/featureFlags.ts
@@ -1,0 +1,5 @@
+export const legacy2dEnabled =
+  import.meta.env.VITE_ENABLE_LEGACY_2D !== 'false';
+
+export const new2dEnabled =
+  import.meta.env.VITE_ENABLE_NEW_2D === 'true';

--- a/tests/new2d.projectPoint.test.ts
+++ b/tests/new2d.projectPoint.test.ts
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import { projectPlannerPoint } from '../src/new2d';
+
+describe('projectPlannerPoint', () => {
+  it('converts planner coordinates to world space', () => {
+    const result = projectPlannerPoint({ x: 5, y: 10 });
+    expect(result).toEqual({ x: 5, z: -10 });
+  });
+});


### PR DESCRIPTION
## Summary
- add design doc outlining new 2D planner goals and architecture
- introduce `VITE_ENABLE_LEGACY_2D` feature flag and hide 2D toggle when disabled
- scaffold `new2d` module with basic projection helper and tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c7013c32088322b06bcf2acf602d8d