### PR TITLE
Add Supabase authentication flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,34 @@
 
 Projekt zawiera podstawowe moduły logiki aplikacji bez interfejsu graficznego.
 
+## Konfiguracja Supabase
+
+Aplikacja wykorzystuje Supabase do zarządzania kontami użytkowników. Aby uruchomić środowisko developerskie lub wdrożeniowe z obsługą logowania:
+
+1. Utwórz nowy projekt w [Supabase](https://supabase.com/).
+2. W panelu **Authentication → Providers** włącz logowanie przy użyciu adresu e-mail i hasła.
+3. Przejdź do **Project settings → API** i skopiuj wartości `Project URL` oraz `anon public API key`.
+4. Utwórz plik `.env.local` (lub ustaw zmienne środowiskowe na platformie hostingowej) i dodaj:
+
+   ```bash
+   VITE_SUPABASE_URL="https://example.supabase.co"
+   VITE_SUPABASE_ANON_KEY="twój_publiczny_klucz_anon"
+   ```
+
+5. Jeśli tworzysz tabele do przechowywania danych użytkownika (np. `plans`, `profiles`), pamiętaj o włączeniu mechanizmu Row Level Security (RLS) oraz zdefiniowaniu polityk dostępu. Przykładowa polityka ograniczająca dostęp tylko do właściciela rekordu:
+
+   ```sql
+   alter table plans enable row level security;
+
+   create policy "Użytkownik widzi tylko swoje plany"
+     on plans for select using (auth.uid() = user_id);
+
+   create policy "Użytkownik może modyfikować swoje plany"
+     on plans for all using (auth.uid() = user_id) with check (auth.uid() = user_id);
+   ```
+
+6. Po zapisaniu zmian uruchom aplikację (`npm run dev`). Formularz logowania automatycznie połączy się z Twoim projektem Supabase.
+
 ## Licencja
 
 Projekt jest udostępniany na licencji **MebloPlan Non-Commercial License 1.0**. Użytkowanie, kopiowanie oraz modyfikacja kodu są dozwolone wyłącznie w celach niekomercyjnych i przy zachowaniu informacji o autorach. Wykorzystanie komercyjne wymaga wcześniejszej zgody wszystkich współautorów.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "8.0.2",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
+        "@supabase/supabase-js": "^2.58.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1"
       },
@@ -22,6 +23,9 @@
         "typescript": "^5.7.3",
         "vite": "^5.4.11",
         "vitest": "^3.2.4"
+      },
+      "engines": {
+        "node": ">=18.17.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -1247,6 +1251,102 @@
         "win32"
       ]
     },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.72.0",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.72.0.tgz",
