### PR TITLE
Add mode option for room shape builder

### DIFF
--- a/src/ui/SceneViewer.tsx
+++ b/src/ui/SceneViewer.tsx
@@ -90,7 +90,11 @@ const SceneViewer: React.FC<Props> = ({
     const shape = store.roomShape;
     let mesh: THREE.Group | null = null;
     if (shape.segments.length > 0) {
-      mesh = buildRoomShapeMesh(shape, store.wallDefaults);
+      mesh = buildRoomShapeMesh(shape, {
+        thickness: store.wallDefaults.thickness,
+        height: store.wallDefaults.height,
+        mode: 'inside',
+      });
       three.group.add(mesh);
       wallMeshRef.current = mesh;
     }

--- a/tests/wallMeshBuilder.test.ts
+++ b/tests/wallMeshBuilder.test.ts
@@ -21,6 +21,25 @@ describe('buildRoomShapeMesh', () => {
     expect(params.depth).toBeCloseTo(0.2); // 200mm -> 0.2m
   });
 
+  it('centers meshes on segments when mode is axis', () => {
+    const a: ShapePoint = { id: 'a', x: 0, y: 0 };
+    const b: ShapePoint = { id: 'b', x: 1, y: 0 };
+    const shape: RoomShape = {
+      points: [a, b],
+      segments: [{ start: a, end: b }],
+    };
+    const group = buildRoomShapeMesh(shape, {
+      height: 3000,
+      thickness: 200,
+      mode: 'axis',
+    });
+    expect(group.children).toHaveLength(1);
+    const mesh = group.children[0] as THREE.Mesh;
+    const params = (mesh.geometry as THREE.BoxGeometry).parameters;
+    expect(params.width).toBeCloseTo(1); // no length extension
+    expect(mesh.position.z).toBeCloseTo(0); // no offset
+  });
+
   it('aligns corner meshes to expected inside and outside coordinates', () => {
     const a: ShapePoint = { id: 'a', x: 0, y: 0 };
     const b: ShapePoint = { id: 'b', x: 1, y: 0 };


### PR DESCRIPTION
## Summary
- add `mode` option to `buildRoomShapeMesh` for axis or inside interpretation
- update scene viewer to call builder with inside mode
- test axis mode behaviour for room shape mesh

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c7164c122c83229e77fd8e5f7712ab