### PR TITLE
test: cover rectangle with mixed Y winding

### DIFF
--- a/tests/wallMeshBuilder.test.ts
+++ b/tests/wallMeshBuilder.test.ts
@@ -175,49 +175,51 @@ describe('buildRoomShapeMesh', () => {
       expect(left.position.x).toBeCloseTo(-thickness / 2000);
     });
 
-    it('keeps first wall at positive Z with mixed Y coordinates for both windings', () => {
-      const a: ShapePoint = { id: 'a', x: 0, y: -1 };
-      const b: ShapePoint = { id: 'b', x: 1, y: -1 };
-      const c: ShapePoint = { id: 'c', x: 1, y: 1 };
-      const d: ShapePoint = { id: 'd', x: 0, y: 1 };
-      const thickness = 200;
+    const a: ShapePoint = { id: 'a', x: 0, y: -1 };
+    const b: ShapePoint = { id: 'b', x: 1, y: -1 };
+    const c: ShapePoint = { id: 'c', x: 1, y: 1 };
+    const d: ShapePoint = { id: 'd', x: 0, y: 1 };
 
-      // Counter-clockwise winding
-      const ccw: RoomShape = {
-        points: [a, b, c, d],
-        segments: [
-          { start: a, end: b },
-          { start: b, end: c },
-          { start: c, end: d },
-          { start: d, end: a },
-        ],
-      };
-      const ccwGroup = buildRoomShapeMesh(ccw, {
-        height: 3000,
-        thickness,
-        mode: 'inside',
-      });
-      const topCcw = ccwGroup.children[0] as THREE.Mesh; // segment a->b
-      expect(topCcw.position.z).toBeGreaterThan(0);
+    const shapes: [string, RoomShape][] = [
+      [
+        'counter-clockwise',
+        {
+          points: [a, b, c, d],
+          segments: [
+            { start: a, end: b },
+            { start: b, end: c },
+            { start: c, end: d },
+            { start: d, end: a },
+          ],
+        },
+      ],
+      [
+        'clockwise',
+        {
+          points: [b, a, d, c],
+          segments: [
+            { start: b, end: a },
+            { start: a, end: d },
+            { start: d, end: c },
+            { start: c, end: b },
+          ],
+        },
+      ],
+    ];
 
-      // Clockwise winding
-      const cw: RoomShape = {
-        points: [b, a, d, c],
-        segments: [
-          { start: b, end: a },
-          { start: a, end: d },
-          { start: d, end: c },
-          { start: c, end: b },
-        ],
-      };
-        const cwGroup = buildRoomShapeMesh(cw, {
+    it.each(shapes)(
+      'keeps first wall at positive Z with mixed Y coordinates (%s winding)',
+      (_winding, shape) => {
+        const thickness = 200;
+        const group = buildRoomShapeMesh(shape, {
           height: 3000,
           thickness,
           mode: 'inside',
         });
-        const topCw = cwGroup.children[0] as THREE.Mesh; // segment b->a
-        expect(topCw.position.z).toBeGreaterThan(0);
-      });
+        const firstWall = group.children[0] as THREE.Mesh;
+        expect(firstWall.position.z).toBeGreaterThan(0);
+      },
+    );
 
     it('builds rectangle with shuffled and reversed segments', () => {
       const a: ShapePoint = { id: 'a', x: 0, y: 0 };


### PR DESCRIPTION
## Summary
- add table-driven test for rectangle spanning positive and negative Y values in both windings

## Testing
- `npx vitest run tests/wallMeshBuilder.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c721f8d3c88322ba6bd118814e0ba6