+      "integrity": "sha512-4+bnUrtTDK1YD0/FCx2YtMiQH5FGu9Jlf4IQi5kcqRwRwqp2ey39V61nHNdH86jm3DIzz0aZKiWfTW8qXk1swQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.5.0.tgz",
+      "integrity": "sha512-SXBx6Jvp+MOBekeKFu+G11YLYPeVeGQl23eYyAG9+Ro0pQ1aIP0UZNIBxHKNHqxzR0L0n6gysNr2KT3841NATw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/node-fetch": {
+      "version": "2.6.15",
+      "resolved": "https://registry.npmjs.org/@supabase/node-fetch/-/node-fetch-2.6.15.tgz",
+      "integrity": "sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
+    "node_modules/@supabase/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/@supabase/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/@supabase/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "1.21.4",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.21.4.tgz",
+      "integrity": "sha512-TxZCIjxk6/dP9abAi89VQbWWMBbybpGWyvmIzTd79OeravM13OjR/YEYeyUOPcM1C3QyvXkvPZhUfItvmhY1IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.15.5",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.15.5.tgz",
+      "integrity": "sha512-/Rs5Vqu9jejRD8ZeuaWXebdkH+J7V6VySbCZ/zQM93Ta5y3mAmocjioa/nzlB6qvFmyylUgKVS1KpE212t30OA==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.13",
+        "@types/phoenix": "^1.6.6",
+        "@types/ws": "^8.18.1",
+        "ws": "^8.18.2"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.12.2.tgz",
+      "integrity": "sha512-SiySHxi3q7gia7NBYpsYRu8gyI0NhFwSORMxbZIxJ/zAVkN6QpwDRan158CJ+UdzD4WB/rQMAGRqIJQP+7ccAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.58.0",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.58.0.tgz",
+      "integrity": "sha512-Tm1RmQpoAKdQr4/8wiayGti/no+If7RtveVZjHR8zbO7hhQjmPW2Ok5ZBPf1MGkt5c+9R85AVMsTfSaqAP1sUg==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.72.0",
+        "@supabase/functions-js": "2.5.0",
+        "@supabase/node-fetch": "2.6.15",
+        "@supabase/postgrest-js": "1.21.4",
+        "@supabase/realtime-js": "2.15.5",
+        "@supabase/storage-js": "2.12.2"
+      }
+    },
     "node_modules/@testing-library/dom": {
       "version": "10.4.1",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
@@ -1400,6 +1500,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "24.5.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.5.2.tgz",
+      "integrity": "sha512-FYxk1I7wPv3K2XBaoyH2cTnocQEu8AOZ60hPbsyukMPLv5/5qr7V1i8PLHdl6Zf87I+xZXFvPCXYjiTFq+YSDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.12.0"
+      }
+    },
+    "node_modules/@types/phoenix": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.6.tgz",
+      "integrity": "sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A==",
+      "license": "MIT"
+    },
     "node_modules/@types/react": {
       "version": "19.1.13",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.13.tgz",
@@ -1418,6 +1533,15 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.0.0"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@vitejs/plugin-react": {
@@ -2655,6 +2779,12 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/undici-types": {
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.12.0.tgz",
+      "integrity": "sha512-goOacqME2GYyOZZfb5Lgtu+1IDmAlAEu5xnD3+xTzS10hT0vzpf0SPjkXwAw9Jm+4n/mQGDP3LO8CPbYROeBfQ==",
+      "license": "MIT"
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
@@ -2923,7 +3053,6 @@
       "version": "8.18.3",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
       "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "license": "SEE LICENSE IN LICENSE",
   "dependencies": {
+    "@supabase/supabase-js": "^2.58.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1"
   },

--- a/src/core/supabaseClient.ts
+++ b/src/core/supabaseClient.ts
@@ -1,0 +1,12 @@
+import { createClient } from '@supabase/supabase-js'
+
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY
+
+if (!supabaseUrl || !supabaseAnonKey) {
+  throw new Error('Supabase environment variables are not configured. Set VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY.')
+}
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey)
+
+export default supabase

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -5,6 +5,15 @@ declare global {
     __packedSheetsLen?: number
     __lastPlan?: SheetPlan
   }
+
+  interface ImportMetaEnv {
+    readonly VITE_SUPABASE_URL: string
+    readonly VITE_SUPABASE_ANON_KEY: string
+  }
+
+  interface ImportMeta {
+    readonly env: ImportMetaEnv
+  }
 }
 
 export {}

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1,17 +1,142 @@
-import { StrictMode, useEffect } from 'react'
+import { StrictMode, useEffect, useState } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
+import type { Session } from '@supabase/supabase-js'
 import Dashboard from './Dashboard'
