### PR TITLE
Render walls with thickness and height

### DIFF
--- a/src/ui/SceneViewer.tsx
+++ b/src/ui/SceneViewer.tsx
@@ -77,7 +77,7 @@ const SceneViewer: React.FC<Props> = ({
   const roomRef = useRef(store.room);
   const [pointerLockError, setPointerLockError] = useState<string | null>(null);
   const wallStartRef = useRef<ShapePoint | null>(null);
-  const wallMeshRef = useRef<THREE.LineSegments | null>(null);
+  const wallMeshRef = useRef<THREE.Group | null>(null);
   const wallPreviewRef = useRef<THREE.Line | null>(null);
 
   useEffect(() => {
@@ -88,20 +88,25 @@ const SceneViewer: React.FC<Props> = ({
     const three = threeRef.current;
     if (!three) return;
     const shape = store.roomShape;
-    let mesh: THREE.LineSegments | null = null;
+    let mesh: THREE.Group | null = null;
     if (shape.segments.length > 0) {
-      mesh = buildRoomShapeMesh(shape);
+      mesh = buildRoomShapeMesh(shape, store.wallDefaults);
       three.group.add(mesh);
       wallMeshRef.current = mesh;
     }
     return () => {
       if (mesh) {
         three.group.remove(mesh);
-        mesh.geometry.dispose();
-        (mesh.material as THREE.Material).dispose();
+        mesh.traverse((obj) => {
+          if ((obj as THREE.Mesh).isMesh) {
+            const m = obj as THREE.Mesh;
+            (m.geometry as THREE.BufferGeometry).dispose();
+            (m.material as THREE.Material).dispose();
+          }
+        });
       }
     };
-  }, [store.roomShape, threeRef]);
+  }, [store.roomShape, store.wallDefaults, threeRef]);
 
   // Removed automatic switch to 3D when room drawing ends.
 

--- a/tests/wallMeshBuilder.test.ts
+++ b/tests/wallMeshBuilder.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import * as THREE from 'three';
+import { buildRoomShapeMesh } from '../src/scene/roomShapeBuilder';
+import type { RoomShape, ShapePoint } from '../src/types';
+
+describe('buildRoomShapeMesh', () => {
+  it('creates wall meshes with provided thickness and height', () => {
+    const a: ShapePoint = { id: 'a', x: 0, y: 0 };
+    const b: ShapePoint = { id: 'b', x: 1, y: 0 };
+    const shape: RoomShape = {
+      points: [a, b],
+      segments: [{ start: a, end: b }],
+    };
+    const group = buildRoomShapeMesh(shape, { height: 3000, thickness: 200 });
+    expect(group.children).toHaveLength(1);
+    const mesh = group.children[0] as THREE.Mesh;
+    const params = (mesh.geometry as THREE.BoxGeometry).parameters;
+    expect(params.width).toBeCloseTo(1); // length in metres
+    expect(params.height).toBeCloseTo(3); // 3000mm -> 3m
+    expect(params.depth).toBeCloseTo(0.2); // 200mm -> 0.2m
+  });
+});
+


### PR DESCRIPTION
## Summary
- Extrude room shape segments into 3D meshes using configurable wall height and thickness
- Update scene viewer to display wall meshes and dispose resources
- Test wall mesh builder to ensure geometry uses provided dimensions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c702bc0964832292383446e30817f6