### PR TITLE
Add admin setup page and documentation updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,19 @@ Aplikacja wykorzystuje Supabase do zarządzania kontami użytkowników. Aby uruc
 
 6. Po zapisaniu zmian uruchom aplikację (`npm run dev`). Formularz logowania automatycznie połączy się z Twoim projektem Supabase.
 
+### Ręczne nadawanie roli administratora
+
+Jeżeli konto zostało utworzone bez użycia formularza konfiguracji administratora, rolę można nadać ręcznie z poziomu panelu Supabase.
+W zakładce **SQL editor** uruchom zapytanie aktualizujące pole `raw_app_meta_data` dla wybranego użytkownika (pamiętaj o podaniu poprawnego adresu e-mail):
+
+```sql
+update auth.users
+set raw_app_meta_data = jsonb_set(coalesce(raw_app_meta_data, '{}'::jsonb), '{role}', '"admin"', true)
+where email = 'admin@example.com';
+```
+
+Po zapisaniu zmian użytkownik otrzyma uprawnienia administratora przy następnym logowaniu.
+
 ## Licencja
 
 Projekt jest udostępniany na licencji **MebloPlan Non-Commercial License 1.0**. Użytkowanie, kopiowanie oraz modyfikacja kodu są dozwolone wyłącznie w celach niekomercyjnych i przy zachowaniu informacji o autorach. Wykorzystanie komercyjne wymaga wcześniejszej zgody wszystkich współautorów.

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -5,6 +5,7 @@ import ClientDashboard from './ClientDashboard'
 import CarpenterDashboard from './CarpenterDashboard'
 import AdminDashboard from './AdminDashboard'
 import SignUpForm from './auth/SignUpForm'
+import AdminSetupPage from './auth/AdminSetupPage'
 import supabase from '../core/supabaseClient'
 
 export const APP_TITLE = 'MebloPlan – panel planowania'
@@ -13,6 +14,8 @@ const App: React.FC = () => {
   const [session, setSession] = useState<Session | null>(null)
   const [isLoading, setIsLoading] = useState(true)
   const [authError, setAuthError] = useState<string | null>(null)
+  const currentPath = typeof window !== 'undefined' ? window.location.pathname : ''
+  const isAdminSetupRoute = currentPath === '/admin-setup'
 
   useEffect(() => {
     document.title = APP_TITLE
@@ -171,7 +174,7 @@ const App: React.FC = () => {
               {authError}
             </div>
           ) : null}
-          <SignUpForm />
+          {isAdminSetupRoute ? <AdminSetupPage /> : <SignUpForm />}
         </>
       )}
     </StrictMode>