+import SignUpForm from './auth/SignUpForm'
+import supabase from '../core/supabaseClient'
 
 export const APP_TITLE = 'MebloPlan – panel planowania'
 
 const App: React.FC = () => {
+  const [session, setSession] = useState<Session | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [authError, setAuthError] = useState<string | null>(null)
+
   useEffect(() => {
     document.title = APP_TITLE
   }, [])
 
+  useEffect(() => {
+    let isMounted = true
+
+    const loadSession = async () => {
+      const { data, error } = await supabase.auth.getSession()
+
+      if (error) {
+        console.error('Błąd podczas pobierania sesji Supabase', error)
+        if (isMounted) {
+          setAuthError('Nie udało się pobrać sesji użytkownika. Odśwież stronę lub spróbuj ponownie później.')
+        }
+      }
+
+      if (isMounted) {
+        setSession(data.session ?? null)
+        setIsLoading(false)
+      }
+    }
+
+    void loadSession()
+
+    const {
+      data: { subscription }
+    } = supabase.auth.onAuthStateChange((_event, nextSession) => {
+      setSession(nextSession)
+      setAuthError(null)
+    })
+
+    return () => {
+      isMounted = false
+      subscription.unsubscribe()
+    }
+  }, [])
+
+  const handleSignOut = async () => {
+    const { error } = await supabase.auth.signOut()
+    if (error) {
+      setAuthError(error.message)
+    }
+  }
+
+  if (isLoading) {
+    return (
+      <StrictMode>
+        <div style={{ padding: '3rem', textAlign: 'center', fontFamily: 'Inter, system-ui, sans-serif' }}>
+          Ładowanie danych logowania...
+        </div>
+      </StrictMode>
+    )
+  }
+
   return (
     <StrictMode>
-      <Dashboard />
+      {session ? (
+        <div style={{ minHeight: '100vh', backgroundColor: '#f8fafc' }}>
+          <header
+            style={{
+              display: 'flex',
+              justifyContent: 'flex-end',
+              padding: '1rem 2rem',
+              backgroundColor: '#1e293b',
+              color: '#f8fafc'
+            }}
+          >
+            <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
+              <span>Zalogowano jako {session.user.email ?? 'użytkownik'}</span>
+              <button
+                type="button"
+                onClick={handleSignOut}
+                style={{
+                  padding: '0.5rem 1rem',
+                  borderRadius: '9999px',
+                  border: 'none',
+                  backgroundColor: '#facc15',
+                  color: '#1e293b',
+                  cursor: 'pointer',
+                  fontWeight: 600
+                }}
+              >
+                Wyloguj się
+              </button>
+            </div>
+          </header>
+          {authError ? (
+            <div
+              role="alert"
+              style={{
+                margin: '1rem auto',
+                maxWidth: '960px',
+                padding: '1rem',
+                borderRadius: '0.75rem',
+                backgroundColor: '#fee2e2',
+                color: '#b91c1c'
+              }}
+            >
+              {authError}
+            </div>
+          ) : null}
+          <Dashboard />
+        </div>
+      ) : (
+        <>
+          {authError ? (
+            <div
+              role="alert"
+              style={{
+                margin: '1rem auto',
+                maxWidth: '480px',
+                padding: '1rem',
+                borderRadius: '0.75rem',
+                backgroundColor: '#fee2e2',
+                color: '#b91c1c',
+                fontFamily: 'Inter, system-ui, sans-serif'
+              }}
+            >
+              {authError}
+            </div>
+          ) : null}
+          <SignUpForm />
+        </>
+      )}
     </StrictMode>
   )
 }

