### PR TITLE
Add role-based dashboards with safe fallback

### DIFF
--- a/src/ui/AdminDashboard.tsx
+++ b/src/ui/AdminDashboard.tsx
@@ -1,0 +1,136 @@
+import type { CSSProperties } from 'react'
+
+const styles = {
+  container: {
+    maxWidth: '1100px',
+    margin: '0 auto',
+    padding: '2rem 1.5rem',
+    fontFamily: 'Inter, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
+    color: '#0f172a'
+  },
+  header: {
+    marginBottom: '2rem',
+    padding: '1.75rem',
+    borderRadius: '1.25rem',
+    background: 'linear-gradient(135deg, #a855f7 0%, #6366f1 100%)',
+    color: '#eef2ff',
+    boxShadow: '0 22px 55px rgba(99, 102, 241, 0.2)'
+  },
+  statsGrid: {
+    display: 'grid',
+    gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))',
+    gap: '1.25rem',
+    marginBottom: '2rem'
+  },
+  statCard: {
+    backgroundColor: '#fff',
+    borderRadius: '1rem',
+    padding: '1.25rem',
+    boxShadow: '0 12px 35px rgba(79, 70, 229, 0.14)',
+    border: '1px solid #c7d2fe'
+  },
+  statValue: {
+    fontSize: '2rem',
+    fontWeight: 700,
+    margin: 0,
+    color: '#4338ca'
+  },
+  statLabel: {
+    margin: 0,
+    color: '#64748b'
+  },
+  section: {
+    backgroundColor: '#f8fafc',
+    borderRadius: '1rem',
+    padding: '1.5rem',
+    marginBottom: '1.5rem',
+    border: '1px solid #e2e8f0'
+  },
+  sectionTitle: {
+    marginTop: 0,
+    marginBottom: '0.75rem',
+    fontSize: '1.2rem',
+    color: '#312e81'
+  },
+  list: {
+    margin: 0,
+    paddingLeft: '1.15rem',
+    lineHeight: 1.6
+  }
+} satisfies Record<string, CSSProperties>
+
+const usageStats = [
+  { label: 'Aktywne konta', value: '128' },
+  { label: 'Projekty w toku', value: '37' },
+  { label: 'Średni czas wdrożenia', value: '12 dni' },
+  { label: 'Zgłoszenia serwisowe', value: '5' }
+]
+
+const auditNotes = [
+  'Zaplanowany przegląd uprawnień 15 maja – wymagane potwierdzenie liderów zespołów.',
+  'Nowy regulator cen materiałów – konieczne dostosowanie widoków do lipca 2024.',
+  'Zarchiwizowano 8 nieaktywnych kont wykonawców (Q1).'
+]
+
+const onboardingChecklist = [
+  'Zweryfikuj rejestry logowań w Supabase i zgłoś odstępstwa.',
+  'Monitoruj limity API oraz wykorzystanie przestrzeni plików.',
+  'Przygotuj szkolenie z modułu wyceny dla nowych sprzedawców.'
+]
+
+const AdminDashboard: React.FC = () => {
+  return (
+    <div style={styles.container}>
+      <header style={styles.header}>
+        <h1 style={{ marginBottom: '0.5rem' }}>Konto administratora</h1>
+        <p style={{ margin: 0 }}>
+          Zarządzaj uprawnieniami, monitoruj kondycję systemu i planuj wdrożenia nowych funkcji. Krytyczne zmiany wymagają
+          akceptacji dwóch administratorów.
+        </p>
+      </header>
+
+      <div style={styles.statsGrid}>
+        {usageStats.map(stat => (
+          <article key={stat.label} style={styles.statCard}>
+            <p style={styles.statValue}>{stat.value}</p>
+            <p style={styles.statLabel}>{stat.label}</p>
+          </article>
+        ))}
+      </div>
+
+      <section style={styles.section} aria-labelledby="security-audit">
+        <h2 id="security-audit" style={styles.sectionTitle}>
+          Kontrola dostępu
+        </h2>
+        <ul style={styles.list}>
+          {auditNotes.map(note => (
+            <li key={note}>{note}</li>
+          ))}
+        </ul>
+      </section>
+
+      <section style={styles.section} aria-labelledby="onboarding">
+        <h2 id="onboarding" style={styles.sectionTitle}>
+          Zadania operacyjne
+        </h2>
+        <ul style={styles.list}>
+          {onboardingChecklist.map(item => (
+            <li key={item}>{item}</li>
+          ))}
+        </ul>
+      </section>
+
+      <section style={styles.section} aria-labelledby="support-info">
+        <h2 id="support-info" style={styles.sectionTitle}>
+          Wsparcie i eskalacje
+        </h2>
+        <p style={{ marginTop: 0 }}>
+          Aktualne SLA dla zgłoszeń krytycznych: 4 godziny. W przypadku incydentów wysokiego ryzyka skorzystaj z kanału
+          #incident-response w Slacku i poinformuj opiekuna klienta. Wszystkie działania audytowe dokumentujemy w Confluence.
+        </p>
+      </section>
+    </div>
+  )
+}
+
+export default AdminDashboard

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1,7 +1,9 @@
 import { StrictMode, useEffect, useState } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import type { Session } from '@supabase/supabase-js'
