### PR TITLE
Ensure consistent 2D/3D grid with major and minor spacing

### DIFF
--- a/src/ui/SceneViewer.tsx
+++ b/src/ui/SceneViewer.tsx
@@ -139,22 +139,13 @@ const SceneViewer: React.FC<Props> = ({
         c.target.set(pos.x, 0, pos.z);
         three.camera.lookAt(c.target);
         c.update();
-        const updateGrid = () => {
-          three.camera.position.y = height;
-          c.target.y = 0;
-          const base = Math.max(
-            1,
-            Math.round(16 / (usePlannerStore.getState().gridSize / 100)),
-          );
-          const divisions = Math.max(
-            1,
-            Math.round(base * three.orthographicCamera.zoom),
-          );
-          three.updateGrid?.(divisions);
-        };
-        c.addEventListener('change', updateGrid);
-        (three as any).gridChangeHandler = updateGrid;
-        updateGrid();
+        three.camera.position.y = height;
+        c.target.y = 0;
+        const base = Math.max(
+          1,
+          Math.round(16 / (usePlannerStore.getState().gridSize / 100)),
+        );
+        three.updateGrid?.(base);
       } else {
         three.setCamera(three.perspectiveCamera);
         three.controls.dispose();


### PR DESCRIPTION
## Summary
- Render a unified grid for 2D and 3D views with 1000 mm major lines and 100 mm minor lines
- Simplify SceneViewer to use the same grid logic in both view modes

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c704b274cc832292c5b2c2c7c2f30e