--- a/src/ui/auth/SignUpForm.tsx
+++ b/src/ui/auth/SignUpForm.tsx
@@ -1,0 +1,207 @@
+import { useState, type FormEvent } from 'react'
+import supabase from '../../core/supabaseClient'
+
+type AuthMode = 'signIn' | 'signUp'
+
+const styles = {
+  container: {
+    maxWidth: '420px',
+    margin: '4rem auto',
+    padding: '2.5rem 2rem',
+    borderRadius: '1rem',
+    border: '1px solid #e2e8f0',
+    boxShadow: '0 20px 45px rgba(15, 23, 42, 0.12)',
+    fontFamily: 'Inter, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
+    backgroundColor: '#ffffff',
+    color: '#1e293b'
+  },
+  heading: {
+    marginBottom: '0.75rem',
+    fontSize: '1.5rem',
+    fontWeight: 700
+  },
+  description: {
+    marginBottom: '1.5rem',
+    color: '#475569',
+    lineHeight: 1.6
+  },
+  fieldset: {
+    display: 'flex',
+    flexDirection: 'column' as const,
+    gap: '1rem'
+  },
+  label: {
+    display: 'flex',
+    flexDirection: 'column' as const,
+    gap: '0.35rem',
+    fontWeight: 600,
+    color: '#1e293b'
+  },
+  input: {
+    padding: '0.75rem 1rem',
+    borderRadius: '0.75rem',
+    border: '1px solid #cbd5f5',
+    fontSize: '1rem',
+    backgroundColor: '#f8fafc',
+    color: '#0f172a'
+  },
+  button: {
+    marginTop: '1.25rem',
+    padding: '0.8rem 1rem',
+    borderRadius: '0.75rem',
+    border: 'none',
+    backgroundColor: '#2563eb',
+    color: '#ffffff',
+    fontWeight: 600,
+    fontSize: '1rem',
+    cursor: 'pointer'
+  },
+  secondary: {
+    marginTop: '1rem',
+    textAlign: 'center' as const,
+    color: '#475569'
+  },
+  toggleLink: {
+    background: 'none',
+    border: 'none',
+    color: '#2563eb',
+    textDecoration: 'underline',
+    cursor: 'pointer',
+    fontWeight: 600,
+    padding: 0,
+    marginLeft: '0.5rem'
+  },
+  feedback: {
+    marginTop: '1rem',
+    padding: '0.75rem 1rem',
+    borderRadius: '0.75rem',
+    backgroundColor: '#fee2e2',
+    color: '#b91c1c'
+  },
+  success: {
+    marginTop: '1rem',
+    padding: '0.75rem 1rem',
+    borderRadius: '0.75rem',
+    backgroundColor: '#dcfce7',
+    color: '#166534'
+  }
+} as const
+
+const SignUpForm: React.FC = () => {
+  const [mode, setMode] = useState<AuthMode>('signIn')
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const [infoMessage, setInfoMessage] = useState<string | null>(null)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+
+    if (!email || !password) {
+      setErrorMessage('Podaj adres e-mail i hasło, aby kontynuować.')
+      return
+    }
+
+    setIsSubmitting(true)
+    setErrorMessage(null)
+    setInfoMessage(null)
+
+    const normalizedEmail = email.trim().toLowerCase()
+
+    try {
+      if (mode === 'signUp') {
+        const { error } = await supabase.auth.signUp({ email: normalizedEmail, password })
+
+        if (error) {
+          setErrorMessage(error.message)
+        } else {
+          setInfoMessage('Utworzono konto. Sprawdź skrzynkę pocztową, aby potwierdzić adres e-mail przed zalogowaniem.')
+        }
+      } else {
+        const { error } = await supabase.auth.signInWithPassword({ email: normalizedEmail, password })
+
+        if (error) {
+          setErrorMessage(error.message)
+        }
+      }
+    } catch (error) {
+      setErrorMessage(error instanceof Error ? error.message : 'Nie udało się połączyć z Supabase.')
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  const toggleMode = () => {
+    setMode(current => (current === 'signIn' ? 'signUp' : 'signIn'))
+    setErrorMessage(null)
+    setInfoMessage(null)
+  }
+
+  return (
+    <div style={styles.container}>
+      <h1 style={styles.heading}>{mode === 'signIn' ? 'Zaloguj się do MebloPlan' : 'Dołącz do MebloPlan'}</h1>
+      <p style={styles.description}>
+        Uzyskaj dostęp do panelu planowania po zalogowaniu. Jeżeli nie masz jeszcze konta, utwórz je za pomocą formularza poniżej.
+      </p>
+
+      <form onSubmit={handleSubmit} style={styles.fieldset}>
+        <label style={styles.label} htmlFor="email">
+          Adres e-mail
+          <input
+            id="email"
+            type="email"
+            name="email"
+            autoComplete="email"
+            style={styles.input}
+            value={email}
+            onChange={event => setEmail(event.target.value)}
+            disabled={isSubmitting}
+            required
+          />
+        </label>
+
+        <label style={styles.label} htmlFor="password">
+          Hasło
+          <input
+            id="password"
+            type="password"
+            name="password"
+            autoComplete={mode === 'signIn' ? 'current-password' : 'new-password'}
+            style={styles.input}
+            value={password}
+            onChange={event => setPassword(event.target.value)}
+            disabled={isSubmitting}
+            minLength={6}
+            required
+          />
+        </label>
+
+        <button type="submit" style={styles.button} disabled={isSubmitting}>
+          {isSubmitting ? 'Przetwarzanie...' : mode === 'signIn' ? 'Zaloguj się' : 'Utwórz konto'}
+        </button>
+      </form>
+
+      {errorMessage ? (
+        <div role="alert" style={styles.feedback}>
+          {errorMessage}
+        </div>
+      ) : null}
+
+      {infoMessage ? (
+        <div role="status" style={styles.success}>
+          {infoMessage}
+        </div>
+      ) : null}
+
+      <p style={styles.secondary}>
+        {mode === 'signIn' ? 'Nie masz konta?' : 'Masz już konto?'}
+        <button type="button" style={styles.toggleLink} onClick={toggleMode}>
+          {mode === 'signIn' ? 'Zarejestruj się' : 'Zaloguj się'}
+        </button>
+      </p>
+    </div>
+  )
+}
+
+export default SignUpForm


### PR DESCRIPTION
## Summary
- add the Supabase JavaScript client and environment typings for the Vite build
- introduce a reusable Supabase client and an authentication form for sign-up/sign-in
- gate the dashboard behind the Supabase session and document the required configuration

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d7fcb96ce883228fd73ba048dc23fc