--- a/src/ui/auth/AdminSetupPage.tsx
+++ b/src/ui/auth/AdminSetupPage.tsx
@@ -1,0 +1,208 @@
+import { useState, type FormEvent } from 'react'
+import supabase from '../../core/supabaseClient'
+
+const styles = {
+  container: {
+    maxWidth: '420px',
+    margin: '4rem auto',
+    padding: '2.5rem 2rem',
+    borderRadius: '1rem',
+    border: '1px solid #e2e8f0',
+    boxShadow: '0 20px 45px rgba(15, 23, 42, 0.12)',
+    fontFamily: 'Inter, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
+    backgroundColor: '#ffffff',
+    color: '#1e293b'
+  },
+  heading: {
+    marginBottom: '0.75rem',
+    fontSize: '1.5rem',
+    fontWeight: 700
+  },
+  description: {
+    marginBottom: '1.5rem',
+    color: '#475569',
+    lineHeight: 1.6
+  },
+  fieldset: {
+    display: 'flex',
+    flexDirection: 'column' as const,
+    gap: '1rem'
+  },
+  label: {
+    display: 'flex',
+    flexDirection: 'column' as const,
+    gap: '0.35rem',
+    fontWeight: 600,
+    color: '#1e293b'
+  },
+  input: {
+    padding: '0.75rem 1rem',
+    borderRadius: '0.75rem',
+    border: '1px solid #cbd5f5',
+    fontSize: '1rem',
+    backgroundColor: '#f8fafc',
+    color: '#0f172a'
+  },
+  button: {
+    marginTop: '1.25rem',
+    padding: '0.8rem 1rem',
+    borderRadius: '0.75rem',
+    border: 'none',
+    backgroundColor: '#2563eb',
+    color: '#ffffff',
+    fontWeight: 600,
+    fontSize: '1rem',
+    cursor: 'pointer'
+  },
+  feedback: {
+    marginTop: '1rem',
+    padding: '0.75rem 1rem',
+    borderRadius: '0.75rem',
+    backgroundColor: '#fee2e2',
+    color: '#b91c1c'
+  },
+  success: {
+    marginTop: '1rem',
+    padding: '0.75rem 1rem',
+    borderRadius: '0.75rem',
+    backgroundColor: '#dcfce7',
+    color: '#166534'
+  }
+} as const
+
+const AdminSetupPage: React.FC = () => {
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [secret, setSecret] = useState('')
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const [infoMessage, setInfoMessage] = useState<string | null>(null)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  const expectedSecret = (import.meta.env.VITE_ADMIN_SETUP_SECRET ?? '').toString().trim()
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+
+    setErrorMessage(null)
+    setInfoMessage(null)
+
+    if (!email || !password) {
+      setErrorMessage('Podaj adres e-mail i hasło, aby kontynuować.')
+      return
+    }
+
+    if (!expectedSecret) {
+      setErrorMessage('Brakuje konfiguracji sekretu administratora. Dodaj zmienną VITE_ADMIN_SETUP_SECRET i spróbuj ponownie.')
+      return
+    }
+
+    if (secret.trim() !== expectedSecret) {
+      setErrorMessage('Nieprawidłowy kod administratora. Sprawdź konfigurację i spróbuj ponownie.')
+      return
+    }
+
+    setIsSubmitting(true)
+
+    try {
+      const normalizedEmail = email.trim().toLowerCase()
+      const { error } = await supabase.auth.signUp({
+        email: normalizedEmail,
+        password,
+        options: {
+          data: {
+            role: 'admin'
+          }
+        }
+      })
+
+      if (error) {
+        setErrorMessage(error.message)
+      } else {
+        setInfoMessage('Utworzono konto administratora. Sprawdź skrzynkę pocztową, aby potwierdzić adres e-mail przed zalogowaniem.')
+      }
+    } catch (error) {
+      setErrorMessage(error instanceof Error ? error.message : 'Nie udało się połączyć z Supabase.')
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <div style={styles.container}>
+      <h1 style={styles.heading}>Konfiguracja konta administratora</h1>
+      <p style={styles.description}>
+        Formularz pozwala utworzyć pierwszego administratora platformy. Wprowadź tajny kod konfiguracji oraz dane logowania.
+        Kod nie jest zapisywany w Supabase i służy jedynie do weryfikacji, że masz dostęp do środowiska wdrożeniowego.
+      </p>
+
+      <form onSubmit={handleSubmit} style={styles.fieldset}>
+        <label style={styles.label} htmlFor="email">
+          Adres e-mail
+          <input
+            id="email"
+            type="email"
+            name="email"
+            autoComplete="email"
+            style={styles.input}
+            value={email}
+            onChange={event => setEmail(event.target.value)}
+            disabled={isSubmitting}
+            required
+          />
+        </label>
+
+        <label style={styles.label} htmlFor="password">
+          Hasło
+          <input
+            id="password"
+            type="password"
+            name="password"
+            autoComplete="new-password"
+            style={styles.input}
+            value={password}
+            onChange={event => setPassword(event.target.value)}
+            disabled={isSubmitting}
+            minLength={6}
+            required
+          />
+        </label>
+
+        <label style={styles.label} htmlFor="adminSecret">
+          Kod administratora
+          <input
+            id="adminSecret"
+            type="password"
+            name="adminSecret"
+            style={styles.input}
+            value={secret}
+            onChange={event => setSecret(event.target.value)}
+            disabled={isSubmitting}
+            required
+          />
+        </label>
+
+        <button
+          type="submit"
+          style={styles.button}
+          disabled={isSubmitting || !email || !password || !secret}
+        >
+          {isSubmitting ? 'Przetwarzanie...' : 'Utwórz konto administratora'}
+        </button>
+      </form>
+
+      {errorMessage ? (
+        <div role="alert" style={styles.feedback}>
+          {errorMessage}
+        </div>
+      ) : null}
+
+      {infoMessage ? (
+        <div role="status" style={styles.success}>
+          {infoMessage}
+        </div>
+      ) : null}
+    </div>
+  )
+}
+
+export default AdminSetupPage


### PR DESCRIPTION
## Summary
- add a simple path check in the app shell to expose the admin setup flow under /admin-setup
- implement an admin-only sign-up form that validates a shared secret and registers accounts with the admin role
- document how to grant the admin role manually through a Supabase SQL query

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dad0c34aa083229357d083c1bf72fe