### PR TITLE
Ensure wall extrusion always expands outward

### DIFF
--- a/src/scene/roomShapeBuilder.ts
+++ b/src/scene/roomShapeBuilder.ts
@@ -15,6 +15,24 @@ export function buildRoomShapeMesh(
   const height = opts.height / 1000;
   const material = new THREE.MeshStandardMaterial({ color: 0xb0b0b0 });
 
+  // Determine polygon orientation to ensure wall thickness always extends
+  // outward from the room shape. A positive signed area indicates a
+  // counter-clockwise winding and a negative area indicates clockwise.
+  let area = 0;
+  if (shape.segments.length) {
+    for (const seg of shape.segments) {
+      area +=
+        seg.start.x * seg.end.y - seg.end.x * seg.start.y;
+    }
+  } else if (shape.points.length) {
+    for (let i = 0; i < shape.points.length; i++) {
+      const p = shape.points[i];
+      const q = shape.points[(i + 1) % shape.points.length];
+      area += p.x * q.y - q.x * p.y;
+    }
+  }
+  const clockwise = area < 0;
+
   for (const seg of shape.segments) {
     const s = plannerPointToWorld(seg.start);
     const e = plannerPointToWorld(seg.end);
@@ -26,6 +44,9 @@ export function buildRoomShapeMesh(
     // one side of the drawn line so that the line represents the inner face of
     // the wall.
     const normal = new THREE.Vector3(-dz, 0, dx).normalize();
+    if (clockwise) {
+      normal.multiplyScalar(-1);
+    }
     const offset = opts.thickness / 2000; // half thickness in metres
 
     // Extend the wall length slightly so adjoining walls meet without gaps.

--- a/tests/wallMeshBuilder.test.ts
+++ b/tests/wallMeshBuilder.test.ts
@@ -55,5 +55,41 @@ describe('buildRoomShapeMesh', () => {
     expect(outside.x).toBeCloseTo(1 + t);
     expect(outside.z).toBeCloseTo(t);
   });
+
+  it('expands wall thickness outward regardless of polygon winding', () => {
+    const a: ShapePoint = { id: 'a', x: 0, y: 0 };
+    const b: ShapePoint = { id: 'b', x: 1, y: 0 };
+    const c: ShapePoint = { id: 'c', x: 1, y: 1 };
+    const d: ShapePoint = { id: 'd', x: 0, y: 1 };
+    const thickness = 200;
+
+    // Clockwise winding
+    const cw: RoomShape = {
+      points: [a, b, c, d],
+      segments: [
+        { start: a, end: b },
+        { start: b, end: c },
+        { start: c, end: d },
+        { start: d, end: a },
+      ],
+    };
+    const cwGroup = buildRoomShapeMesh(cw, { height: 3000, thickness });
+    const top = cwGroup.children[0] as THREE.Mesh; // segment a->b
+    expect(top.position.z).toBeCloseTo(thickness / 2000);
+
+    // Counter-clockwise winding
+    const ccw: RoomShape = {
+      points: [a, d, c, b],
+      segments: [
+        { start: a, end: d },
+        { start: d, end: c },
+        { start: c, end: b },
+        { start: b, end: a },
+      ],
+    };
+    const ccwGroup = buildRoomShapeMesh(ccw, { height: 3000, thickness });
+    const left = ccwGroup.children[0] as THREE.Mesh; // segment a->d
+    expect(left.position.x).toBeCloseTo(-thickness / 2000);
+  });
 });
 


### PR DESCRIPTION
## Summary
- detect polygon winding via signed area
- flip wall normals for clockwise polygons to keep thickness expanding outward
- test clockwise and counter-clockwise room shapes

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c70c78308c832290491f86c732885f