### PR TITLE
Offset wall meshes to one side

### DIFF
--- a/src/scene/roomShapeBuilder.ts
+++ b/src/scene/roomShapeBuilder.ts
@@ -21,9 +21,22 @@ export function buildRoomShapeMesh(
     const dx = e.x - s.x;
     const dz = e.z - s.z;
     const length = Math.sqrt(dx * dx + dz * dz);
-    const geometry = new THREE.BoxGeometry(length, height, thickness);
+
+    // Compute a perpendicular unit vector (normal) for offsetting the wall to
+    // one side of the drawn line so that the line represents the inner face of
+    // the wall.
+    const normal = new THREE.Vector3(-dz, 0, dx).normalize();
+    const offset = opts.thickness / 2000; // half thickness in metres
+
+    // Extend the wall length slightly so adjoining walls meet without gaps.
+    const geometry = new THREE.BoxGeometry(length + thickness, height, thickness);
     const mesh = new THREE.Mesh(geometry, material.clone());
-    mesh.position.set(s.x + dx / 2, height / 2, s.z + dz / 2);
+    mesh.position.set(
+      s.x + dx / 2 + normal.x * offset,
+      height / 2,
+      s.z + dz / 2 + normal.z * offset,
+    );
+    // Keep rotation based on segment direction
     mesh.rotation.y = Math.atan2(dz, dx);
     group.add(mesh);
   }

--- a/tests/wallMeshBuilder.test.ts
+++ b/tests/wallMeshBuilder.test.ts
@@ -15,7 +15,8 @@ describe('buildRoomShapeMesh', () => {
     expect(group.children).toHaveLength(1);
     const mesh = group.children[0] as THREE.Mesh;
     const params = (mesh.geometry as THREE.BoxGeometry).parameters;
-    expect(params.width).toBeCloseTo(1); // length in metres
+    // Length is extended by the wall thickness so adjoining walls overlap
+    expect(params.width).toBeCloseTo(1.2); // length + thickness in metres
     expect(params.height).toBeCloseTo(3); // 3000mm -> 3m
     expect(params.depth).toBeCloseTo(0.2); // 200mm -> 0.2m
   });


### PR DESCRIPTION
## Summary
- compute wall normals and offset meshes so walls lie on one side of drawing lines
- extend wall segments slightly so adjoining walls overlap
- update wall mesh builder test for new geometry length

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c707849dec83228a99068b58c1e752