### PR TITLE
Restore wall module family

### DIFF
--- a/src/core/catalog.ts
+++ b/src/core/catalog.ts
@@ -1,9 +1,9 @@
-export enum FAMILY { BASE='BASE', TALL='TALL', PAWLACZ='PAWLACZ' }
+export enum FAMILY { BASE='BASE', TALL='TALL', WALL='WALL', PAWLACZ='PAWLACZ' }
 export const FAMILY_LABELS: Record<FAMILY,string> = {
-  [FAMILY.BASE]:'Dolna',[FAMILY.TALL]:'Słupek',[FAMILY.PAWLACZ]:'Pawlacz'
+  [FAMILY.BASE]:'Dolna',[FAMILY.TALL]:'Słupek',[FAMILY.WALL]:'Górna',[FAMILY.PAWLACZ]:'Pawlacz'
 }
 export const FAMILY_COLORS: Record<FAMILY,string> = {
-  [FAMILY.BASE]:'#3B82F6',[FAMILY.TALL]:'#10B981',[FAMILY.PAWLACZ]:'#8B5CF6'
+  [FAMILY.BASE]:'#3B82F6',[FAMILY.TALL]:'#10B981',[FAMILY.WALL]:'#6B7280',[FAMILY.PAWLACZ]:'#8B5CF6'
 }
 export type Variant = { key:string; label:string }
 export type Kind = { key:string; label:string; variants: Variant[] }
@@ -80,6 +80,15 @@ export const KIND_SETS: Record<FAMILY, Kind[]> = {
         { key:'fridge', label:'Lodówka' }
       ]
     }
+  ],
+  [FAMILY.WALL]: [
+    { key:'doors', label:'Drzwiczki', variants:[
+      { key:'wd1', label:'1 drzwiczki' },
+      { key:'wd2', label:'2 drzwiczki' },
+      { key:'hood', label:'Okapowa' },
+      { key:'avHK', label:'Aventos HK' },
+      { key:'avHS', label:'Aventos HS' }
+    ]},
   ],
   [FAMILY.PAWLACZ]: [
     { key:'doors', label:'Drzwiczki', variants:[

--- a/src/core/variantRules.ts
+++ b/src/core/variantRules.ts
@@ -29,6 +29,13 @@ export const variantRules: Record<FAMILY, Record<string, VariantRule>> = {
     'oven+mw': { kits: ['dwKit', 'mwKit'] },
     fridge: { doors: 2, kits: ['fridgeKit'] },
   },
+  [FAMILY.WALL]: {
+    wd1: { doors: 1 },
+    wd2: { doors: 2 },
+    hood: { doors: 2, kits: ['hoodKit'] },
+    avHK: { aventos: 'HK' },
+    avHS: { aventos: 'HS' },
+  },
   [FAMILY.PAWLACZ]: {
     p1: { doors: 1 },
     p2: { doors: 2 },


### PR DESCRIPTION
## Summary
- reintroduce the wall cabinet family with labels, colors, and kinds
- define variant rules for wall cabinets including hood and aventos options

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c738e9908c832293a60a41dbeb0157