### PR TITLE
fix: centre wall meshes on drawn axis

### DIFF
--- a/src/ui/SceneViewer.tsx
+++ b/src/ui/SceneViewer.tsx
@@ -93,7 +93,9 @@ const SceneViewer: React.FC<Props> = ({
       mesh = buildRoomShapeMesh(shape, {
         thickness: store.wallDefaults.thickness,
         height: store.wallDefaults.height,
-        mode: 'inside',
+        // Wall lines in the planner represent the centre axis, so meshes
+        // should be centred on the segments without any outward offset.
+        mode: 'axis',
       });
       three.group.add(mesh);
       wallMeshRef.current = mesh;


### PR DESCRIPTION
## Summary
- center wall meshes on planner segments treated as wall axes

## Testing
- `npx vitest run tests/wallMeshBuilder.test.ts tests/sceneViewer.gizmo.test.tsx tests/sceneViewer.mode.test.tsx tests/sceneViewer.pointerLock.test.tsx tests/sceneViewer.viewMode.test.tsx tests/sceneViewer.radialMenu.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68c706e5ae848322883518c0573eed85