-import Dashboard from './Dashboard'
+import ClientDashboard from './ClientDashboard'
+import CarpenterDashboard from './CarpenterDashboard'
+import AdminDashboard from './AdminDashboard'
 import SignUpForm from './auth/SignUpForm'
 import supabase from '../core/supabaseClient'
 
@@ -67,6 +69,32 @@ const App: React.FC = () => {
     )
   }
 
+  const metadata = session?.user?.user_metadata as { role?: unknown } | undefined
+  const rawRole = typeof metadata?.role === 'string' ? metadata.role.trim().toLowerCase() : ''
+  const recognizedRole = rawRole === 'client' || rawRole === 'carpenter' || rawRole === 'admin' ? rawRole : null
+
+  const fallbackNotice = (
+    <div
+      role="alert"
+      style={{
+        margin: '1rem auto 2rem',
+        maxWidth: '960px',
+        padding: '1.25rem 1.5rem',
+        borderRadius: '1rem',
+        backgroundColor: '#fef3c7',
+        color: '#92400e',
+        fontFamily: 'Inter, system-ui, sans-serif',
+        boxShadow: '0 12px 30px rgba(202, 138, 4, 0.18)'
+      }}
+    >
+      <h2 style={{ marginTop: 0, marginBottom: '0.5rem' }}>Ograniczony dostęp</h2>
+      <p style={{ margin: 0 }}>
+        Nie udało się ustalić rodzaju Twojego konta. Skontaktuj się z administratorem, aby zweryfikować uprawnienia. Na
+        potrzeby przeglądu udostępniamy bezpieczny widok katalogu w trybie tylko do odczytu.
+      </p>
+    </div>
+  )
+
   return (
     <StrictMode>
       {session ? (
@@ -114,7 +142,16 @@ const App: React.FC = () => {
               {authError}
             </div>
           ) : null}
-          <Dashboard />
+          {recognizedRole === 'carpenter' ? (
+            <CarpenterDashboard />
+          ) : recognizedRole === 'admin' ? (
+            <AdminDashboard />
+          ) : (
+            <>
+              {recognizedRole === null && fallbackNotice}
+              <ClientDashboard />
+            </>
+          )}
         </div>
       ) : (
         <>

--- a/src/ui/CarpenterDashboard.tsx
+++ b/src/ui/CarpenterDashboard.tsx
@@ -1,0 +1,148 @@
+import type { CSSProperties } from 'react'
+
+const styles = {
+  container: {
+    maxWidth: '960px',
+    margin: '0 auto',
+    padding: '2rem 1.5rem',
+    fontFamily: 'Inter, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
+    color: '#111827'
+  },
+  header: {
+    marginBottom: '2rem',
+    padding: '1.5rem',
+    borderRadius: '1rem',
+    background: 'linear-gradient(135deg, #f97316 0%, #fb923c 100%)',
+    color: '#1f2937',
+    boxShadow: '0 18px 45px rgba(249, 115, 22, 0.2)'
+  },
+  grid: {
+    display: 'grid',
+    gridTemplateColumns: 'repeat(auto-fit, minmax(280px, 1fr))',
+    gap: '1.5rem'
+  },
+  card: {
+    padding: '1.5rem',
+    borderRadius: '1rem',
+    backgroundColor: '#fff7ed',
+    border: '1px solid #fed7aa',
+    boxShadow: '0 12px 35px rgba(249, 115, 22, 0.12)'
+  },
+  cardTitle: {
+    marginTop: 0,
+    fontSize: '1.15rem',
+    marginBottom: '0.75rem',
+    color: '#9a3412'
+  },
+  list: {
+    margin: 0,
+    paddingLeft: '1.1rem',
+    lineHeight: 1.6,
+    color: '#7c2d12'
+  },
+  badge: {
+    display: 'inline-block',
+    padding: '0.2rem 0.6rem',
+    borderRadius: '999px',
+    backgroundColor: '#fdba74',
+    color: '#7c2d12',
+    fontSize: '0.75rem',
+    fontWeight: 600
+  }
+} satisfies Record<string, CSSProperties>
+
+type InstallationTask = {
+  id: string
+  client: string
+  address: string
+  scheduledFor: string
+  stage: 'pomiar' | 'produkcja' | 'montaż'
+}
+
+const installationPipeline: InstallationTask[] = [
+  {
+    id: 'MP-104',
+    client: 'Nowakowie',
+    address: 'Warszawa, ul. Modrzewiowa 4',
+    scheduledFor: '2024-05-08',
+    stage: 'montaż'
+  },
+  {
+    id: 'MP-099',
+    client: 'p. Borkowska',
+    address: 'Gdańsk, ul. Myśliwska 18',
+    scheduledFor: '2024-05-13',
+    stage: 'produkcja'
+  },
+  {
+    id: 'MP-097',
+    client: 'Studio Loft 5',
+    address: 'Łódź, ul. Włókiennicza 22',
+    scheduledFor: '2024-05-17',
+    stage: 'pomiar'
+  }
+]
+
+const workshopAlerts = [
+  'Uzupełnij zapas zawiasów typu Blum CLIP top (stan < 30 szt.)',
+  'Potwierdź odbiór płyt EGGER H3331 ST10 – dostawa planowana na środę',
+  'Przygotuj raport z reklamacji frontów lakierowanych za Q1'
+]
+
+const CarpenterDashboard: React.FC = () => {
+  return (
+    <div style={styles.container}>
+      <header style={styles.header}>
+        <h1 style={{ marginBottom: '0.5rem' }}>Konto stolarza</h1>
+        <p style={{ margin: 0 }}>
+          Tutaj znajdziesz harmonogram montaży, listy materiałowe i zgłoszenia serwisowe wymagające reakcji. Wszelkie
+          zmiany w dokumentacji weryfikuje koordynator produkcji.
+        </p>
+      </header>
+
+      <div style={styles.grid}>
+        <section style={styles.card} aria-labelledby="upcoming-installations">
+          <h2 id="upcoming-installations" style={styles.cardTitle}>
+            Najbliższe realizacje
+          </h2>
+          <ul style={styles.list}>
+            {installationPipeline.map(task => (
+              <li key={task.id}>
+                <strong>{task.id}</strong> – {task.client}, {task.address}
+                <br />
+                  <span style={{ fontSize: '0.9rem' }}>
+                    Termin: {new Date(task.scheduledFor).toLocaleDateString('pl-PL')} •{' '}
+                    <span style={styles.badge}>{task.stage.toUpperCase()}</span>
+                  </span>
+              </li>
+            ))}
+          </ul>
+        </section>
+
+        <section style={styles.card} aria-labelledby="workshop-checklist">
+          <h2 id="workshop-checklist" style={styles.cardTitle}>
+            Lista kontrolna warsztatu
+          </h2>
+          <ul style={styles.list}>
+            {workshopAlerts.map(alert => (
+              <li key={alert}>{alert}</li>
+            ))}
+          </ul>
+        </section>
+
+        <section style={styles.card} aria-labelledby="safety-notice">
+          <h2 id="safety-notice" style={styles.cardTitle}>
+            Bezpieczeństwo i dokumentacja
+          </h2>
+          <p style={{ marginTop: 0 }}>
+            Pamiętaj o aktualizacji protokołów BHP po każdym montażu oraz o przesłaniu zdjęć z odbioru jakościowego w ciągu
+            24 godzin. Dostęp do edycji projektów jest ograniczony – w razie potrzeby zmian skontaktuj się z działem
+            projektowym.
+          </p>
+        </section>
+      </div>
+    </div>
+  )
+}
+
+export default CarpenterDashboard

--- a/src/ui/ClientDashboard.tsx
+++ b/src/ui/ClientDashboard.tsx
@@ -9,7 +9,14 @@ const styles = {
     fontFamily: 'Inter, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
     color: '#1f2933'
   },
-  header: {
+  accountHeader: {
+    marginBottom: '2rem',
+    padding: '1.5rem',
+    borderRadius: '1rem',
+    background: 'linear-gradient(135deg, #eff6ff 0%, #dbeafe 100%)',
+    boxShadow: '0 10px 30px rgba(59, 130, 246, 0.12)'
+  },
+  panelHeader: {
     marginBottom: '1.5rem'
   },
   familyList: {
@@ -38,7 +45,8 @@ const styles = {
   viewToggle: {
     display: 'flex',
     gap: '0.75rem',
-    marginBottom: '1rem'
+    marginBottom: '1rem',
+    alignItems: 'center'
   },
   toggleButton: (active: boolean): CSSProperties => ({
     padding: '0.4rem 0.9rem',
@@ -111,7 +119,9 @@ function buildVariantsDescription(kinds: Kind[]): string {
   const fragments: string[] = []
   if (categoriesWithSingle.length > 0) {
     fragments.push(
-      `${categoriesWithSingle.length} kategor${categoriesWithSingle.length === 1 ? 'ia' : 'ie'} oferuj${categoriesWithSingle.length === 1 ? 'e' : 'ą'} pojedynczy wariant`
+      `${categoriesWithSingle.length} kategor${categoriesWithSingle.length === 1 ? 'ia' : 'ie'} oferuj${
+        categoriesWithSingle.length === 1 ? 'e' : 'ą'
+      } pojedynczy wariant`
     )
   }
   if (categoriesWithMany.length > 0) {
@@ -121,7 +131,7 @@ function buildVariantsDescription(kinds: Kind[]): string {
   return `Łącznie dostępnych jest ${totalVariants} wariantów. ${fragments.join('. ')}`
 }
 
-const Dashboard: React.FC = () => {
+const ClientDashboard: React.FC = () => {
   const [selectedFamily, setSelectedFamily] = useState<FAMILY>(FAMILY.BASE)
   const [viewMode, setViewMode] = useState<ViewMode>('tabela')
 
@@ -142,16 +152,24 @@ const Dashboard: React.FC = () => {
 
   return (
     <div style={styles.container}>
-      <header style={styles.header}>
-        <h1>Panel planowania korpusów</h1>
-        <p>
-          W tym miejscu możesz przejrzeć dostępne moduły kuchenne i wybrać najlepszą konfigurację dla projektu.
-          Wybierz rodzinę korpusów, aby zobaczyć szczegółowe warianty i liczebność.
+      <header style={styles.accountHeader}>
+        <h1 style={{ marginBottom: '0.25rem' }}>Konto klienta</h1>
+        <p style={{ margin: 0 }}>
+          Możesz przeglądać katalog modułów, zestawiać warianty i przygotowywać listy pytań dla projektanta. Wszystkie dane
+          prezentujemy w trybie tylko do odczytu, aby zachować bezpieczeństwo konfiguracji.
         </p>
       </header>
 
+      <section style={styles.panelHeader} aria-labelledby="planning-panel-heading">
+        <h2 id="planning-panel-heading">Panel planowania korpusów</h2>
+        <p>
+          W tym miejscu przejrzysz dostępne moduły kuchenne i wybierzesz najlepszą konfigurację dla swojego projektu. Wybierz
+          rodzinę korpusów, aby zobaczyć szczegółowe warianty i liczebność.
+        </p>
+      </section>
+
       <section aria-labelledby="families-heading">
-        <h2 id="families-heading">Rodziny korpusów</h2>
+        <h3 id="families-heading">Rodziny korpusów</h3>
         <p>Wskaż rodzinę, aby zobaczyć odpowiadające jej moduły.</p>
         <div style={styles.familyList}>
           {Object.values(FAMILY).map(family => (
@@ -169,16 +187,26 @@ const Dashboard: React.FC = () => {
       </section>
 
       <section aria-labelledby="summary-heading" style={styles.summary}>
-        <h3 id="summary-heading">Podsumowanie wybranej rodziny</h3>
-        <p>Wybrana rodzina: <strong>{FAMILY_LABELS[selectedFamily]}</strong>.</p>
-        <p>Łączna liczba kategorii modułów: <strong>{kinds.length}</strong>.</p>
-        <p>Łączna liczba wariantów w rodzinie: <strong>{variantCount}</strong>.</p>
+        <h4 id="summary-heading" style={{ marginTop: 0 }}>
+          Podsumowanie wybranej rodziny
+        </h4>
+        <p>
+          Wybrana rodzina: <strong>{FAMILY_LABELS[selectedFamily]}</strong>.
+        </p>
+        <p>
+          Łączna liczba kategorii modułów: <strong>{kinds.length}</strong>.
+        </p>
+        <p>
+          Łączna liczba wariantów w rodzinie: <strong>{variantCount}</strong>.
+        </p>
         <p>{description}</p>
       </section>
 
       <section aria-labelledby="variants-heading">
         <div style={styles.viewToggle}>
-          <h2 id="variants-heading" style={{ margin: 0 }}>Warianty modułów</h2>
+          <h3 id="variants-heading" style={{ margin: 0 }}>
+            Warianty modułów
+          </h3>
           <div role="group" aria-label="Zmiana sposobu prezentacji">
             <button
               type="button"
@@ -212,7 +240,9 @@ const Dashboard: React.FC = () => {
                   <td style={styles.td}>{kind.label}</td>
                   <td style={styles.td}>
                     {kind.variants.length > 0
-                      ? `Rodzina ${FAMILY_LABELS[selectedFamily]} oferuje ${kind.variants.length} wariant${kind.variants.length === 1 ? '' : 'y'} w tej kategorii.`
+                      ? `Rodzina ${FAMILY_LABELS[selectedFamily]} oferuje ${kind.variants.length} wariant${
+                          kind.variants.length === 1 ? '' : 'y'
+                        } w tej kategorii.`
                       : 'Brak wariantów — możesz dodać własne moduły.'}
                   </td>
                   <td style={styles.td}>
@@ -228,7 +258,7 @@ const Dashboard: React.FC = () => {
           <div style={styles.cardsGrid} role="list" aria-label="Lista wariantów">
             {kinds.map(kind => (
               <article style={styles.card} key={kind.key} role="listitem">
-                <h3 style={styles.cardTitle}>{kind.label}</h3>
+                <h4 style={styles.cardTitle}>{kind.label}</h4>
                 {kind.variants.length > 0 ? (
                   <ul style={styles.cardList}>
                     {kind.variants.map(variant => (
@@ -245,11 +275,11 @@ const Dashboard: React.FC = () => {
       </section>
 
       <footer style={{ marginTop: '2rem', fontSize: '0.85rem', color: '#64748b' }}>
-        Wskazówka: kliknij w różne rodziny, aby od razu zobaczyć zmiany w dostępnych modułach. Dane pochodzą z wbudowanego katalogu
-        MebloPlan i są prezentowane w języku polskim.
+        Wskazówka: kliknij w różne rodziny, aby od razu zobaczyć zmiany w dostępnych modułach. Dane pochodzą z wbudowanego
+        katalogu MebloPlan i są prezentowane w języku polskim.
       </footer>
     </div>
   )
 }
 
-export default Dashboard
+export default ClientDashboard

--- a/src/ui/__tests__/ClientDashboard.test.tsx
+++ b/src/ui/__tests__/ClientDashboard.test.tsx
@@ -1,11 +1,12 @@
 import { describe, it, expect } from 'vitest'
 import { fireEvent, render, screen } from '@testing-library/react'
-import Dashboard from '../Dashboard'
+import ClientDashboard from '../ClientDashboard'
 
-describe('Dashboard', () => {
+describe('ClientDashboard', () => {
   it('pozwala na przełączanie rodzin i widoków', () => {
-    render(<Dashboard />)
+    render(<ClientDashboard />)
 
+    expect(screen.getByRole('heading', { name: 'Konto klienta' })).toBeInTheDocument()
     expect(
       screen.getByRole('heading', { name: 'Panel planowania korpusów' })
     ).toBeInTheDocument()

--- a/src/ui/index.ts
+++ b/src/ui/index.ts
@@ -1,2 +1,4 @@
 export { default as App, mountApp, APP_TITLE } from './App'
-export { default as Dashboard } from './Dashboard'
+export { default as ClientDashboard } from './ClientDashboard'
+export { default as CarpenterDashboard } from './CarpenterDashboard'
+export { default as AdminDashboard } from './AdminDashboard'


### PR DESCRIPTION
## Summary
- detect the Supabase session role in the app shell to render the matching dashboard and show a read-only fallback when the role is missing or unknown
- add dedicated client, carpenter, and admin dashboard components with role-specific headers and guidance, and re-export them from the UI entry point
- refresh the client dashboard test suite to cover the new structure and retain view toggling behaviour

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dacd1a56bc8322bec32aea16768289